### PR TITLE
fix(e2e): reconcile self-managed suites — 17 ran nowhere in CI

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -118,6 +118,10 @@ All config fields can be set via `ORCH8_*` environment variables. Environment va
 | `ORCH8_MAX_INSTANCES_PER_TENANT` | `0` | Per-tenant claim limit (0 = unlimited) |
 | `ORCH8_ENCRYPTION_KEY` | — | 64 hex chars for AES-256-GCM encryption at rest |
 | `ORCH8_CRON_TICK_SECS` | `10` | Cron loop check interval (seconds) |
+| `ORCH8_WORKER_REAPER_TICK_SECS` | `30` | How often the stale worker-task reaper runs (seconds) |
+| `ORCH8_WORKER_REAPER_STALE_SECS` | `60` | Claimed task is reclaimed after this long without a heartbeat (seconds) |
+| `ORCH8_NODE_REAPER_TICK_SECS` | `60` | How often the stale cluster-node reaper runs (seconds) |
+| `ORCH8_NODE_REAPER_STALE_SECS` | `120` | Cluster node is reaped after this long without a heartbeat (seconds) |
 | `ORCH8_EXTERNALIZE_THRESHOLD` | `0` | Externalize outputs larger than N bytes (0 = disabled) |
 | `ORCH8_WEBHOOK_URLS` | — | Comma-separated webhook endpoint URLs |
 

--- a/orch8-server/src/main.rs
+++ b/orch8-server/src/main.rs
@@ -579,6 +579,30 @@ fn apply_env_overrides(config: &mut EngineConfig) {
             config.engine.cron_tick_secs = n;
         }
     }
