### PR TITLE
🛡️ Sentinel: [MEDIUM] Refactor format! out of SQLx queries in SQLite storage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,15 @@
 **Vulnerability:** A `format!` macro was used to dynamically construct SQL queries in `orch8-storage/src/postgres/workers.rs`.
 **Learning:** Although the variable passed into `format!` was a static slice array and not user input, using `format!` or string concatenation with `sqlx` defeats defense-in-depth and will trigger SAST/linters.
 **Prevention:** Construct parameterized queries using `sqlx::QueryBuilder` or use `match` for table-level SQL string generation. Never use string format/concat for SQL queries.
+## 2025-02-15 - [Refactored format! out of SQLx query in SQLite Externalized]
+**Vulnerability:** A `format!` macro was used to dynamically construct SQL queries with `IN` clauses in `orch8-storage/src/sqlite/externalized.rs`.
+**Learning:** Using `format!` or string concatenation with `sqlx` defeats defense-in-depth and will trigger SAST/linters. The preferred method to build dynamic `IN` clauses is using `QueryBuilder` with `.separated()`.
+**Prevention:** Construct parameterized queries using `sqlx::QueryBuilder` with `.separated()` and `.push_bind()`. Never use string format/concat for SQL queries.
+## 2025-02-15 - [Refactored format! out of SQLx query in SQLite Outputs]
+**Vulnerability:** A `format!` macro was used to dynamically construct SQL queries with `IN` clauses in `orch8-storage/src/sqlite/outputs.rs`.
+**Learning:** Using `format!` or string concatenation with `sqlx` defeats defense-in-depth and will trigger SAST/linters. The preferred method to build dynamic `IN` clauses is using `QueryBuilder` with `.separated()`.
+**Prevention:** Construct parameterized queries using `sqlx::QueryBuilder` with `.separated()` and `.push_bind()`. Never use string format/concat for SQL queries.
+## 2025-02-15 - [Refactored format! out of SQLx query in SQLite Signals]
+**Vulnerability:** A `format!` macro was used to dynamically construct SQL queries with `IN` clauses in `orch8-storage/src/sqlite/signals.rs`.
+**Learning:** Using `format!` or string concatenation with `sqlx` defeats defense-in-depth and will trigger SAST/linters. The preferred method to build dynamic `IN` clauses is using `QueryBuilder` with `.separated()`.
+**Prevention:** Construct parameterized queries using `sqlx::QueryBuilder` with `.separated()` and `.push_bind()`. Never use string format/concat for SQL queries.

--- a/orch8-storage/src/sqlite/externalized.rs
+++ b/orch8-storage/src/sqlite/externalized.rs
@@ -179,21 +179,16 @@ pub(super) async fn batch_get(
         return Ok(HashMap::new());
     }
 
-    // Build placeholder list: "?1,?2,?3" — 1-based for clarity, though sqlx
-    // accepts plain "?" too. Named indices keep behavior unambiguous.
-    let placeholders = (1..=ref_keys.len())
-        .map(|i| format!("?{i}"))
-        .collect::<Vec<_>>()
-        .join(",");
-    let sql = format!(
-        "SELECT ref_key, payload, payload_bytes, compression \
-         FROM externalized_state WHERE ref_key IN ({placeholders})"
+    let mut qb = sqlx::QueryBuilder::new(
+        "SELECT ref_key, payload, payload_bytes, compression FROM externalized_state WHERE ref_key IN ("
     );
-
-    let mut query = sqlx::query(&sql);
+    let mut separated = qb.separated(",");
     for key in ref_keys {
-        query = query.bind(key);
+        separated.push_bind(key);
     }
+    separated.push_unseparated(")");
+
+    let query = qb.build();
     let rows = query.fetch_all(&storage.pool).await?;
 
     let mut out = HashMap::with_capacity(rows.len());

--- a/orch8-storage/src/sqlite/outputs.rs
+++ b/orch8-storage/src/sqlite/outputs.rs
@@ -136,15 +136,15 @@ pub(super) async fn get_completed_ids_batch(
     if instance_ids.is_empty() {
         return Ok(HashMap::new());
     }
-    let placeholders: Vec<String> = (1..=instance_ids.len()).map(|i| format!("?{i}")).collect();
-    let sql = format!(
-        "SELECT DISTINCT instance_id, block_id FROM block_outputs WHERE instance_id IN ({})",
-        placeholders.join(",")
+    let mut qb = sqlx::QueryBuilder::new(
+        "SELECT DISTINCT instance_id, block_id FROM block_outputs WHERE instance_id IN (",
     );
-    let mut query = sqlx::query(&sql);
+    let mut separated = qb.separated(",");
     for id in instance_ids {
-        query = query.bind(id.0.to_string());
+        separated.push_bind(id.0.to_string());
     }
+    separated.push_unseparated(")");
+    let query = qb.build();
     let rows = query.fetch_all(&storage.pool).await?;
     let mut result: HashMap<InstanceId, Vec<BlockId>> =
         instance_ids.iter().map(|id| (*id, Vec::new())).collect();

--- a/orch8-storage/src/sqlite/signals.rs
+++ b/orch8-storage/src/sqlite/signals.rs
@@ -148,15 +148,13 @@ pub(super) async fn get_pending_batch(
     if instance_ids.is_empty() {
         return Ok(HashMap::new());
     }
-    let placeholders: Vec<String> = (1..=instance_ids.len()).map(|i| format!("?{i}")).collect();
-    let sql = format!(
-        "SELECT * FROM signal_inbox WHERE instance_id IN ({}) AND delivered=0 ORDER BY created_at",
-        placeholders.join(",")
-    );
-    let mut query = sqlx::query(&sql);
+    let mut qb = sqlx::QueryBuilder::new("SELECT * FROM signal_inbox WHERE instance_id IN (");
+    let mut separated = qb.separated(",");
     for id in instance_ids {
-        query = query.bind(id.0.to_string());
+        separated.push_bind(id.0.to_string());
     }
+    separated.push_unseparated(") AND delivered=0 ORDER BY created_at");
+    let query = qb.build();
     let rows = query.fetch_all(&storage.pool).await?;
     let mut result: HashMap<InstanceId, Vec<Signal>> =
         instance_ids.iter().map(|id| (*id, Vec::new())).collect();


### PR DESCRIPTION
* 🚨 Severity: MEDIUM
* 💡 Vulnerability: Dynamic SQL queries were being built using the `format!` macro with string joined lists for `IN` clauses in the SQLite storage backend.
* 🎯 Impact: While the original code safely bound variables directly with `?1, ?2` parameters, utilizing string concatenation patterns (`format!`) for SQL generation circumvents standard defense-in-depth methodologies and would flag in SAST scans.
* 🔧 Fix: Replaced `format!` usage with `sqlx::QueryBuilder::new()`, utilizing `.separated()` to safely inject bounded parameters for dynamic `IN` clauses.
* ✅ Verification: Ran formatting, clippy and storage cargo tests to ensure all queries generate correctly.

---
*PR created automatically by Jules for task [2696433282599713497](https://jules.google.com/task/2696433282599713497) started by @ovasylenko*