### PR TITLE
⚡ Bolt: Eliminate recursive allocations in evaluator paths

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2025-10-24 - [Avoid Deep Cloning Large Structs in Filter Pipelines]
 **Learning:** In the `claim_due` hot path across all database backends, an earlier implementation built an index of elements to exclude and then filtered the candidate slice by allocating a new `Vec` and calling `.clone()` on every retained `TaskInstance`. Since `TaskInstance` holds deep `serde_json::Value` trees (like `context`), this created massive, unnecessary memory allocation and deep-copy overhead simply to trim a few excluded elements.
 **Action:** When filtering temporary vectors containing deep structs on a hot path, pass ownership of the `Vec` into the filtering function and use `into_iter` to selectively retain elements, avoiding any `clone()` calls.
+
+## 2025-02-12 - [Zero-Allocation State Checks in Execution Trees]
+**Learning:** Avoid instantiating `HashMap` or `HashSet` structures on every call within hot loops or recursive tree traversals (e.g., `is_descendant_of_any` and `cancel_subtree`). The previous implementation repeatedly allocated new `HashMap`s during deep recursion, creating severe algorithmic overhead and compounding allocation latency.
+**Action:** Replace small-to-medium set lookups on hot paths with sorted `Vec` instances and `.binary_search()`. For parent tracking inside tree recursive loops, prefer iterating over the slice directly (`tree.iter().find(...)`) rather than building a full `HashMap` inside the function scope.

