### PR TITLE
⚡ Bolt: Optimize `merge_context_data` with in-place encryption

### DIFF
--- a/orch8-storage/src/encrypting.rs
+++ b/orch8-storage/src/encrypting.rs
@@ -69,6 +69,17 @@ impl EncryptingStorage {
         Ok(Cow::Owned(ctx))
     }
 
+    fn encrypt_context_mut(
+        &self,
+        context: &mut ExecutionContext,
+    ) -> Result<(), StorageError> {
+        if !FieldEncryptor::is_encrypted(&context.data) {
+            context.data = self.encryptor.encrypt_value(&context.data)
+                .map_err(|e| StorageError::Query(format!("encryption: {e}")))?;
+        }
+        Ok(())
+    }
+
     fn decrypt_instance(&self, instance: &mut TaskInstance) -> Result<(), StorageError> {
         if FieldEncryptor::is_encrypted(&instance.context.data) {
             instance.context.data = self
@@ -238,6 +249,9 @@ impl_encrypting_storage! {
             // Encrypted context is a single blob — read → decrypt → merge →
             // encrypt → CAS write. Retry on contention (another writer
             // updated `updated_at` between our read and write).
+            // ⚡ Bolt optimization: Move allocation outside the retry loop
+            let key_str = key.to_string();
+
             for _ in 0..5 {
                 let Some(mut instance) = self.inner.get_instance(id).await? else {
                     return Ok(());
@@ -249,11 +263,12 @@ impl_encrypting_storage! {
                     instance.context.data = serde_json::Value::Object(serde_json::Map::new());
                 }
                 if let Some(map) = instance.context.data.as_object_mut() {
-                    map.insert(key.to_string(), value.clone());
+                    map.insert(key_str.clone(), value.clone());
                 }
 
-                let encrypted = self.encrypt_context(&instance.context)?;
-                if self.inner.update_instance_context_cas(id, encrypted.as_ref(), snapshot_ts).await? {
+                // ⚡ Bolt optimization: Use in-place encryption instead of `encrypt_context` to avoid cloning the struct on every retry
+                self.encrypt_context_mut(&mut instance.context)?;
+                if self.inner.update_instance_context_cas(id, &instance.context, snapshot_ts).await? {
                     return Ok(());
                 }
             }

--- a/orch8-storage/src/encrypting.rs
+++ b/orch8-storage/src/encrypting.rs
@@ -69,12 +69,11 @@ impl EncryptingStorage {
         Ok(Cow::Owned(ctx))
     }
 
-    fn encrypt_context_mut(
-        &self,
-        context: &mut ExecutionContext,
-    ) -> Result<(), StorageError> {
+    fn encrypt_context_mut(&self, context: &mut ExecutionContext) -> Result<(), StorageError> {
         if !FieldEncryptor::is_encrypted(&context.data) {
-            context.data = self.encryptor.encrypt_value(&context.data)
+            context.data = self
+                .encryptor
+                .encrypt_value(&context.data)
                 .map_err(|e| StorageError::Query(format!("encryption: {e}")))?;
         }
         Ok(())


### PR DESCRIPTION
💡 **What**: Added `encrypt_context_mut` to `EncryptingStorage` to support in-place encryption of the `ExecutionContext`. Updated `merge_context_data` to use this new method inside its 5-iteration CAS retry loop and hoisted `key.to_string()` outside the loop.
🎯 **Why**: Previously, `encrypt_context` cloned the entire `ExecutionContext` on every retry loop iteration to return a `Cow::Owned`. For payloads with large JSON structures in `context.data`, this introduces significant allocation overhead inside a highly concurrent, contention-prone loop. Modifying it in-place drastically reduces GC pressure and speeds up retries.
📊 **Impact**: Expected to significantly lower latency and allocation rates on `merge_context_data` operations, especially under high CAS contention. 
🔬 **Measurement**: Verify via benchmarking CAS contention on `update_instance_context_cas`. Tests passed (`cargo test -p orch8-storage`).

---
*PR created automatically by Jules for task [18415218452123972473](https://jules.google.com/task/18415218452123972473) started by @ovasylenko*