### PR TITLE
feat(usage): model pricing table and cost estimates in GET /usage

### DIFF
--- a/orch8-api/src/lib.rs
+++ b/orch8-api/src/lib.rs
@@ -10,6 +10,7 @@ pub mod health;
 pub mod instances;
 pub mod metrics;
 pub mod mobile_sync;
+pub mod model_pricing;
 #[allow(clippy::needless_for_each)]
 pub mod openapi;
 pub mod plugins;

--- a/orch8-api/src/model_pricing.rs
+++ b/orch8-api/src/model_pricing.rs
@@ -1,0 +1,277 @@
+//! Static LLM model pricing table used to estimate USD cost from token usage.
+//!
+//! Prices are **estimates** (USD per 1M tokens, list prices as of mid-2025)
+//! and exist so `GET /usage` can attach a ballpark `cost_usd` to each
+//! aggregate without calling out to any provider. Deployments can correct or
+//! extend the table at process start via the `ORCH8_MODEL_PRICING` env var
+//! (a JSON object merged over the defaults, see [`price_for_model`]).
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+
+/// USD price per 1M input/output tokens for a single model family.
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+pub struct ModelPrice {
+    /// USD per 1M input (prompt) tokens.
+    pub input_per_1m: f64,
+    /// USD per 1M output (completion) tokens.
+    pub output_per_1m: f64,
+}
+
+/// Default pricing table: model-name prefix → (input, output) USD per 1M
+/// tokens. Entries are matched by longest normalized prefix, so versioned
+/// names like `gpt-4o-2024-08-06` or `claude-sonnet-4-6` resolve to their
+/// family entry.
+const DEFAULT_PRICES: &[(&str, ModelPrice)] = &[
+    // OpenAI
+    ("gpt-4o", price(2.50, 10.00)),
+    ("gpt-4o-mini", price(0.15, 0.60)),
+    ("gpt-4.1", price(2.00, 8.00)),
+    ("gpt-4.1-mini", price(0.40, 1.60)),
+    ("gpt-4.1-nano", price(0.10, 0.40)),
+    ("gpt-4-turbo", price(10.00, 30.00)),
+    ("gpt-3.5-turbo", price(0.50, 1.50)),
+    ("o1", price(15.00, 60.00)),
+    ("o3", price(2.00, 8.00)),
+    ("o3-mini", price(1.10, 4.40)),
+    ("o4-mini", price(1.10, 4.40)),
+    // Anthropic
+    ("claude-opus-4", price(15.00, 75.00)),
+    ("claude-sonnet-4", price(3.00, 15.00)),
+    ("claude-haiku", price(1.00, 5.00)),
+    ("claude-haiku-4-5", price(1.00, 5.00)),
+    ("claude-3-5-sonnet", price(3.00, 15.00)),
+    ("claude-3-5-haiku", price(0.80, 4.00)),
+    ("claude-3-7-sonnet", price(3.00, 15.00)),
+    ("claude-3-opus", price(15.00, 75.00)),
+    // Google
+    ("gemini-2.5-pro", price(1.25, 10.00)),
+    ("gemini-2.5-flash", price(0.30, 2.50)),
+    ("gemini-2.0-flash", price(0.10, 0.40)),
+    ("gemini-1.5-pro", price(1.25, 5.00)),
+    ("gemini-1.5-flash", price(0.075, 0.30)),
+    // DeepSeek
+    ("deepseek-chat", price(0.27, 1.10)),
+    ("deepseek-reasoner", price(0.55, 2.19)),
+    // Mistral
+    ("mistral-large", price(2.00, 6.00)),
+    ("mistral-medium", price(0.40, 2.00)),
+    ("mistral-small", price(0.10, 0.30)),
+    // Meta
+    ("llama-3.3-70b", price(0.59, 0.79)),
+    ("llama-3.1-70b", price(0.59, 0.79)),
+    ("llama-3.1-8b", price(0.05, 0.08)),
+    ("llama-3.1-405b", price(3.50, 3.50)),
+    // xAI
+    ("grok-3", price(3.00, 15.00)),
+    ("grok-3-mini", price(0.30, 0.50)),
+    ("grok-2", price(2.00, 10.00)),
+    // Alibaba
+    ("qwen-max", price(1.60, 6.40)),
+    ("qwen-plus", price(0.40, 1.20)),
+    ("qwen-turbo", price(0.05, 0.20)),
+    // Cohere
+    ("command-r", price(0.15, 0.60)),
+    ("command-r-plus", price(2.50, 10.00)),
+    // Amazon
+    ("nova-pro", price(0.80, 3.20)),
+    ("nova-lite", price(0.06, 0.24)),
+];
+
+/// `const`-context constructor so [`DEFAULT_PRICES`] stays readable.
+const fn price(input_per_1m: f64, output_per_1m: f64) -> ModelPrice {
+    ModelPrice {
+        input_per_1m,
+        output_per_1m,
+    }
+}
+
+/// Env var holding pricing overrides: a JSON object of
+/// `{"model-prefix": {"input_per_1m": <f64>, "output_per_1m": <f64>}}`
+/// merged over the built-in defaults (replacing existing entries, adding new
+/// ones). Read once on first use; invalid JSON logs a warning and is ignored.
+pub const PRICING_ENV_VAR: &str = "ORCH8_MODEL_PRICING";
+
+/// Build the effective pricing table: defaults merged with optional JSON
+/// overrides (keys are normalized to lowercase). Invalid JSON logs a warning
+/// and yields the defaults unchanged.
+fn build_table(overrides_json: Option<&str>) -> HashMap<String, ModelPrice> {
+    let mut table: HashMap<String, ModelPrice> = DEFAULT_PRICES
+        .iter()
+        .map(|(name, p)| (name.to_lowercase(), *p))
+        .collect();
+
+    if let Some(json) = overrides_json {
+        match serde_json::from_str::<HashMap<String, ModelPrice>>(json) {
+            Ok(overrides) => {
+                for (name, p) in overrides {
+                    table.insert(name.to_lowercase(), p);
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "invalid {PRICING_ENV_VAR} JSON; using default model pricing"
+                );
+            }
+        }
+    }
+    table
+}
+
+/// The process-wide pricing table, initialised once from defaults +
+/// `ORCH8_MODEL_PRICING`.
+fn pricing_table() -> &'static HashMap<String, ModelPrice> {
+    static TABLE: OnceLock<HashMap<String, ModelPrice>> = OnceLock::new();
+    TABLE.get_or_init(|| build_table(std::env::var(PRICING_ENV_VAR).ok().as_deref()))
+}
+
+/// Normalize a model identifier for table lookup: trim, lowercase, and drop
+/// any provider path prefix (`anthropic/claude-sonnet-4` → `claude-sonnet-4`).
+fn normalize(model: &str) -> String {
+    let trimmed = model.trim().to_lowercase();
+    match trimmed.rsplit_once('/') {
+        Some((_, name)) => name.to_string(),
+        None => trimmed,
+    }
+}
+
+/// Longest-prefix lookup against `table` for an already-normalized name.
+///
+/// A table key matches when it is a prefix of `normalized` and the remainder
+/// is empty or starts at a separator (non-alphanumeric), so `gpt-4o-mini`
+/// never falls back to the `gpt-4o` entry while `gpt-4o-2024-08-06` does.
+/// Among matches the longest key wins.
+fn lookup(table: &HashMap<String, ModelPrice>, normalized: &str) -> Option<ModelPrice> {
+    table
+        .iter()
+        .filter(|(key, _)| {
+            normalized.starts_with(key.as_str())
+                && normalized[key.len()..]
+                    .chars()
+                    .next()
+                    .is_none_or(|c| !c.is_ascii_alphanumeric())
+        })
+        .max_by_key(|(key, _)| key.len())
+        .map(|(_, p)| *p)
+}
+
+/// Look up the estimated price for `model` (case-insensitive, longest-prefix
+/// match after normalization). Returns `None` for unknown models.
+pub fn price_for_model(model: &str) -> Option<ModelPrice> {
+    lookup(pricing_table(), &normalize(model))
+}
+
+/// Estimate the USD cost of `input_tokens`/`output_tokens` against `model`'s
+/// table entry. Returns `None` when the model is unknown. The result is an
+/// **estimate** — list prices only, no caching/batch/tier discounts.
+pub fn estimate_cost_usd(model: &str, input_tokens: i64, output_tokens: i64) -> Option<f64> {
+    let p = price_for_model(model)?;
+    #[allow(clippy::cast_precision_loss)]
+    let cost = (input_tokens as f64 / 1_000_000.0) * p.input_per_1m
+        + (output_tokens as f64 / 1_000_000.0) * p.output_per_1m;
+    Some(cost)
+}
+
+#[cfg(test)]
+// Exact float comparison is intentional here: the assertions compare values
+// copied verbatim from the constant pricing table, not computed results.
+#[allow(clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_match_basic_models() {
+        let p = price_for_model("gpt-4o").unwrap();
+        assert_eq!((p.input_per_1m, p.output_per_1m), (2.50, 10.00));
+        let p = price_for_model("claude-opus-4").unwrap();
+        assert_eq!((p.input_per_1m, p.output_per_1m), (15.00, 75.00));
+    }
+
+    #[test]
+    fn longest_prefix_wins_gpt4o_vs_mini() {
+        // "gpt-4o-mini" must hit its own entry, not the shorter "gpt-4o".
+        let mini = price_for_model("gpt-4o-mini").unwrap();
+        assert_eq!((mini.input_per_1m, mini.output_per_1m), (0.15, 0.60));
+        // A dated snapshot of the mini model still resolves to mini.
+        let mini = price_for_model("gpt-4o-mini-2024-07-18").unwrap();
+        assert_eq!(mini.input_per_1m, 0.15);
+        // While a dated base model resolves to the base entry.
+        let base = price_for_model("gpt-4o-2024-08-06").unwrap();
+        assert_eq!(base.input_per_1m, 2.50);
+    }
+
+    #[test]
+    fn versioned_claude_matches_family_prefix() {
+        let p = price_for_model("claude-sonnet-4-6").unwrap();
+        assert_eq!((p.input_per_1m, p.output_per_1m), (3.00, 15.00));
+        // "claude-haiku-4-5" has its own (longer) entry over "claude-haiku".
+        let p = price_for_model("claude-haiku-4-5").unwrap();
+        assert_eq!(p.input_per_1m, 1.00);
+    }
+
+    #[test]
+    fn lookup_is_case_insensitive_and_strips_provider_prefix() {
+        assert!(price_for_model("GPT-4o").is_some());
+        assert!(price_for_model("  Claude-Sonnet-4 ").is_some());
+        let p = price_for_model("anthropic/claude-sonnet-4").unwrap();
+        assert_eq!(p.output_per_1m, 15.00);
+    }
+
+    #[test]
+    fn unknown_model_is_none() {
+        assert!(price_for_model("totally-unknown-model").is_none());
+        assert!(price_for_model("").is_none());
+        // Alphanumeric continuation is NOT a family match.
+        assert!(price_for_model("gpt-4o2").is_none());
+    }
+
+    #[test]
+    fn cost_math() {
+        // 1M input + 1M output of gpt-4o = $2.50 + $10.00.
+        assert_eq!(
+            estimate_cost_usd("gpt-4o", 1_000_000, 1_000_000),
+            Some(12.5)
+        );
+        // 100k in / 50k out of gpt-4o-mini = 0.1*0.15 + 0.05*0.60 = 0.045.
+        let cost = estimate_cost_usd("gpt-4o-mini", 100_000, 50_000).unwrap();
+        assert!((cost - 0.045).abs() < 1e-12);
+        assert_eq!(estimate_cost_usd("gpt-4o", 0, 0), Some(0.0));
+        assert_eq!(estimate_cost_usd("no-such-model", 1_000, 1_000), None);
+    }
+
+    // The merge logic is tested with an injected JSON string rather than the
+    // real env var: the table behind `price_for_model` is a process-wide
+    // OnceLock, so mutating the env in a parallel test run would be racy.
+    #[test]
+    fn override_json_merges_over_defaults() {
+        let json = r#"{
+            "gpt-4o": {"input_per_1m": 1.0, "output_per_1m": 2.0},
+            "My-Custom-Model": {"input_per_1m": 5.0, "output_per_1m": 6.0}
+        }"#;
+        let table = build_table(Some(json));
+        // Existing entry replaced.
+        let p = lookup(&table, "gpt-4o").unwrap();
+        assert_eq!((p.input_per_1m, p.output_per_1m), (1.0, 2.0));
+        // New entry added, key lowercased.
+        let p = lookup(&table, &normalize("my-custom-model-v2")).unwrap();
+        assert_eq!((p.input_per_1m, p.output_per_1m), (5.0, 6.0));
+        // Untouched defaults survive the merge.
+        assert_eq!(lookup(&table, "gpt-4o-mini").unwrap().input_per_1m, 0.15);
+    }
+
+    #[test]
+    fn invalid_override_json_falls_back_to_defaults() {
+        let table = build_table(Some("not json at all"));
+        assert_eq!(table.len(), DEFAULT_PRICES.len());
+        assert_eq!(lookup(&table, "gpt-4o").unwrap().input_per_1m, 2.50);
+    }
+
+    #[test]
+    fn no_override_yields_defaults() {
+        let table = build_table(None);
+        assert_eq!(table.len(), DEFAULT_PRICES.len());
+    }
+}

