### PR TITLE
🛡️ Sentinel: [CRITICAL] Refactor dynamic IN clause using sqlx::QueryBuilder

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,7 @@
 **Vulnerability:** A `format!` macro was used to dynamically construct SQL query strings (`SET search_path TO ...`) in `orch8-storage/src/postgres/mod.rs`.
 **Learning:** Using string interpolation with `sqlx` defeats defense-in-depth and triggers SAST/linters. Although the schema identifier may have been validated prior, parameter binding provides robust SQL injection protection in case validation fails.
 **Prevention:** Use the `set_config` PostgreSQL function with `sqlx::QueryBuilder` or `.bind()` for parameterized queries instead of string concatenation/interpolation for database settings. Never use string format/concat for SQL queries.
+## 2025-02-15 - [Refactored format! out of SQLx query in SQLite Signals Batch Delivery]
+**Vulnerability:** A `format!` macro and string joining was used to dynamically construct SQL queries with `IN` clauses in `orch8-storage/src/sqlite/signals.rs`.
+**Learning:** Using `format!` or string concatenation with `sqlx` defeats defense-in-depth and will trigger SAST/linters, even when used only for placeholders. The preferred method to build dynamic `IN` clauses securely is using `QueryBuilder` with `.separated()`.
+**Prevention:** Construct parameterized queries using `sqlx::QueryBuilder` with `.separated()` and `.push_bind()`. Never use string format/concat to build query structure.

--- a/orch8-storage/src/sqlite/signals.rs
+++ b/orch8-storage/src/sqlite/signals.rs
@@ -183,19 +183,13 @@ pub(super) async fn mark_delivered_batch(
     if signal_ids.is_empty() {
         return Ok(());
     }
-    let placeholders: Vec<String> = signal_ids
-        .iter()
-        .enumerate()
-        .map(|(i, _)| format!("?{}", i + 1))
-        .collect();
-    let sql = format!(
-        "UPDATE signal_inbox SET delivered=1 WHERE id IN ({})",
-        placeholders.join(",")
-    );
-    let mut query = sqlx::query(&sql);
+    let mut qb = sqlx::QueryBuilder::new("UPDATE signal_inbox SET delivered=1 WHERE id IN (");
+    let mut separated = qb.separated(",");
     for id in signal_ids {
-        query = query.bind(id.to_string());
+        separated.push_bind(id.to_string());
     }
+    separated.push_unseparated(")");
+    let query = qb.build();
     query.execute(&storage.pool).await?;
     Ok(())
 }


### PR DESCRIPTION
Replaces string concatenation for an SQL query in `mark_delivered_batch` in `sqlite/signals.rs` with `sqlx::QueryBuilder` to enhance security and comply with the project's data-access patterns.

---
*PR created automatically by Jules for task [16053475409265512781](https://jules.google.com/task/16053475409265512781) started by @ovasylenko*