### PR TITLE
⚡ Bolt: Replace synchronous eprintln! with async-friendly tracing::debug!

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-11-20 - Removed synchronous eprintln! from async executor
+**Learning:** Found leftover debugging `eprintln!` statements inside core engine loops in `signals.rs` and `handlers/builtin.rs`. In a high-throughput async executor like Tokio, synchronous console I/O can block executor threads and degrade performance.
+**Action:** Replaced `eprintln!` with `tracing::debug!` which integrates cleanly with the existing tracing subscriber, honors logging levels in production, and avoids unexpected synchronous stalls in async functions.

--- a/orch8-engine/src/handlers/builtin.rs
+++ b/orch8-engine/src/handlers/builtin.rs
@@ -222,7 +222,9 @@ async fn handle_sleep(ctx: StepContext) -> Result<Value, StepError> {
         };
         tracing::debug!(
             "DBG-SLEEP: inst={} block={} inside_scope={}",
-            ctx.instance_id, ctx.block_id, inside_scope
+            ctx.instance_id,
+            ctx.block_id,
+            inside_scope
         );
         if inside_scope {
             continue;

--- a/orch8-engine/src/handlers/builtin.rs
+++ b/orch8-engine/src/handlers/builtin.rs
@@ -220,7 +220,7 @@ async fn handle_sleep(ctx: StepContext) -> Result<Value, StepError> {
             }
             Err(_) => false,
         };
-        eprintln!(
+        tracing::debug!(
             "DBG-SLEEP: inst={} block={} inside_scope={}",
             ctx.instance_id, ctx.block_id, inside_scope
         );

--- a/orch8-engine/src/signals.rs
+++ b/orch8-engine/src/signals.rs
@@ -126,7 +126,8 @@ async fn process_signals_inner(
                     let has_non_cancellable = cancel_scoped(storage, instance_id, seq).await?;
                     tracing::debug!(
                         "DBG-CANCEL: inst={} has_non_cancellable={}",
-                        instance_id, has_non_cancellable
+                        instance_id,
+                        has_non_cancellable
                     );
                     if has_non_cancellable {
                         debug!(

--- a/orch8-engine/src/signals.rs
+++ b/orch8-engine/src/signals.rs
@@ -115,7 +115,7 @@ async fn process_signals_inner(
                     continue;
                 }
 
-                eprintln!(
+                tracing::debug!(
                     "DBG-CANCEL: inst={} sequence_def={}",
                     instance_id,
                     sequence_def.is_some()
@@ -124,7 +124,7 @@ async fn process_signals_inner(
                 // cancellable nodes and let non-cancellable ones finish.
                 if let Some(seq) = sequence_def {
                     let has_non_cancellable = cancel_scoped(storage, instance_id, seq).await?;
-                    eprintln!(
+                    tracing::debug!(
                         "DBG-CANCEL: inst={} has_non_cancellable={}",
                         instance_id, has_non_cancellable
                     );


### PR DESCRIPTION
💡 **What:** Replaced hardcoded `eprintln!` debug statements with `tracing::debug!` in `orch8-engine/src/handlers/builtin.rs` and `orch8-engine/src/signals.rs`.
🎯 **Why:** `eprintln!` performs synchronous I/O. In a high-throughput async executor like Tokio, synchronous I/O operations can stall worker threads and reduce overall concurrency. Moving these to the tracing framework also correctly gates them behind debug log levels so they don't impact production logging overhead.
📊 **Impact:** Prevents executor thread blocking from synchronous stdio operations in core processing loops (`process_signals_inner` and `handle_sleep`), improving overall engine concurrency. 
🔬 **Measurement:** `cargo test` confirms logic correctness. Benchmarks running heavy concurrent tasks with debug logging enabled vs disabled would show fewer thread blocking events.

---
*PR created automatically by Jules for task [9120984015946189578](https://jules.google.com/task/9120984015946189578) started by @ovasylenko*