--- a/orch8-api/src/usage.rs
+++ b/orch8-api/src/usage.rs
@@ -13,7 +13,13 @@ use serde::Deserialize;
 
 use crate::auth::TenantContext;
 use crate::error::ApiError;
+use crate::model_pricing;
 use crate::AppState;
+
+/// Round a USD amount to 6 decimal places for stable API output.
+fn round6(v: f64) -> f64 {
+    (v * 1_000_000.0).round() / 1_000_000.0
+}
 
 /// Query params for [`get_usage`].
 #[derive(Debug, Deserialize)]
@@ -36,7 +42,7 @@ pub struct UsageQuery {
         ("end" = Option<String>, Query, description = "Window end (RFC 3339)"),
     ),
     responses(
-        (status = 200, description = "Usage aggregated by (kind, model)", body = serde_json::Value),
+        (status = 200, description = "Usage aggregated by (kind, model) with estimated USD costs", body = serde_json::Value),
         (status = 400, description = "No tenant resolvable"),
     )
 )]
@@ -66,11 +72,37 @@ pub async fn get_usage(
         .await
         .map_err(|e| ApiError::from_storage(e, "usage"))?;
 
+    // Attach an estimated USD cost to each aggregate (null for unknown
+    // models) plus a window-wide total over the known ones. Costs are list
+    // prices from the static pricing table — hence `cost_is_estimate`.
+    let mut total_cost_usd = 0.0;
+    let usage: Vec<serde_json::Value> = usage
+        .into_iter()
+        .map(|u| {
+            let cost_usd =
+                model_pricing::estimate_cost_usd(&u.model, u.input_tokens, u.output_tokens)
+                    .map(round6);
+            if let Some(c) = cost_usd {
+                total_cost_usd += c;
+            }
+            serde_json::json!({
+                "kind": u.kind,
+                "model": u.model,
+                "events": u.events,
+                "input_tokens": u.input_tokens,
+                "output_tokens": u.output_tokens,
+                "cost_usd": cost_usd,
+            })
+        })
+        .collect();
+
     Ok(Json(serde_json::json!({
         "tenant": tenant,
         "start": start,
         "end": end,
         "usage": usage,
+        "total_cost_usd": round6(total_cost_usd),
+        "cost_is_estimate": true,
     })))
 }
 