--- a/orch8-engine/src/evaluator.rs
+++ b/orch8-engine/src/evaluator.rs
@@ -146,14 +146,15 @@ pub async fn ensure_execution_tree(
     let existing = storage.get_execution_tree(instance.id).await?;
     if !existing.is_empty() {
         // Check for newly injected blocks that don't have execution nodes yet.
-        let mut existing_block_ids = std::collections::HashSet::with_capacity(existing.len());
-        for n in &existing {
-            existing_block_ids.insert(n.block_id.as_str());
-        }
+        let mut existing_block_ids: Vec<&str> =
+            existing.iter().map(|n| n.block_id.as_str()).collect();
+        existing_block_ids.sort_unstable();
+        existing_block_ids.dedup();
+
         let mut new_nodes = Vec::with_capacity(blocks.len());
         for block in blocks {
             let (bid, _) = block_meta(block);
-            if !existing_block_ids.contains(bid.as_str()) {
+            if existing_block_ids.binary_search(&bid.as_str()).is_err() {
                 build_nodes(
                     instance.id,
                     None,
@@ -1143,13 +1144,13 @@ pub async fn cancel_subtree(
         }
     }
 
-    // Build a HashSet for O(1) lookup when scanning the tree.
-    let to_cancel_set: std::collections::HashSet<ExecutionNodeId> =
-        to_cancel.iter().copied().collect();
+    // Sort and dedup for O(log N) lookup when scanning the tree.
+    to_cancel.sort_unstable();
+    to_cancel.dedup();
 
     // Cancel worker tasks for any Waiting descendants before we flip their state.
     for node in tree {
-        if to_cancel_set.contains(&node.id) && node.state == NodeState::Waiting {
+        if to_cancel.binary_search(&node.id).is_ok() && node.state == NodeState::Waiting {
             storage
                 .cancel_worker_tasks_for_block(instance_id.into_uuid(), node.block_id.as_str())
                 .await?;

--- a/orch8-engine/src/signals.rs
+++ b/orch8-engine/src/signals.rs
@@ -261,11 +261,13 @@ async fn cancel_scoped(
     let mut cancellable_node_ids: Vec<ExecutionNodeId> = Vec::new();
 
     // Collect IDs of CancellationScope nodes so we can check ancestry.
-    let scope_node_ids: std::collections::HashSet<_> = tree
+    let mut scope_node_ids: Vec<ExecutionNodeId> = tree
         .iter()
         .filter(|n| n.block_type == BlockType::CancellationScope)
         .map(|n| n.id)
         .collect();
+    scope_node_ids.sort_unstable();
+    scope_node_ids.dedup();
 
     let block_map = crate::evaluator::flatten_blocks(&sequence_def.blocks);
 
@@ -373,15 +375,14 @@ fn is_inside_finally_branch(
 fn is_descendant_of_any(
     tree: &[orch8_types::execution::ExecutionNode],
     node: &orch8_types::execution::ExecutionNode,
-    ancestor_ids: &std::collections::HashSet<orch8_types::ids::ExecutionNodeId>,
+    ancestor_ids: &[orch8_types::ids::ExecutionNodeId],
 ) -> bool {
-    let node_map: std::collections::HashMap<_, _> = tree.iter().map(|n| (n.id, n)).collect();
     let mut current_parent = node.parent_id;
     while let Some(pid) = current_parent {
-        if ancestor_ids.contains(&pid) {
+        if ancestor_ids.binary_search(&pid).is_ok() {
             return true;
         }
-        current_parent = node_map.get(&pid).copied().and_then(|n| n.parent_id);
+        current_parent = tree.iter().find(|n| n.id == pid).and_then(|n| n.parent_id);
     }
     false
 }
@@ -1181,16 +1182,21 @@ mod tests {
             completed_at: None,
         };
         let tree = vec![root.clone(), child.clone(), grandchild.clone()];
-        let ancestors = std::collections::HashSet::from([root.id]);
+        let mut ancestors = vec![root.id];
+        ancestors.sort_unstable();
+        ancestors.dedup();
         assert!(is_descendant_of_any(&tree, &grandchild, &ancestors));
         assert!(is_descendant_of_any(&tree, &child, &ancestors));
         // Root is not a descendant of itself.
         assert!(!is_descendant_of_any(&tree, &root, &ancestors));
         // Unknown ancestor — returns false.
+        let mut unknown_ancestors = vec![ExecutionNodeId::new()];
+        unknown_ancestors.sort_unstable();
+        unknown_ancestors.dedup();
         assert!(!is_descendant_of_any(
             &tree,
             &grandchild,
-            &std::collections::HashSet::from([ExecutionNodeId::new()])
+            &unknown_ancestors
         ));
     }
 

--- a/orch8-types/src/ids.rs
+++ b/orch8-types/src/ids.rs
@@ -5,15 +5,54 @@ use uuid::Uuid;
 /// Newtype wrappers prevent mixing up UUIDs at compile time.
 /// Zero cost at runtime (transparent newtypes).
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, sqlx::Type, ToSchema)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    sqlx::Type,
+    ToSchema,
+)]
 #[sqlx(transparent)]
 pub struct InstanceId(Uuid);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, sqlx::Type, ToSchema)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    sqlx::Type,
+    ToSchema,
+)]
 #[sqlx(transparent)]
 pub struct SequenceId(Uuid);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, sqlx::Type, ToSchema)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    sqlx::Type,
+    ToSchema,
+)]
 #[sqlx(transparent)]
 pub struct ExecutionNodeId(Uuid);
 


### PR DESCRIPTION
💡 What: Replaced `HashSet` and `HashMap` lookups on hot execution tree evaluation paths (`ensure_execution_tree`, `cancel_subtree`, and `is_descendant_of_any`) with sorted `Vec` instances and `binary_search`. Added `PartialOrd` and `Ord` to ID types to support this.
🎯 Why: In recursive or looping execution tree evaluations, dynamically allocating `HashSet` and `HashMap` instances for state tracking incurs massive memory allocation and hashing overhead, significantly slowing down the evaluator loop.
📊 Impact: Expected to significantly reduce memory allocation overhead and CPU cache misses during deep execution tree dispatch cycles, removing $O(N^2)$ allocation patterns.
🔬 Measurement: Verify using `cargo test -p orch8-engine --lib` locally, and check allocation profiles under heavy execution tree traversal load.

---
*PR created automatically by Jules for task [9581756372931136750](https://jules.google.com/task/9581756372931136750) started by @ovasylenko*