### PR TITLE
⚡ Bolt: Eliminate deep clones in concurrency filter

### DIFF
--- a/fix_fmt.sh
+++ b/fix_fmt.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-sed -i '/pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};/d' orch8-api/src/instances.rs
-#!/bin/bash
-sed -i '/pub(crate) use checkpoints::{/i \pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};' orch8-api/src/instances.rs

--- a/fix_fmt.sh
+++ b/fix_fmt.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+sed -i '/pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};/d' orch8-api/src/instances.rs
+#!/bin/bash
+sed -i '/pub(crate) use checkpoints::{/i \pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};' orch8-api/src/instances.rs

--- a/orch8-api/src/instances.rs
+++ b/orch8-api/src/instances.rs
@@ -24,12 +24,12 @@ pub(crate) use bulk::{
     __path_bulk_reschedule, __path_bulk_update_state, __path_list_dlq, bulk_reschedule,
     bulk_update_state, list_dlq,
 };
+pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};
 pub(crate) use checkpoints::{
     __path_get_latest_checkpoint, __path_list_checkpoints, __path_prune_checkpoints,
     __path_save_checkpoint, get_latest_checkpoint, list_checkpoints, prune_checkpoints,
     save_checkpoint,
 };
-pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};
 pub use inject::InjectBlocksRequest;
 pub(crate) use inject::{__path_inject_blocks, inject_blocks};
 pub(crate) use lifecycle::{

--- a/orch8-storage/src/postgres/instances.rs
+++ b/orch8-storage/src/postgres/instances.rs
@@ -224,7 +224,7 @@ pub(super) async fn claim_due(
     }
 
     // Step 2: Filter by concurrency limits within the transaction.
-    let instances = filter_by_concurrency_pg(&mut tx, &all_candidates).await?;
+    let instances = filter_by_concurrency_pg(&mut tx, all_candidates).await?;
 
     if !instances.is_empty() {
         // Step 3: Only update the filtered instances to Running.
@@ -253,7 +253,7 @@ pub(super) async fn claim_due(
 /// Filter candidates by `concurrency_key` / `max_concurrency` within a transaction.
 async fn filter_by_concurrency_pg(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-    candidates: &[TaskInstance],
+    candidates: Vec<TaskInstance>,
 ) -> Result<Vec<TaskInstance>, StorageError> {
     let mut keyed: HashMap<&str, Vec<usize>> = HashMap::with_capacity(candidates.len() / 2);
     for (idx, inst) in candidates.iter().enumerate() {
@@ -263,7 +263,7 @@ async fn filter_by_concurrency_pg(
     }
 
     if keyed.is_empty() {
-        return Ok(candidates.to_vec());
+        return Ok(candidates);
     }
 
     // Batch-fetch running counts for all concurrency keys in a single query
@@ -305,10 +305,10 @@ async fn filter_by_concurrency_pg(
     excluded.sort_unstable();
 
     Ok(candidates
-        .iter()
+        .into_iter()
         .enumerate()
         .filter(|(idx, _)| excluded.binary_search(idx).is_err())
-        .map(|(_, inst)| inst.clone())
+        .map(|(_, inst)| inst)
         .collect())
 }
 

--- a/orch8-storage/src/sqlite/instances.rs
+++ b/orch8-storage/src/sqlite/instances.rs
@@ -188,7 +188,7 @@ async fn claim_due_inner(
     // would exceed max_concurrency are never set to Running. This prevents
     // a window where the test (or any observer) could see more Running
     // instances than allowed.
-    let instances = filter_by_concurrency(&mut *conn, &all_candidates).await?;
+    let instances = filter_by_concurrency(&mut *conn, all_candidates).await?;
 
     if !instances.is_empty() {
         let mut qb =
@@ -212,7 +212,7 @@ async fn claim_due_inner(
 /// fill the remaining slots.
 async fn filter_by_concurrency(
     conn: &mut sqlx::SqliteConnection,
-    candidates: &[TaskInstance],
+    candidates: Vec<TaskInstance>,
 ) -> Result<Vec<TaskInstance>, StorageError> {
     // Group candidates by concurrency_key.
     let mut keyed: HashMap<&str, Vec<usize>> = HashMap::with_capacity(candidates.len() / 2);
@@ -223,7 +223,7 @@ async fn filter_by_concurrency(
     }
 
     if keyed.is_empty() {
-        return Ok(candidates.to_vec());
+        return Ok(candidates);
     }
 
     // Single batched COUNT query for all concurrency keys.
@@ -260,10 +260,10 @@ async fn filter_by_concurrency(
     excluded.sort_unstable();
 
     Ok(candidates
-        .iter()
+        .into_iter()
         .enumerate()
         .filter(|(idx, _)| excluded.binary_search(idx).is_err())
-        .map(|(_, inst)| inst.clone())
+        .map(|(_, inst)| inst)
         .collect())
 }
 


### PR DESCRIPTION
💡 **What:** 
Updated `filter_by_concurrency` (SQLite) and `filter_by_concurrency_pg` (Postgres) to accept ownership of the `all_candidates` vector rather than taking a slice reference. This allows the use of `.into_iter()` to filter the instances in-place, eliminating the previously required `.clone()` call on `TaskInstance`.

🎯 **Why:** 
`TaskInstance` holds a nested `ExecutionContext`, containing potentially large `serde_json::Value` payload fields (`data`, `config`, `audit`). Previously, when `claim_due_inner` enforced the concurrency limits, every single candidate that passed the filter was deep-cloned. By taking ownership, we retain the instances directly without allocation, avoiding a massive source of memory overhead on the core hot-path.

📊 **Impact:** 
Eliminates $O(K)$ deep struct clones per execution tick (where $K \le$ `limit` and $K$ instances pass the filter), saving significant allocations and CPU cycles during high-throughput concurrent workloads.

🔬 **Measurement:** 
Tested with `cargo test -p orch8-storage` to ensure concurrency filter semantics behave exactly as before.

---
*PR created automatically by Jules for task [425094174592384216](https://jules.google.com/task/425094174592384216) started by @ovasylenko*