### PR TITLE
🛡️ Sentinel: [Security Enhancement] Refactor format! out of SQLx query in SQLite storage layer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** A `format!` macro was used to dynamically construct SQL queries in `orch8-storage/src/postgres/workers.rs`.
 **Learning:** Although the variable passed into `format!` was a static slice array and not user input, using `format!` or string concatenation with `sqlx` defeats defense-in-depth and will trigger SAST/linters.
 **Prevention:** Construct parameterized queries using `sqlx::QueryBuilder` or use `match` for table-level SQL string generation. Never use string format/concat for SQL queries.
+## 2025-02-15 - [Refactored format! out of SQLx query in SQLite storage layer]
+**Vulnerability:** A `format!` macro was used to dynamically construct SQL queries with `IN ({})` clauses in `orch8-storage/src/sqlite/signals.rs`, `orch8-storage/src/sqlite/outputs.rs`, and `orch8-storage/src/sqlite/externalized.rs`.
+**Learning:** Although the variable passed into `format!` was a dynamically constructed string of placeholders (e.g. `?1, ?2`) and not user input, using `format!` or string concatenation with `sqlx` defeats defense-in-depth and will trigger SAST/linters.
+**Prevention:** Construct parameterized queries for `IN (...)` clauses using `sqlx::QueryBuilder` with the `.separated(",")` and `.push_bind()` pattern. Never use string format/concat for SQL queries.

--- a/orch8-storage/src/sqlite/externalized.rs
+++ b/orch8-storage/src/sqlite/externalized.rs
@@ -179,22 +179,17 @@ pub(super) async fn batch_get(
         return Ok(HashMap::new());
     }
 
-    // Build placeholder list: "?1,?2,?3" — 1-based for clarity, though sqlx
-    // accepts plain "?" too. Named indices keep behavior unambiguous.
-    let placeholders = (1..=ref_keys.len())
-        .map(|i| format!("?{i}"))
-        .collect::<Vec<_>>()
-        .join(",");
-    let sql = format!(
+    let mut qb = sqlx::QueryBuilder::new(
         "SELECT ref_key, payload, payload_bytes, compression \
-         FROM externalized_state WHERE ref_key IN ({placeholders})"
+         FROM externalized_state WHERE ref_key IN (",
     );
-
-    let mut query = sqlx::query(&sql);
+    let mut separated = qb.separated(",");
     for key in ref_keys {
-        query = query.bind(key);
+        separated.push_bind(key);
     }
-    let rows = query.fetch_all(&storage.pool).await?;
+    separated.push_unseparated(")");
+
+    let rows = qb.build().fetch_all(&storage.pool).await?;
 
     let mut out = HashMap::with_capacity(rows.len());
     for row in rows {

--- a/orch8-storage/src/sqlite/outputs.rs
+++ b/orch8-storage/src/sqlite/outputs.rs
@@ -136,16 +136,18 @@ pub(super) async fn get_completed_ids_batch(
     if instance_ids.is_empty() {
         return Ok(HashMap::new());
     }
-    let placeholders: Vec<String> = (1..=instance_ids.len()).map(|i| format!("?{i}")).collect();
-    let sql = format!(
-        "SELECT DISTINCT instance_id, block_id FROM block_outputs WHERE instance_id IN ({})",
-        placeholders.join(",")
+
+    let mut qb = sqlx::QueryBuilder::new(
+        "SELECT DISTINCT instance_id, block_id FROM block_outputs WHERE instance_id IN (",
     );
-    let mut query = sqlx::query(&sql);
+    let mut separated = qb.separated(",");
     for id in instance_ids {
-        query = query.bind(id.0.to_string());
+        separated.push_bind(id.0.to_string());
     }
-    let rows = query.fetch_all(&storage.pool).await?;
+    separated.push_unseparated(")");
+
+    let rows = qb.build().fetch_all(&storage.pool).await?;
+
     let mut result: HashMap<InstanceId, Vec<BlockId>> =
         instance_ids.iter().map(|id| (*id, Vec::new())).collect();
     for row in &rows {

--- a/orch8-storage/src/sqlite/signals.rs
+++ b/orch8-storage/src/sqlite/signals.rs
@@ -148,16 +148,16 @@ pub(super) async fn get_pending_batch(
     if instance_ids.is_empty() {
         return Ok(HashMap::new());
     }
-    let placeholders: Vec<String> = (1..=instance_ids.len()).map(|i| format!("?{i}")).collect();
-    let sql = format!(
-        "SELECT * FROM signal_inbox WHERE instance_id IN ({}) AND delivered=0 ORDER BY created_at",
-        placeholders.join(",")
-    );
-    let mut query = sqlx::query(&sql);
+
+    let mut qb = sqlx::QueryBuilder::new("SELECT * FROM signal_inbox WHERE instance_id IN (");
+    let mut separated = qb.separated(",");
     for id in instance_ids {
-        query = query.bind(id.0.to_string());
+        separated.push_bind(id.0.to_string());
     }
-    let rows = query.fetch_all(&storage.pool).await?;
+    separated.push_unseparated(") AND delivered=0 ORDER BY created_at");
+
+    let rows = qb.build().fetch_all(&storage.pool).await?;
+
     let mut result: HashMap<InstanceId, Vec<Signal>> =
         instance_ids.iter().map(|id| (*id, Vec::new())).collect();
     for row in &rows {


### PR DESCRIPTION
🚨 Severity: ENHANCEMENT
💡 Vulnerability: A `format!` macro was used to dynamically construct SQL queries with `IN ({})` clauses in `orch8-storage/src/sqlite/signals.rs`, `orch8-storage/src/sqlite/outputs.rs`, and `orch8-storage/src/sqlite/externalized.rs`. While it safely concatenated *placeholders* (`?1, ?2`) and not user input directly, manipulating raw SQL query strings with `format!` defeats defense-in-depth and could result in SQL injection vulnerabilities if carelessly modified.
🎯 Impact: Using `sqlx::QueryBuilder` prevents future modifications from inadvertently introducing SQL injection vulnerabilities.
🔧 Fix: Replaced string concatenation with `sqlx::QueryBuilder` using the `.separated(",")` and `.push_bind()` pattern, making the code more robust and idiomatic.
✅ Verification: Ran `cargo test -p orch8-storage` to ensure all existing storage backend tests continue to pass correctly. Checked `cargo clippy` and `cargo fmt`.

---
*PR created automatically by Jules for task [8768860849523060119](https://jules.google.com/task/8768860849523060119) started by @ovasylenko*