+    // Reaper cadence/threshold overrides. Defaults (tick 30s / stale 60s for
+    // worker tasks, 60s / 120s for nodes) are sane for production but make
+    // reclamation tests wait minutes; the E2E harness sets these low so the
+    // worker-reaper suites run in seconds.
+    if let Ok(val) = std::env::var("ORCH8_WORKER_REAPER_TICK_SECS") {
+        if let Ok(n) = val.parse() {
+            config.engine.worker_reaper_tick_secs = n;
+        }
+    }
+    if let Ok(val) = std::env::var("ORCH8_WORKER_REAPER_STALE_SECS") {
+        if let Ok(n) = val.parse() {
+            config.engine.worker_reaper_stale_secs = n;
+        }
+    }
+    if let Ok(val) = std::env::var("ORCH8_NODE_REAPER_TICK_SECS") {
+        if let Ok(n) = val.parse() {
+            config.engine.node_reaper_tick_secs = n;
+        }
+    }
+    if let Ok(val) = std::env::var("ORCH8_NODE_REAPER_STALE_SECS") {
+        if let Ok(n) = val.parse() {
+            config.engine.node_reaper_stale_secs = n;
+        }
+    }
     if let Ok(val) = std::env::var("ORCH8_BATCH_SIZE") {
         if let Ok(n) = val.parse() {
             config.engine.batch_size = n;

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -9,7 +9,7 @@
     "test:dot": "ORCH8_E2E_REPORTER=dot tsx ./run-e2e.ts",
     "test:tap": "ORCH8_E2E_REPORTER=tap tsx ./run-e2e.ts",
     "test:standalone": "tsx ./run-standalone.ts",
-    "test:standalone:serial": "node --import tsx/esm --test --test-concurrency=1 --test-timeout=60000 ./resilience/persistence_recovery.test.ts ./features/triggers.test.ts ./signals/wait-signal.test.ts ./features/worker-dashboard.test.ts ./features/workers.test.ts ./handlers/artifacts.test.ts"
+    "test:standalone:serial": "ORCH8_E2E_CONCURRENCY=1 tsx ./run-standalone.ts"
   },
   "devDependencies": {
     "@types/node": "^22.10.1",

--- a/tests/e2e/resilience/worker_heartbeat_timeout.test.ts
+++ b/tests/e2e/resilience/worker_heartbeat_timeout.test.ts
@@ -3,16 +3,14 @@
  * reaped back to `pending` by the engine's stale-task reaper, and becomes
  * available for re-polling by a new worker.
  *
- * Engine timing (see `orch8-engine/src/lib.rs`):
- *   - The reaper runs on a 30-second tick with a 60-second stale threshold.
- *   - Effective wall-clock for reclamation: 60-90 seconds after the last
- *     heartbeat.
- *   - Neither knob is currently configurable via env or per-test. That's an
- *     engine gap worth closing for test ergonomics.
+ * Engine timing (see `orch8-engine/src/lib.rs`): the reaper cadence and
+ * stale threshold come from `SchedulerConfig` and are env-overridable
+ * (`ORCH8_WORKER_REAPER_TICK_SECS` / `ORCH8_WORKER_REAPER_STALE_SECS`).
+ * This suite boots its own server with a 1s tick / 2s stale window so
+ * reclamation lands in seconds instead of the production 30s/60s.
  *
- * This test therefore waits ~120s in the worst case. It's marked as
- * SELF_MANAGED in `run-e2e.ts` because it touches globally-scoped
- * worker_tasks rows.
+ * SELF_MANAGED in `self-managed.ts`: it touches globally-scoped
+ * worker_tasks rows AND needs the low-threshold env.
  */
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
@@ -23,9 +21,10 @@ import type { WorkerTask } from "../client.ts";
 
 const client = new Orch8Client();
 
-// Worst-case reclamation window: 60s stale threshold + 30s tick interval.
-const RECLAIM_TIMEOUT_MS = 120_000;
-const POLL_INTERVAL_MS = 1_000;
+// With a 2s stale window + 1s reaper tick (set via env below) reclamation
+// lands within ~3-5s. Generous ceiling for slow/loaded CI runners.
+const RECLAIM_TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 500;
 
 async function waitFor<T>(
   fn: () => Promise<T | undefined | null>,
@@ -44,7 +43,12 @@ describe("Worker Heartbeat Timeout", () => {
   let server: ServerHandle | undefined;
 
   before(async () => {
-    server = await startServer();
+    server = await startServer({
+      env: {
+        ORCH8_WORKER_REAPER_TICK_SECS: "1",
+        ORCH8_WORKER_REAPER_STALE_SECS: "2",
+      },
+    });
   });
 
   after(async () => {

--- a/tests/e2e/resilience/worker_task_timeout.test.ts
+++ b/tests/e2e/resilience/worker_task_timeout.test.ts
@@ -9,16 +9,15 @@
  * anchored at `claimed_at` (which the storage layer sets as the initial
  * `heartbeat_at`, per `orch8-storage/src/postgres/workers.rs::claim`).
  *
- * Engine gap: neither the tick interval nor the stale threshold is
- * configurable per-test or via env. A `StepDef.timeout` field exists but
- * is stamped onto the WorkerTask row as `timeout_ms` and is not enforced
- * by the reaper today — reclamation is purely heartbeat-driven. Closing
- * that gap (e.g. wiring StepDef.timeout into the reaper, or exposing
- * `ORCH8_RECLAIM_THRESHOLD_MS`) would let this test run in seconds
- * rather than minutes.
+ * The reaper cadence/threshold come from `SchedulerConfig` and are now
+ * env-overridable (`ORCH8_WORKER_REAPER_TICK_SECS` /
+ * `ORCH8_WORKER_REAPER_STALE_SECS`). This suite boots its own server with
+ * a 1s tick / 2s stale window so reclamation happens in seconds instead of
+ * the production defaults (30s / 60s) that made the test run for minutes.
  *
- * This test is SELF_MANAGED in `run-e2e.ts` because it touches
- * globally-scoped worker_tasks rows.
+ * This test is SELF_MANAGED in `self-managed.ts` because it touches
+ * globally-scoped worker_tasks rows AND needs the low-threshold env that
+ * the shared attach-mode server doesn't set.
  */
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
@@ -29,8 +28,10 @@ import type { WorkerTask } from "../client.ts";
 
 const client = new Orch8Client();
 
-const RECLAIM_TIMEOUT_MS = 120_000;
-const POLL_INTERVAL_MS = 1_000;
+// With a 2s stale window + 1s reaper tick (set via env below) reclamation
+// lands within ~3-5s. Keep a generous ceiling for slow/loaded CI runners.
+const RECLAIM_TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 500;
 
 async function waitFor<T>(
   fn: () => Promise<T | undefined | null>,
@@ -49,7 +50,12 @@ describe("Worker Task Claim Timeout", () => {
   let server: ServerHandle | undefined;
 
   before(async () => {
-    server = await startServer();
+    server = await startServer({
+      env: {
+        ORCH8_WORKER_REAPER_TICK_SECS: "1",
+        ORCH8_WORKER_REAPER_STALE_SECS: "2",
+      },
+    });
   });
 
   after(async () => {

--- a/tests/e2e/run-e2e.ts
+++ b/tests/e2e/run-e2e.ts
@@ -35,6 +35,7 @@ import { basename, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { startServer, stopServer } from "./harness.ts";
 import type { ServerHandle } from "./harness.ts";
+import { SELF_MANAGED_BASENAMES } from "./self-managed.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = Number(process.env.ORCH8_E2E_PORT) || 18080;
@@ -58,67 +59,11 @@ function fmtDuration(ms: number): string {
   return `${m}m${rem}s`;
 }
 
-// Suites that need their own server.
-//
-// Three reasons a suite lands here:
-//
-// 1. Server-lifecycle tests (persistence_recovery): the suite itself does
-//    stop/start mid-test, which is incompatible with attach-mode.
-//
-// 2. Suites exercising **globally-scoped** state — worker task queue,
-//    trigger definitions, signal inbox, worker dashboard. These tables
-//    aren't keyed by tenant_id, so accumulated rows from earlier suites
-//    in a shared server leak in and break assertions like
-//    `assert.equal(tasks.length, 1)`. A tenant prefix doesn't help; only
-//    a fresh server does.
-//
-// 3. Suites that **self-terminate the server**. The cluster drain test
-//    calls `POST /cluster/nodes/{id}/drain` on the shared server's own
-//    node_id; the engine's 10s heartbeat loop reads `should_drain=true`
-//    and cancels the shutdown token (orch8-engine/src/lib.rs:165-172),
-//    killing the shared server cleanly (code=0) mid-run. Only a sacrificial
-//    own-server can be drained safely.
-const SELF_MANAGED_SUITES = new Set<string>([
-  "persistence_recovery.test.ts",
-  "triggers.test.ts",
-  "wait-signal.test.ts",
-  "worker-dashboard.test.ts",
-  "workers.test.ts",
-  // Worker task queue — not keyed by tenant_id (see rule #2).
-  "worker_task_timeout.test.ts",
-  "worker_heartbeat_timeout.test.ts",
-  "retryable_false_open_circuit.test.ts",
-  "circuit_breaker_trip.test.ts",
-  "complex_patterns.test.ts",
-  // Signal inbox — not keyed by tenant_id.
-  "signal_ordering.test.ts",
-  "signal_during_finally.test.ts",
-  // Trigger definitions — globally scoped, leak across suites.
-  "emit_event_deep_chains.test.ts",
-  "emit_event_invalid_target.test.ts",
-  "emit_event_dedupe_scope.test.ts",
-  // Server-lifecycle tests (rule #1): require mid-test restart or env swap.
-  "encryption_key_rotation.test.ts",
-  "ab_split_determinism_restart.test.ts",
-  // Needs its own server started with ORCH8_ENCRYPTION_KEY set — the shared
-  // attach-mode server was launched without a key.
-  "encryption_at_rest.test.ts",
-  "credential_encryption_at_rest.test.ts",
-  // Spawns its own server with ORCH8_API_KEY and
-  // ORCH8_REQUIRE_TENANT_HEADER set — shared attach-mode server has
-  // neither, so auth enforcement can't be observed there.
-  "api_key_auth_enforcement.test.ts",
-  // Spawns its own server with ORCH8_ACTIVEPIECES_URL pointed at a
-  // local mock sidecar — the env override is ignored in attach mode.
-  "activepieces_scenarios.test.ts",
-  // Spawns its own server with ORCH8_ARTIFACT_BACKEND=local + a temp
-  // ORCH8_ARTIFACT_PATH — the shared attach-mode server has no artifact
-  // backend, so `response_as: artifact` steps hang and the instance never
-  // completes (20s waitForState timeout).
-  "artifacts.test.ts",
-  // Self-terminates the shared server (rule #3): drains its own node_id.
-  "cluster.test.ts",
-]);
+// Suites that need their own server are excluded from the shared run and
+// dispatched by `run-standalone.ts` instead. The list lives in
+// `self-managed.ts` (single source of truth) so the two runners can't
+// drift — see that file for why each suite qualifies.
+const SELF_MANAGED_SUITES = SELF_MANAGED_BASENAMES;
 
 // Directories whose tests are organizational scaffolding, not runnable yet.
 // Skip them so empty scaffolds don't fail the runner. Remove once they have

--- a/tests/e2e/run-standalone.ts
+++ b/tests/e2e/run-standalone.ts
@@ -25,6 +25,7 @@
 import { spawn, execFileSync } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { SELF_MANAGED_SUITES, basenameOf } from "./self-managed.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -34,19 +35,23 @@ interface Suite {
   dbName: string;
 }
 
-// Keep the port range well away from the shared-runner default (18080) and
-// common app defaults. `run-e2e.ts` defaults to 18080; we start at 19001.
-const SUITES: Suite[] = [
-  { file: "resilience/persistence_recovery.test.ts", port: 19001, dbName: "orch8_std_persist" },
-  { file: "features/triggers.test.ts",               port: 19002, dbName: "orch8_std_triggers" },
-  { file: "signals/wait-signal.test.ts",             port: 19003, dbName: "orch8_std_waitsig" },
-  { file: "features/worker-dashboard.test.ts",       port: 19004, dbName: "orch8_std_dash" },
-  { file: "features/workers.test.ts",                port: 19005, dbName: "orch8_std_workers" },
-  // Boots its own server with ORCH8_ARTIFACT_BACKEND=local — the shared
-  // attach-mode server has no artifact backend (see run-e2e.ts
-  // SELF_MANAGED_SUITES), so `response_as: artifact` steps hang there.
-  { file: "handlers/artifacts.test.ts",              port: 19006, dbName: "orch8_std_artifacts" },
-];
+// Derive the suite list from the single source of truth (self-managed.ts),
+// auto-assigning a unique port and Postgres database to each. Ports start at
+// 19001 — well clear of the shared-runner default (18080) and common app
+// defaults. DB names are derived from the basename so two suites can't
+// collide. This replaces a hand-maintained list that drifted out of sync
+// with run-e2e.ts and silently dropped 17 suites from CI.
+const SUITES: Suite[] = SELF_MANAGED_SUITES.map((s, i) => ({
+  file: s.file,
+  port: 19001 + i,
+  dbName: `orch8_std_${basenameOf(s.file).replace(/\.test\.ts$/, "").replace(/[^a-z0-9]/gi, "_")}`,
+}));
+
+// Cap how many suites run at once. Each suite boots its own debug-build
+// server + Postgres DB; 20+ in parallel would exhaust a CI runner's RAM and
+// connection slots. A small pool keeps wall time low (≈ceil(N/limit) waves)
+// without thrashing. Override with ORCH8_E2E_CONCURRENCY (1 = fully serial).
+const CONCURRENCY = Math.max(1, Number(process.env.ORCH8_E2E_CONCURRENCY) || 6);
 
 const BASE_DB_URL =
   process.env.ORCH8_DATABASE_URL ||
@@ -187,22 +192,44 @@ function runSuite(suite: Suite): Promise<SuiteResult> {
 }
 
 console.log(
-  `runner: dispatching ${SUITES.length} self-managed suite(s) in parallel`,
+  `runner: dispatching ${SUITES.length} self-managed suite(s), ${CONCURRENCY} at a time`,
 );
 for (const s of SUITES) {
   console.log(`  [${suiteLabel(s).padEnd(LABEL_WIDTH)}] ${s.file}`);
 }
 ensureDatabases(SUITES);
 
+/**
+ * Run all suites through a fixed-size worker pool. Each of the `limit`
+ * workers pulls the next un-started suite until the queue drains, so at
+ * most `limit` servers are live at once. Results preserve completion order
+ * (the summary re-sorts for readability anyway).
+ */
+async function runPool(suites: Suite[], limit: number): Promise<SuiteResult[]> {
+  const results: SuiteResult[] = [];
+  let next = 0;
+  const worker = async (): Promise<void> => {
+    while (next < suites.length) {
+      const suite = suites[next++]!;
+      results.push(await runSuite(suite));
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(limit, suites.length) }, worker),
+  );
+  return results;
+}
+
 const start = Date.now();
-const results = await Promise.all(SUITES.map(runSuite));
+const results = await runPool(SUITES, CONCURRENCY);
 const wallMs = Date.now() - start;
 
 // Concise summary at the bottom so CI reviewers can see status at a glance
 // without scrolling through the prefixed output above.
 console.log("");
 console.log("runner: ───────────── summary ─────────────");
-for (const r of results) {
+const sorted = [...results].sort((a, b) => a.suite.file.localeCompare(b.suite.file));
+for (const r of sorted) {
   const status = r.code === 0 ? "PASS" : `FAIL(${r.code})`;
   console.log(`  ${status.padEnd(8)} ${suiteLabel(r.suite).padEnd(LABEL_WIDTH)}  ${r.suite.file}`);
 }

--- a/tests/e2e/self-managed.ts
+++ b/tests/e2e/self-managed.ts
@@ -1,0 +1,78 @@
+/**
+ * Single source of truth for **self-managed** E2E suites.
+ *
+ * A self-managed suite cannot share the one attach-mode server that
+ * `run-e2e.ts` boots for the bulk of the suite. Two runners consume this
+ * list, and they MUST agree — historically they were two hand-maintained
+ * lists that drifted, leaving 17 suites excluded from the shared run *and*
+ * absent from the standalone runner, so they ran nowhere in CI. Deriving
+ * both from this module makes that drift impossible.
+ *
+ *   - `run-e2e.ts`      → EXCLUDES these from the shared-server run
+ *                         (matched by basename).
+ *   - `run-standalone.ts` → RUNS each one in spawn mode with its own
+ *                         server + Postgres database.
+ *
+ * Paths are relative to this directory (tests/e2e). Keep them as full
+ * paths — `run-standalone.ts` needs the location to spawn the file, and
+ * `run-e2e.ts` only needs the basename, which it derives.
+ *
+ * Three reasons a suite belongs here:
+ *
+ *   1. Server-lifecycle: the suite stops/starts or swaps env mid-test
+ *      (incompatible with attach-mode).
+ *   2. Globally-scoped state — worker task queue, trigger definitions,
+ *      signal inbox, worker dashboard. These tables aren't keyed by
+ *      tenant_id, so rows from earlier suites leak in and break
+ *      count-based assertions. Only a fresh server isolates them.
+ *   3. Self-terminating: e.g. the cluster drain test kills its own
+ *      server's node_id mid-run, so it needs a sacrificial own-server.
+ */
+
+export interface SelfManagedSuite {
+  /** Path relative to tests/e2e, e.g. "features/triggers.test.ts". */
+  file: string;
+  /** Why it can't share the attach-mode server (one line, for the log). */
+  reason: string;
+}
+
+export const SELF_MANAGED_SUITES: readonly SelfManagedSuite[] = [
+  // Server-lifecycle: restarts mid-test.
+  { file: "resilience/persistence_recovery.test.ts", reason: "restarts the server mid-test" },
+  // Globally-scoped state (rule #2).
+  { file: "features/triggers.test.ts", reason: "trigger defs are globally scoped" },
+  { file: "signals/wait-signal.test.ts", reason: "signal inbox not keyed by tenant" },
+  { file: "features/worker-dashboard.test.ts", reason: "worker queue not keyed by tenant" },
+  { file: "features/workers.test.ts", reason: "worker queue not keyed by tenant" },
+  { file: "resilience/worker_task_timeout.test.ts", reason: "worker queue not keyed by tenant" },
+  { file: "resilience/worker_heartbeat_timeout.test.ts", reason: "worker queue not keyed by tenant" },
+  { file: "resilience/retryable_false_open_circuit.test.ts", reason: "circuit-breaker state is server-global" },
+  { file: "resilience/circuit_breaker_trip.test.ts", reason: "circuit-breaker state is server-global" },
+  { file: "blocks/complex_patterns.test.ts", reason: "exercises globally-scoped state" },
+  { file: "signals/signal_ordering.test.ts", reason: "signal inbox not keyed by tenant" },
+  { file: "blocks/signal_during_finally.test.ts", reason: "signal inbox not keyed by tenant" },
+  { file: "handlers/emit_event_deep_chains.test.ts", reason: "trigger defs leak across suites" },
+  { file: "handlers/emit_event_invalid_target.test.ts", reason: "trigger defs leak across suites" },
+  { file: "handlers/emit_event_dedupe_scope.test.ts", reason: "trigger defs leak across suites" },
+  // Server-lifecycle / env-swap (rule #1).
+  { file: "security/encryption_key_rotation.test.ts", reason: "swaps ORCH8_ENCRYPTION_KEY mid-test" },
+  { file: "features/ab_split_determinism_restart.test.ts", reason: "restarts the server mid-test" },
+  // Need their own server started with a specific env the shared server lacks.
+  { file: "features/encryption_at_rest.test.ts", reason: "needs ORCH8_ENCRYPTION_KEY set at boot" },
+  { file: "security/credential_encryption_at_rest.test.ts", reason: "needs ORCH8_ENCRYPTION_KEY set at boot" },
+  { file: "security/api_key_auth_enforcement.test.ts", reason: "needs ORCH8_API_KEY + ORCH8_REQUIRE_TENANT_HEADER" },
+  { file: "handlers/activepieces_scenarios.test.ts", reason: "needs ORCH8_ACTIVEPIECES_URL → local mock" },
+  { file: "handlers/artifacts.test.ts", reason: "needs ORCH8_ARTIFACT_BACKEND=local" },
+  // Self-terminates (rule #3).
+  { file: "features/cluster.test.ts", reason: "drains its own node_id, killing the server" },
+];
+
+/** Basename of a suite path (e.g. "features/triggers.test.ts" → "triggers.test.ts"). */
+export function basenameOf(file: string): string {
+  return file.split("/").pop() ?? file;
+}
+
+/** Set of basenames — used by run-e2e.ts to exclude these from the shared run. */
+export const SELF_MANAGED_BASENAMES: ReadonlySet<string> = new Set(
+  SELF_MANAGED_SUITES.map((s) => basenameOf(s.file)),
+);


### PR DESCRIPTION
## The gap

`run-e2e.ts` excludes ~24 suites from the shared-server run via `SELF_MANAGED_SUITES`, but `run-standalone.ts` only dispatched a **hardcoded 6**. The other **17 suites ran in no CI job at all** — excluded from the shared run *and* absent from the standalone runner. Two hand-maintained lists had silently drifted.

Suites that were dormant: `cluster`, `encryption_at_rest`, `credential_encryption_at_rest`, `api_key_auth_enforcement`, `activepieces_scenarios`, `encryption_key_rotation`, `ab_split_determinism_restart`, `complex_patterns`, `signal_ordering`, `signal_during_finally`, `circuit_breaker_trip`, `retryable_false_open_circuit`, `worker_task_timeout`, `worker_heartbeat_timeout`, `emit_event_deep_chains`, `emit_event_invalid_target`, `emit_event_dedupe_scope`.

## Fix: single source of truth

- **`tests/e2e/self-managed.ts`** (new) — one list, full paths + a reason per suite. `run-e2e.ts` excludes by basename; `run-standalone.ts` derives the full dispatch list with auto-assigned ports (19001+) and per-suite Postgres DBs. Drift is now structurally impossible.
- **`run-standalone.ts`** — bounded worker pool (`ORCH8_E2E_CONCURRENCY`, default 6) so 20+ own-server suites don't exhaust a CI runner; stable sorted summary.
- **`package.json`** — `test:standalone:serial` derives from the same source (`CONCURRENCY=1`) instead of a stale hardcoded list.

## Two dormant suites needed real fixes

- **`worker_task_timeout`** was a *genuine failure*: it waited on the heartbeat reaper, whose 60s stale threshold wasn't env-configurable, so it ran >120s and timed out (this is why it was never noticed — it would always have failed). Exposed `ORCH8_WORKER_REAPER_{TICK,STALE}_SECS` (plus the node-reaper pair) as env overrides. Both worker-reaper suites now boot with a 1s tick / 2s window and pass in ~3s.
- **`persistence_recovery`**'s earlier pool flake was the 120s `worker_task_timeout` hogging a slot and bunching the rest — gone now that it's fast.

## Verification

All **23** self-managed suites run and pass locally. Standalone wall time dropped from **123s → ~20s**. `cargo fmt --check`, `cargo clippy -p orch8-server`, and e2e `tsc` all clean. New env vars documented in `docs/CONFIGURATION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)