### PR TITLE
⚡ Bolt: optimize circuit breaker DashMap write-locks and allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-09 - [Zero-Allocation Batch Query Binding]
 **Learning:** `sqlx::QueryBuilder::push_values` accepts collections of references, meaning we don't need to clone `String` or deep-clone `serde_json::Value` objects simply to build a query chunk. In `batch_save` operations, deep cloning JSON payloads into `Vec` buffers was creating massive memory allocation overhead.
 **Action:** Always map elements to references (`&str`, `&serde_json::Value`) when building temporary `Vec` buffers for `push_values`, rather than using owned objects.
+
+## 2025-05-16 - [DashMap Lock Contention & Key Allocation]
+**Learning:** In highly concurrent paths like circuit breakers, allocating a new String key and acquiring a full `DashMap` entry lock via `.entry(key)` simply to update an existing breaker is extremely expensive. The previous approach allocated a String for every single failure or initialization check and acquired a lock that blocked other updates to the same shard.
+**Action:** Use `.get_mut(q)` with a zero-allocation reference key first to update existing entries, falling back to allocating a Key and using `.entry(key)` ONLY when initialization is required.

--- a/orch8-api/src/instances.rs
+++ b/orch8-api/src/instances.rs
@@ -24,12 +24,12 @@ pub(crate) use bulk::{
     __path_bulk_reschedule, __path_bulk_update_state, __path_list_dlq, bulk_reschedule,
     bulk_update_state, list_dlq,
 };
+pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};
 pub(crate) use checkpoints::{
     __path_get_latest_checkpoint, __path_list_checkpoints, __path_prune_checkpoints,
     __path_save_checkpoint, get_latest_checkpoint, list_checkpoints, prune_checkpoints,
     save_checkpoint,
 };
-pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};
 pub use inject::InjectBlocksRequest;
 pub(crate) use inject::{__path_inject_blocks, inject_blocks};
 pub(crate) use lifecycle::{

--- a/orch8-api/src/instances.rs
+++ b/orch8-api/src/instances.rs
@@ -24,12 +24,12 @@ pub(crate) use bulk::{
     __path_bulk_reschedule, __path_bulk_update_state, __path_list_dlq, bulk_reschedule,
     bulk_update_state, list_dlq,
 };
-pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};
 pub(crate) use checkpoints::{
     __path_get_latest_checkpoint, __path_list_checkpoints, __path_prune_checkpoints,
     __path_save_checkpoint, get_latest_checkpoint, list_checkpoints, prune_checkpoints,
     save_checkpoint,
 };
+pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};
 pub use inject::InjectBlocksRequest;
 pub(crate) use inject::{__path_inject_blocks, inject_blocks};
 pub(crate) use lifecycle::{

--- a/orch8-engine/src/circuit_breaker.rs
+++ b/orch8-engine/src/circuit_breaker.rs
@@ -225,45 +225,48 @@ impl CircuitBreakerRegistry {
             }
         }
 
-        let key = Key(tenant_id.clone(), handler.to_string());
+        // Mid path: if the breaker is Open, we acquire a write lock via get_mut
+        // to potentially mutate it, without allocating a new Key string.
+        if let Some(mut breaker) = self.breakers.get_mut(q) {
+            return match breaker.state {
+                BreakerState::Closed | BreakerState::HalfOpen => Ok(()),
+                BreakerState::Open => {
+                    if let Some(opened_at) = breaker.opened_at {
+                        #[allow(clippy::cast_sign_loss)]
+                        let elapsed = (now - opened_at).num_seconds().max(0) as u64;
+                        if elapsed >= breaker.cooldown_secs {
+                            breaker.state = BreakerState::HalfOpen;
+                            // Cooldown elapsed: transitioning to HalfOpen means the
+                            // breaker is no longer protecting — remove from
+                            // durable store so a crash now doesn't revive it.
+                            let snapshot = breaker.clone();
+                            drop(breaker);
+                            self.spawn_delete(&snapshot);
+                            Ok(())
+                        } else {
+                            Err(breaker.cooldown_secs - elapsed)
+                        }
+                    } else {
+                        // No opened_at means it was just set — cooldown starts now
+                        breaker.opened_at = Some(now);
+                        let cooldown = breaker.cooldown_secs;
+                        let snapshot = breaker.clone();
+                        drop(breaker);
+                        self.spawn_upsert(&snapshot);
+                        Err(cooldown)
+                    }
+                }
+            };
+        }
 
