### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix dynamic SQL format! in SQLite bulk_reschedule

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,7 @@
 **Vulnerability:** A `format!` macro was used to dynamically construct SQL queries with `IN` clauses in `orch8-storage/src/sqlite/signals.rs`.
 **Learning:** Using `format!` or string concatenation with `sqlx` defeats defense-in-depth and will trigger SAST/linters. The preferred method to build dynamic `IN` clauses is using `QueryBuilder` with `.separated()`.
 **Prevention:** Construct parameterized queries using `sqlx::QueryBuilder` with `.separated()` and `.push_bind()`. Never use string format/concat for SQL queries.
+## 2025-02-15 - [Refactored format! out of SQLx query in SQLite Instances Bulk Reschedule]
+**Vulnerability:** A `format!` macro was used to dynamically construct SQL queries with string concatenation for datetime modifier in `orch8-storage/src/sqlite/instances.rs`.
+**Learning:** Using `format!` or string concatenation to build raw SQL query string parts defeats defense-in-depth and triggers SAST/linters, even if the value itself is an integer and safe from traditional SQL injection. Parameter binding should always be preferred over string concatenation.
+**Prevention:** Construct parameterized queries using `sqlx::QueryBuilder` with `.push_bind()`, formatting values before binding instead of formatting the SQL string itself. Never use string format/concat for raw SQL string components.

--- a/orch8-storage/src/sqlite/instances.rs
+++ b/orch8-storage/src/sqlite/instances.rs
@@ -670,15 +670,14 @@ pub(super) async fn bulk_reschedule(
 ) -> Result<u64, StorageError> {
     let mut qb =
         sqlx::QueryBuilder::new("UPDATE task_instances SET next_fire_at=datetime(next_fire_at, ");
-    // SQLite's datetime() does not accept positional parameters (?1) for
-    // modifiers — they must be literal strings. Validate the numeric range
-    // before inlining to prevent SQL injection via malicious offset values.
+
+    // Validate the numeric range to prevent overflow/unreasonable values.
     if offset_secs.abs() > BULK_RESCHEDULE_MAX_OFFSET_SECS {
         return Err(StorageError::Query(format!(
             "bulk_reschedule offset too large: {offset_secs}"
         )));
     }
-    qb.push(format!("\"+{offset_secs} seconds\""));
+    qb.push_bind(format!("{offset_secs:+} seconds"));
     qb.push("), updated_at=");
     qb.push_bind(ts(Utc::now()));
     qb.push(" WHERE state='scheduled'");


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: A `format!` macro was used to dynamically construct SQL queries with string concatenation for the datetime modifier in `orch8-storage/src/sqlite/instances.rs` (`bulk_reschedule` function). While the value is a numeric offset, generating raw SQL via string formatting defeats defense-in-depth and triggers SAST/linters.
🎯 **Impact**: Using raw string formatting in SQL string builders establishes an anti-pattern. Additionally, if the `offset_secs` was a negative number, the formatting would have generated invalid SQLite modifier strings (`"+-10 seconds"`).
🔧 **Fix**: Modified the code to use parameterized queries for the datetime modifier. I bound the entire formatted modifier string (e.g., `+10 seconds`) using `.push_bind(format!("{offset_secs:+} seconds"))` instead of appending it to the raw query via `format!`. This safely passes the offset, and effectively formats it with its proper sign whether positive or negative.
✅ **Verification**: Verified using `cargo test -p orch8-storage --lib` and `cargo clippy`. Also recorded the learning in Sentinel's journal.

---
*PR created automatically by Jules for task [17207885661455282793](https://jules.google.com/task/17207885661455282793) started by @ovasylenko*