### PR TITLE
⚡ Bolt: Optimize `enforce_concurrency_limits` by replacing `HashSet` with `Vec`

### DIFF
--- a/orch8-engine/src/scheduler.rs
+++ b/orch8-engine/src/scheduler.rs
@@ -342,7 +342,9 @@ async fn enforce_concurrency_limits(
     let running_counts = storage.count_running_by_concurrency_keys(&keys).await?;
 
     // For each concurrency key, determine how many slots are available.
-    let mut deferred_indices = std::collections::HashSet::new();
+    // OPTIMIZATION: Collect deferred indices in a Vec instead of a HashSet to
+    // eliminate hashing and allocation overhead in this hot path.
+    let mut deferred_indices = Vec::new();
     for (key, indices) in &key_instances {
         // All instances in the group share the same max_concurrency.
         let max = instances[indices[0]].max_concurrency.unwrap_or(u32::MAX);
@@ -361,9 +363,7 @@ async fn enforce_concurrency_limits(
         // Keep the first `slots` instances (by batch order, which preserves
         // priority ordering from claim_due_instances), defer the rest.
         if slots < indices.len() {
-            for &idx in &indices[slots..] {
-                deferred_indices.insert(idx);
-            }
+            deferred_indices.extend_from_slice(&indices[slots..]);
         }
     }
 
@@ -387,9 +387,10 @@ async fn enforce_concurrency_limits(
         .await?;
 
     let mut kept = instances;
-    let mut deferred_sorted: Vec<_> = deferred_indices.into_iter().collect();
-    deferred_sorted.sort_unstable_by(|a, b| b.cmp(a));
-    for idx in deferred_sorted {
+    // Sort descending and dedup so swap_remove works correctly without shifting remaining indices.
+    deferred_indices.sort_unstable_by(|a, b| b.cmp(a));
+    deferred_indices.dedup();
+    for idx in deferred_indices {
         kept.swap_remove(idx);
     }
 


### PR DESCRIPTION
💡 What: Replaced `HashSet` with a `Vec` for collecting `deferred_indices` in `enforce_concurrency_limits`. Added sort descending + dedup to safely run `swap_remove`.
🎯 Why: `HashSet` incurs unnecessary hashing and allocation overhead for a collection of slice indices that are populated by grouping into disjoint key sets.
📊 Impact: Eliminates a `HashSet` allocation and hashing cost per scheduling batch when concurrency limits are hit, lowering CPU overhead on the hot path.
🔬 Measurement: Verify tests pass with `cargo test -p orch8-engine --lib scheduler` and verify memory usage/CPU load on a heavily concurrent scheduler workload.

---
*PR created automatically by Jules for task [8740298394709888601](https://jules.google.com/task/8740298394709888601) started by @ovasylenko*