### PR TITLE
⚡ Bolt: Avoid unnecessary cloning when building sqlx QueryBuilder

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-11-20 - Removed synchronous eprintln! from async executor
 **Learning:** Found leftover debugging `eprintln!` statements inside core engine loops in `signals.rs` and `handlers/builtin.rs`. In a high-throughput async executor like Tokio, synchronous console I/O can block executor threads and degrade performance.
 **Action:** Replaced `eprintln!` with `tracing::debug!` which integrates cleanly with the existing tracing subscriber, honors logging levels in production, and avoids unexpected synchronous stalls in async functions.
+## 2026-04-19 - Avoided unnecessary cloning when building sqlx QueryBuilder
+**Learning:** In `orch8-storage/src/postgres`, multiple functions (like `apply_instance_filter`, `apply_worker_task_filter`) were cloning strings (`tid.0.clone()`, `ns.0.clone()`, etc.) when pushing bind parameters to `sqlx::QueryBuilder`. Since `QueryBuilder::push_bind` accepts references and internally binds the lifetime, the explicit `.clone()` is unnecessary and creates overhead.
+**Action:** Replaced `.push_bind(var.clone())` with `.push_bind(var)` (or `.push_bind(&var)` for inner properties) and updated the function signatures to include a named lifetime parameter `<'a>` to link the `QueryBuilder` and the filter reference.

--- a/orch8-storage/src/postgres/instances.rs
+++ b/orch8-storage/src/postgres/instances.rs
@@ -610,12 +610,15 @@ pub(super) async fn bulk_reschedule(
 }
 
 /// Apply `InstanceFilter` conditions to a query builder.
-fn apply_instance_filter(qb: &mut sqlx::QueryBuilder<'_, sqlx::Postgres>, filter: &InstanceFilter) {
+fn apply_instance_filter<'a>(
+    qb: &mut sqlx::QueryBuilder<'a, sqlx::Postgres>,
+    filter: &'a InstanceFilter,
+) {
     if let Some(ref tid) = filter.tenant_id {
-        qb.push(" AND tenant_id = ").push_bind(tid.0.clone());
+        qb.push(" AND tenant_id = ").push_bind(&tid.0);
     }
     if let Some(ref ns) = filter.namespace {
-        qb.push(" AND namespace = ").push_bind(ns.0.clone());
+        qb.push(" AND namespace = ").push_bind(&ns.0);
     }
     if let Some(ref sid) = filter.sequence_id {
         qb.push(" AND sequence_id = ").push_bind(sid.0);
@@ -629,7 +632,7 @@ fn apply_instance_filter(qb: &mut sqlx::QueryBuilder<'_, sqlx::Postgres>, filter
         }
     }
     if let Some(ref meta) = filter.metadata_filter {
-        qb.push(" AND metadata @> ").push_bind(meta.clone());
+        qb.push(" AND metadata @> ").push_bind(meta);
     }
     if let Some(ref p) = filter.priority {
         qb.push(" AND priority = ").push_bind(*p as i16);

--- a/orch8-storage/src/postgres/workers.rs
+++ b/orch8-storage/src/postgres/workers.rs
@@ -259,13 +259,13 @@ pub(super) async fn stats(
 }
 
 /// Apply `WorkerTaskFilter` conditions to a query builder.
-fn apply_worker_task_filter(
-    qb: &mut sqlx::QueryBuilder<'_, sqlx::Postgres>,
-    filter: &orch8_types::worker_filter::WorkerTaskFilter,
+fn apply_worker_task_filter<'a>(
+    qb: &mut sqlx::QueryBuilder<'a, sqlx::Postgres>,
+    filter: &'a orch8_types::worker_filter::WorkerTaskFilter,
 ) {
     if let Some(ref tid) = filter.tenant_id {
         qb.push(" AND instance_id IN (SELECT id FROM instances WHERE tenant_id = ")
-            .push_bind(tid.0.clone())
+            .push_bind(&tid.0)
             .push(")");
     }
     if let Some(ref states) = filter.states {
@@ -277,12 +277,12 @@ fn apply_worker_task_filter(
         }
     }
     if let Some(ref handler) = filter.handler_name {
-        qb.push(" AND handler_name = ").push_bind(handler.clone());
+        qb.push(" AND handler_name = ").push_bind(handler);
     }
     if let Some(ref wid) = filter.worker_id {
-        qb.push(" AND worker_id = ").push_bind(wid.clone());
+        qb.push(" AND worker_id = ").push_bind(wid);
     }
     if let Some(ref queue) = filter.queue_name {
-        qb.push(" AND queue_name = ").push_bind(queue.clone());
+        qb.push(" AND queue_name = ").push_bind(queue);
     }
 }


### PR DESCRIPTION
💡 **What:** Modified `apply_instance_filter` and `apply_worker_task_filter` in `orch8-storage/src/postgres` to use references instead of `.clone()` when pushing parameters to `sqlx::QueryBuilder`. Added a named lifetime parameter `<'a>` to link the builder and the borrowed filter properties safely.
🎯 **Why:** Multiple properties (`String` and `Uuid`) were being explicitly cloned just to be bound to the SQL query. `QueryBuilder::push_bind` is capable of accepting references, meaning we were incurring unnecessary memory allocations and CPU overhead on frequently called database filtering logic.
📊 **Impact:** Reduces heap allocations by passing references, saving memory and processing time per query build.
🔬 **Measurement:** Verify functionality is unchanged via `cargo test` and ensure zero performance regressions by measuring memory profiling metrics on database query operations.

---
*PR created automatically by Jules for task [7595576266311404957](https://jules.google.com/task/7595576266311404957) started by @ovasylenko*