--- a/orch8-api/tests/usage.rs
+++ b/orch8-api/tests/usage.rs
@@ -1,0 +1,112 @@
+//! E2E tests for the Usage API cost estimates.
+//!
+//! Records usage events directly through the storage handle (the same path
+//! `llm_call`/`agent` use in production) and asserts the `GET /usage`
+//! response carries per-entry `cost_usd`, a window-wide `total_cost_usd` and
+//! the `cost_is_estimate` marker.
+
+use chrono::Utc;
+use orch8_api::test_harness::spawn_test_server;
+use orch8_storage::{TelemetryStore, UsageEvent};
+use reqwest::StatusCode;
+
+fn usage_event(tenant: &str, model: &str, input_tokens: i64, output_tokens: i64) -> UsageEvent {
+    UsageEvent {
+        tenant_id: tenant.into(),
+        instance_id: None,
+        block_id: Some("llm".into()),
+        kind: "llm_tokens".into(),
+        model: model.into(),
+        input_tokens,
+        output_tokens,
+        created_at: Utc::now(),
+    }
+}
+
+#[tokio::test]
+async fn get_usage_includes_cost_estimates() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+
+    // gpt-4o: 1M in + 1M out = $2.50 + $10.00 = $12.50 (two events).
+    srv.storage
+        .record_usage_event(&usage_event("t1", "gpt-4o", 600_000, 400_000))
+        .await
+        .unwrap();
+    srv.storage
+        .record_usage_event(&usage_event("t1", "gpt-4o", 400_000, 600_000))
+        .await
+        .unwrap();
+    // Versioned model name resolves by prefix: claude-sonnet-4-6 →
+    // claude-sonnet-4 at $3/$15 per 1M → 0.5M/0.1M = $1.50 + $1.50 = $3.00.
+    srv.storage
+        .record_usage_event(&usage_event("t1", "claude-sonnet-4-6", 500_000, 100_000))
+        .await
+        .unwrap();
+    // Unknown model → cost_usd null, excluded from the total.
+    srv.storage
+        .record_usage_event(&usage_event("t1", "mystery-model", 1_000_000, 1_000_000))
+        .await
+        .unwrap();
+    // Another tenant — must not leak into t1's report.
+    srv.storage
+        .record_usage_event(&usage_event("t2", "gpt-4o", 999_999, 999_999))
+        .await
+        .unwrap();
+
+    let resp = client
+        .get(format!("{}/usage", srv.v1_url()))
+        .header("X-Tenant-Id", "t1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.unwrap();
+
+    assert_eq!(body["tenant"], "t1");
+    assert_eq!(body["cost_is_estimate"], true);
+
+    let usage = body["usage"].as_array().unwrap();
+    assert_eq!(usage.len(), 3, "grouped by (kind, model)");
+
+    let entry = |model: &str| {
+        usage
+            .iter()
+            .find(|u| u["model"] == model)
+            .unwrap_or_else(|| panic!("no usage entry for {model}"))
+    };
+
+    let gpt = entry("gpt-4o");
+    assert_eq!(gpt["events"], 2);
+    assert_eq!(gpt["input_tokens"], 1_000_000);
+    assert_eq!(gpt["output_tokens"], 1_000_000);
+    assert_eq!(gpt["cost_usd"], 12.5);
+
+    let claude = entry("claude-sonnet-4-6");
+    assert_eq!(claude["cost_usd"], 3.0);
+
+    let unknown = entry("mystery-model");
+    assert!(unknown["cost_usd"].is_null(), "unknown model → null cost");
+
+    // Total covers only the priceable entries: 12.50 + 3.00.
+    assert_eq!(body["total_cost_usd"], 15.5);
+}
+
+#[tokio::test]
+async fn get_usage_empty_window_has_zero_total() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("{}/usage", srv.v1_url()))
+        .header("X-Tenant-Id", "t-empty")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.unwrap();
+
+    assert_eq!(body["usage"].as_array().unwrap().len(), 0);
+    assert_eq!(body["total_cost_usd"], 0.0);
+    assert_eq!(body["cost_is_estimate"], true);
+}


### PR DESCRIPTION
## Summary
- New `orch8-api/src/model_pricing.rs`: static pricing table (~45 model families, USD per 1M tokens) with case-insensitive longest-prefix matching (word-boundary aware, so `gpt-4o-2024-08-06` → `gpt-4o` but `gpt-4o-mini` never falls back to `gpt-4o`), provider-path normalization (`anthropic/claude-…`), and an `ORCH8_MODEL_PRICING` JSON env override merged over defaults.
- `GET /usage` now returns `cost_usd` per aggregate (null for unknown models), a window-wide `total_cost_usd`, and `cost_is_estimate: true`. Token counts remain the exact source of truth; dollars are labeled estimates (list prices, no caching/batch discounts).

## Tests
- 9 unit tests: prefix matching, versioned model names, normalization, unknown→None, cost math, override merge + invalid-JSON fallback.
- 2 integration tests via `spawn_test_server`: per-model `cost_usd`, `total_cost_usd`, tenant isolation, empty-window zero total.
- `cargo test -p orch8-api`: 269 passed. fmt/clippy/doc gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)