### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix SQL construction pattern to use QueryBuilder

### DIFF
--- a/orch8-mobile/src/storage.rs
+++ b/orch8-mobile/src/storage.rs
@@ -63,17 +63,14 @@ impl MobileStorage {
         if ids.is_empty() {
             return Ok(0);
         }
-        // SQLite doesn't support binding arrays directly; build an IN clause.
-        let placeholders: Vec<String> = ids.iter().map(|_| "?".to_string()).collect();
-        let sql = format!(
-            "DELETE FROM telemetry_events WHERE id IN ({})",
-            placeholders.join(",")
-        );
-        let mut query = sqlx::query(&sql);
+        // SQLite doesn't support binding arrays directly; build an IN clause safely using QueryBuilder.
+        let mut qb = sqlx::QueryBuilder::new("DELETE FROM telemetry_events WHERE id IN (");
+        let mut separated = qb.separated(",");
         for id in ids {
-            query = query.bind(id);
+            separated.push_bind(id);
         }
-        let result = query.execute(self.pool()).await?;
+        separated.push_unseparated(")");
+        let result = qb.build().execute(self.pool()).await?;
         Ok(result.rows_affected())
     }
 


### PR DESCRIPTION
🚨 **Severity**: MEDIUM

💡 **Vulnerability**: A SQL query inside `orch8-mobile/src/storage.rs` used `format!` string joining to build an `IN (...)` clause. While the current usage safely handled an array of `i64` integers—meaning it was technically safe from SQL injection—relying on manual string building for SQL interpolation establishes an unsafe structural pattern that could lead to vulnerabilities if copied or modified to accept untrusted strings.

🎯 **Impact**: If this pattern were replicated and applied to variables containing strings without escaping, it would expose the database to SQL Injection (SQLi) attacks.

🔧 **Fix**: Refactored the `delete_telemetry_events` query to utilize `sqlx::QueryBuilder` and `.separated()`, which securely joins and parameterizes values strictly avoiding manual string formatting.

✅ **Verification**:
- Verified the fix by running `cargo test -p orch8-mobile`
- Verified code structure rules utilizing `cargo clippy -p orch8-mobile`
- Verified code format rules utilizing `cargo fmt -p orch8-mobile`

---
*PR created automatically by Jules for task [8550483007677530121](https://jules.google.com/task/8550483007677530121) started by @ovasylenko*