### PR TITLE
🛡️ Sentinel: [Security Enhancement] Refactor string concatenation to `QueryBuilder` in SQLite sequences

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -30,3 +30,11 @@
 **Vulnerability:** A `format!` macro and string joining was used to dynamically construct SQL queries with `IN` clauses in `orch8-storage/src/sqlite/signals.rs`.
 **Learning:** Using `format!` or string concatenation with `sqlx` defeats defense-in-depth and will trigger SAST/linters, even when used only for placeholders. The preferred method to build dynamic `IN` clauses securely is using `QueryBuilder` with `.separated()`.
 **Prevention:** Construct parameterized queries using `sqlx::QueryBuilder` with `.separated()` and `.push_bind()`. Never use string format/concat to build query structure.
+## 2026-05-03 - [Refactored string concat out of SQLx query in SQLite Sequences list_all]
+**Vulnerability:** String concatenation (, ) was used to dynamically construct a SQL query in `orch8-storage/src/sqlite/sequences.rs`.
+**Learning:** Although the variable passed into string concat was a static placeholder `?`, and positional binding was used with `sqlx`, manually tracking the correct number and order of `?` placeholders versus `.bind()` calls is brittle and can lead to runtime crashes or unexpected behavior if future developers make a mistake. Refactoring to `QueryBuilder` prevents placeholder-mismatch bugs and trigger SAST/linters.
+**Prevention:** Construct parameterized queries using `sqlx::QueryBuilder`. Never use string format/concat for SQL queries.
+## 2025-02-15 - [Refactored string concat out of SQLx query in SQLite Sequences list_all]
+**Vulnerability:** String concatenation (`String::from`, `.push_str`) was used to dynamically construct a SQL query in `orch8-storage/src/sqlite/sequences.rs`.
+**Learning:** Although the variable passed into string concat was a static placeholder `?`, and positional binding was used with `sqlx`, manually tracking the correct number and order of `?` placeholders versus `.bind()` calls is brittle and can lead to runtime crashes or unexpected behavior if future developers make a mistake. Refactoring to `QueryBuilder` prevents placeholder-mismatch bugs and trigger SAST/linters.
+**Prevention:** Construct parameterized queries using `sqlx::QueryBuilder`. Never use string format/concat for SQL queries.

--- a/orch8-storage/src/sqlite/sequences.rs
+++ b/orch8-storage/src/sqlite/sequences.rs
@@ -79,32 +79,21 @@ pub(super) async fn list_all(
     limit: u32,
     offset: u32,
 ) -> Result<Vec<orch8_types::sequence::SequenceDefinition>, StorageError> {
-    // Dynamic SQL assembly: bindings are positional so a string placeholder is
-    // safe and keeps the query plan stable.
-    let mut sql = String::from("SELECT * FROM sequences");
-    let mut conds: Vec<&'static str> = Vec::new();
-    if tenant_id.is_some() {
-        conds.push("tenant_id = ?");
-    }
-    if namespace.is_some() {
-        conds.push("namespace = ?");
-    }
-    if !conds.is_empty() {
-        sql.push_str(" WHERE ");
-        sql.push_str(&conds.join(" AND "));
-    }
-    sql.push_str(" ORDER BY tenant_id, namespace, name, version DESC LIMIT ? OFFSET ?");
-
-    let mut q = sqlx::query(&sql);
+    let mut qb = sqlx::QueryBuilder::new("SELECT * FROM sequences WHERE 1=1");
     if let Some(t) = tenant_id {
-        q = q.bind(&t.0);
+        qb.push(" AND tenant_id = ");
+        qb.push_bind(&t.0);
     }
     if let Some(n) = namespace {
-        q = q.bind(&n.0);
+        qb.push(" AND namespace = ");
+        qb.push_bind(&n.0);
     }
-    q = q.bind(limit as i64).bind(offset as i64);
+    qb.push(" ORDER BY tenant_id, namespace, name, version DESC LIMIT ");
+    qb.push_bind(limit as i64);
+    qb.push(" OFFSET ");
+    qb.push_bind(offset as i64);
 
-    let rows = q.fetch_all(&storage.pool).await?;
+    let rows = qb.build().fetch_all(&storage.pool).await?;
     rows.iter().map(row_to_sequence).collect()
 }
 


### PR DESCRIPTION
Sentinel security enhancement: Refactored `list_all` in SQLite sequences to build parameterized queries safely via `sqlx::QueryBuilder`. The previous implementation built the query string manually and applied positional `.bind()` calls afterward, which is brittle. The new approach prevents placeholder-mismatch bugs and avoids linters/SAST failures regarding dynamic SQL construction.

---
*PR created automatically by Jules for task [4259276648623670056](https://jules.google.com/task/4259276648623670056) started by @ovasylenko*