### PR TITLE
fix(e2e): run artifacts suite self-managed (fixes red main E2E)

### DIFF
--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -9,7 +9,7 @@
     "test:dot": "ORCH8_E2E_REPORTER=dot tsx ./run-e2e.ts",
     "test:tap": "ORCH8_E2E_REPORTER=tap tsx ./run-e2e.ts",
     "test:standalone": "tsx ./run-standalone.ts",
-    "test:standalone:serial": "node --import tsx/esm --test --test-concurrency=1 --test-timeout=60000 ./resilience/persistence_recovery.test.ts ./features/triggers.test.ts ./signals/wait-signal.test.ts ./features/worker-dashboard.test.ts ./features/workers.test.ts"
+    "test:standalone:serial": "node --import tsx/esm --test --test-concurrency=1 --test-timeout=60000 ./resilience/persistence_recovery.test.ts ./features/triggers.test.ts ./signals/wait-signal.test.ts ./features/worker-dashboard.test.ts ./features/workers.test.ts ./handlers/artifacts.test.ts"
   },
   "devDependencies": {
     "@types/node": "^22.10.1",

--- a/tests/e2e/run-e2e.ts
+++ b/tests/e2e/run-e2e.ts
@@ -111,6 +111,11 @@ const SELF_MANAGED_SUITES = new Set<string>([
   // Spawns its own server with ORCH8_ACTIVEPIECES_URL pointed at a
   // local mock sidecar — the env override is ignored in attach mode.
   "activepieces_scenarios.test.ts",
+  // Spawns its own server with ORCH8_ARTIFACT_BACKEND=local + a temp
+  // ORCH8_ARTIFACT_PATH — the shared attach-mode server has no artifact
+  // backend, so `response_as: artifact` steps hang and the instance never
+  // completes (20s waitForState timeout).
+  "artifacts.test.ts",
   // Self-terminates the shared server (rule #3): drains its own node_id.
   "cluster.test.ts",
 ]);

--- a/tests/e2e/run-standalone.ts
+++ b/tests/e2e/run-standalone.ts
@@ -42,6 +42,10 @@ const SUITES: Suite[] = [
   { file: "signals/wait-signal.test.ts",             port: 19003, dbName: "orch8_std_waitsig" },
   { file: "features/worker-dashboard.test.ts",       port: 19004, dbName: "orch8_std_dash" },
   { file: "features/workers.test.ts",                port: 19005, dbName: "orch8_std_workers" },
+  // Boots its own server with ORCH8_ARTIFACT_BACKEND=local — the shared
+  // attach-mode server has no artifact backend (see run-e2e.ts
+  // SELF_MANAGED_SUITES), so `response_as: artifact` steps hang there.
+  { file: "handlers/artifacts.test.ts",              port: 19006, dbName: "orch8_std_artifacts" },
 ];
 
 const BASE_DB_URL =


### PR DESCRIPTION
## Problem

After #41 merged, **main's E2E Tests job went red**. Root cause: `tests/e2e/handlers/artifacts.test.ts` calls `startServer({ env: { ORCH8_ARTIFACT_BACKEND: "local", ORCH8_ARTIFACT_PATH } })`, but in CI's **shared-server (attach) mode** that env override is **ignored** (`harness.ts` attach path) — the runner-owned server has no artifact backend. With no backend, `response_as: artifact` steps never complete, so each test hangs to its 20s `waitForState` timeout:

```
✖ response_as=artifact captures the response body as a durable artifact (20063ms)
✖ downloads to an artifact then uploads the same bytes downstream (20035ms)
✖ tests/e2e/handlers/artifacts.test.ts (60019ms)
```

## Fix

Make the suite **self-managed** so it boots its own server in spawn mode (where the artifact env override applies):

- `run-e2e.ts`: add `artifacts.test.ts` to `SELF_MANAGED_SUITES` (excluded from the shared run).
- `run-standalone.ts`: register it (port 19006, db `orch8_std_artifacts`) so `npm run test:standalone` actually executes it — otherwise it'd be silently disabled.
- `package.json`: keep `test:standalone:serial` in parity.

This mirrors how `encryption_at_rest`, `activepieces_scenarios`, and `api_key_auth_enforcement` already self-manage for the same reason.

## Verification

Ran the suite in the exact isolated mode the standalone runner uses (own server + own DB, attach cleared): **3/3 pass**. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)