-        // Slow path: if the breaker is Open (or doesn't exist yet), we acquire
-        // a write lock to potentially mutate it (e.g. initialize it, or check
-        // if cooldown elapsed and transition to HalfOpen).
-        let mut breaker = self
-            .breakers
+        // Slow path: if the breaker doesn't exist yet, we acquire
+        // a write lock to initialize it.
+        let key = Key(tenant_id.clone(), handler.to_string());
+        self.breakers
             .entry(key)
             .or_insert_with(|| self.default_breaker(tenant_id, handler));
 
-        match breaker.state {
-            BreakerState::Closed | BreakerState::HalfOpen => Ok(()),
-            BreakerState::Open => {
-                if let Some(opened_at) = breaker.opened_at {
-                    #[allow(clippy::cast_sign_loss)]
-                    let elapsed = (now - opened_at).num_seconds().max(0) as u64;
-                    if elapsed >= breaker.cooldown_secs {
-                        breaker.state = BreakerState::HalfOpen;
-                        // Cooldown elapsed: transitioning to HalfOpen means the
-                        // breaker is no longer protecting — remove from
-                        // durable store so a crash now doesn't revive it.
-                        let snapshot = breaker.clone();
-                        drop(breaker);
-                        self.spawn_delete(&snapshot);
-                        Ok(())
-                    } else {
-                        Err(breaker.cooldown_secs - elapsed)
-                    }
-                } else {
-                    // No opened_at means it was just set — cooldown starts now
-                    breaker.opened_at = Some(now);
-                    let cooldown = breaker.cooldown_secs;
-                    let snapshot = breaker.clone();
-                    drop(breaker);
-                    self.spawn_upsert(&snapshot);
-                    Err(cooldown)
-                }
-            }
-        }
+        Ok(())
     }
 
     /// Record a successful execution for a tenant+handler. Clears failures and
@@ -301,9 +304,22 @@ impl CircuitBreakerRegistry {
     /// which also persists the transition.
     pub fn record_failure(&self, tenant_id: &TenantId, handler: &str) {
         let now = Utc::now();
-        let key = Key(tenant_id.clone(), handler.to_string());
+        let search = KeyRef(tenant_id, handler);
+        let q: &dyn CircuitKey = &search;
         let mut tripped_snapshot = None;
-        {
+
+        if let Some(mut breaker) = self.breakers.get_mut(q) {
+            breaker.failure_count += 1;
+
+            if breaker.failure_count >= breaker.failure_threshold
+                && breaker.state != BreakerState::Open
+            {
+                breaker.state = BreakerState::Open;
+                breaker.opened_at = Some(now);
+                tripped_snapshot = Some(breaker.clone());
+            }
+        } else {
+            let key = Key(tenant_id.clone(), handler.to_string());
             let mut breaker = self
                 .breakers
                 .entry(key)
@@ -319,6 +335,7 @@ impl CircuitBreakerRegistry {
                 tripped_snapshot = Some(breaker.clone());
             }
         }
+
         if let Some(snap) = tripped_snapshot {
             self.spawn_upsert(&snap);
         }


### PR DESCRIPTION
💡 **What**: Refactored the `check` and `record_failure` methods in the in-memory `CircuitBreakerRegistry` to try `self.breakers.get_mut(q)` with a zero-allocation reference key *before* falling back to allocating a `String` key and invoking `.entry()`.
🎯 **Why**: In highly concurrent systems, `.entry()` allocates a `String` and acquires a write-lock on the `DashMap` shard even if the entry already exists. This creates massive memory allocation overhead and lock contention on the hot path. 
📊 **Impact**: Significantly reduces memory allocations and `DashMap` shard lock contention for existing circuit breakers, leading to improved throughput and lower latency under heavy load.
🔬 **Measurement**: Run the load tests against an open circuit breaker; observe reduced CPU and memory footprint with lower response percentiles. Cargo tests (`cargo test -p orch8-engine --lib circuit_breaker`) continue to pass, proving correctness is preserved.

---
*PR created automatically by Jules for task [11071828307639489794](https://jules.google.com/task/11071828307639489794) started by @ovasylenko*