### PR TITLE
⚡ Bolt: Replace HashSet with Vec in concurrency limit enforcement

### DIFF
--- a/orch8-engine/src/scheduler.rs
+++ b/orch8-engine/src/scheduler.rs
@@ -342,7 +342,7 @@ async fn enforce_concurrency_limits(
     let running_counts = storage.count_running_by_concurrency_keys(&keys).await?;
 
     // For each concurrency key, determine how many slots are available.
-    let mut deferred_indices = std::collections::HashSet::new();
+    let mut deferred_indices = Vec::new();
     for (key, indices) in &key_instances {
         // All instances in the group share the same max_concurrency.
         let max = instances[indices[0]].max_concurrency.unwrap_or(u32::MAX);
@@ -362,7 +362,7 @@ async fn enforce_concurrency_limits(
         // priority ordering from claim_due_instances), defer the rest.
         if slots < indices.len() {
             for &idx in &indices[slots..] {
-                deferred_indices.insert(idx);
+                deferred_indices.push(idx);
             }
         }
     }
@@ -387,9 +387,8 @@ async fn enforce_concurrency_limits(
         .await?;
 
     let mut kept = instances;
-    let mut deferred_sorted: Vec<_> = deferred_indices.into_iter().collect();
-    deferred_sorted.sort_unstable_by(|a, b| b.cmp(a));
-    for idx in deferred_sorted {
+    deferred_indices.sort_unstable_by(|a, b| b.cmp(a));
+    for idx in deferred_indices {
         kept.swap_remove(idx);
     }
 

--- a/orch8-storage/src/postgres/instances.rs
+++ b/orch8-storage/src/postgres/instances.rs
@@ -288,7 +288,7 @@ async fn filter_by_concurrency_pg(
         })
         .collect();
 
-    let mut excluded = std::collections::HashSet::new();
+    let mut excluded = Vec::new();
     for (key, indices) in &keyed {
         let max = candidates[indices[0]].max_concurrency.unwrap_or(u32::MAX);
         let already_running = running_counts.get(*key).copied().unwrap_or(0);
@@ -297,15 +297,17 @@ async fn filter_by_concurrency_pg(
         let slots = (i64::from(max) - already_running).max(0) as usize;
         if slots < indices.len() {
             for &idx in &indices[slots..] {
-                excluded.insert(idx);
+                excluded.push(idx);
             }
         }
     }
 
+    excluded.sort_unstable();
+
     Ok(candidates
         .iter()
         .enumerate()
-        .filter(|(idx, _)| !excluded.contains(idx))
+        .filter(|(idx, _)| excluded.binary_search(idx).is_err())
         .map(|(_, inst)| inst.clone())
         .collect())
 }

--- a/orch8-storage/src/sqlite/instances.rs
+++ b/orch8-storage/src/sqlite/instances.rs
@@ -244,7 +244,7 @@ async fn filter_by_concurrency(
         running_counts.insert(key, cnt);
     }
 
-    let mut excluded = std::collections::HashSet::new();
+    let mut excluded = Vec::new();
     for (key, indices) in &keyed {
         let max = candidates[indices[0]].max_concurrency.unwrap_or(u32::MAX);
         let already_running = running_counts.get(*key).copied().unwrap_or(0);
@@ -252,15 +252,17 @@ async fn filter_by_concurrency(
         let slots = (i64::from(max) - already_running).max(0) as usize;
         if slots < indices.len() {
             for &idx in &indices[slots..] {
-                excluded.insert(idx);
+                excluded.push(idx);
             }
         }
     }
 
+    excluded.sort_unstable();
+
     Ok(candidates
         .iter()
         .enumerate()
-        .filter(|(idx, _)| !excluded.contains(idx))
+        .filter(|(idx, _)| excluded.binary_search(idx).is_err())
         .map(|(_, inst)| inst.clone())
         .collect())
 }


### PR DESCRIPTION
⚡ Bolt: Replace HashSet with Vec in concurrency limit enforcement

💡 What: Replaced `std::collections::HashSet` with `Vec` for collecting and filtering indices of items that exceed their concurrency constraints, specifically in `orch8-engine/src/scheduler.rs`, `orch8-storage/src/sqlite/instances.rs`, and `orch8-storage/src/postgres/instances.rs`. The code now uses a `Vec<usize>` that is sorted via `sort_unstable()` and queried using `binary_search()` or iterated over linearly for element removal.

🎯 Why: During batch operations (like `claim_due_instances`), we limit how many instances can run under the same `concurrency_key`. Since instances are partitioned into disjoint groups by their single concurrency key, the indices we collect as "exceeding limits" are intrinsically unique. Thus, using a `HashSet` provides no deduplication benefit while introducing heap allocation overhead for buckets and incurring the cost of SipHash (Rust's default hasher) for simple integers.

📊 Impact: Removes multiple `HashSet` allocations and hashing operations per scheduler tick or database batch fetch, noticeably reducing CPU overhead on the hot path.

🔬 Measurement: Run the scheduler load tests or `cargo test -p orch8-engine --lib scheduler` to verify that index limiting is functionally identical but with fewer heap allocations per tick.

---
*PR created automatically by Jules for task [1406795784032022384](https://jules.google.com/task/1406795784032022384) started by @ovasylenko*