### PR TITLE
feat(cli): built-in template gallery — init --template, templates list/show

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,7 @@ target/
 dashboard/
 tests/
 docs/
+!docs/agent-patterns
+!docs/agent-patterns/**
 worker-sdk-node/
 *.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2667,6 +2667,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tabled",
+ "tempfile",
  "tokio",
  "toml 0.8.23",
  "uuid",

--- a/orch8-cli/Cargo.toml
+++ b/orch8-cli/Cargo.toml
@@ -24,5 +24,8 @@ toml.workspace = true
 orch8-types = { path = "../orch8-types" }
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "postgres", "migrate"] }
 
+[dev-dependencies]
+tempfile = "3"
+
 [lints]
 workspace = true

--- a/orch8-cli/src/commands/init.rs
+++ b/orch8-cli/src/commands/init.rs
@@ -4,13 +4,19 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use rand::RngCore;
 
-pub fn run(dir: &str) -> Result<()> {
+use crate::templates;
+
+pub fn run(dir: &str, template: &str) -> Result<()> {
+    // Resolve the template before touching the filesystem so an unknown
+    // name fails cleanly without leaving a half-initialized directory.
+    let template = templates::find(template)?;
+
     let base = Path::new(dir);
     if !base.exists() {
         fs::create_dir_all(base).context("failed to create directory")?;
     }
 
-    write_scaffolds(base)?;
+    write_scaffolds(base, template)?;
 
     println!("Initialized Orch8 project in {dir}/");
     println!();
@@ -94,34 +100,6 @@ level = "info"                             # trace, debug, info, warn, error
 json = true                                # true = JSON logs, false = pretty
 "#;
 
-const SEQUENCE_JSON_TEMPLATE: &str = r#"{
-  "tenant_id": "demo",
-  "namespace": "default",
-  "name": "hello-world",
-  "version": 1,
-  "blocks": [
-    {
-      "type": "Step",
-      "id": "greet",
-      "handler": "greet_user",
-      "params": { "message": "Hello from Orch8!" }
-    },
-    {
-      "type": "Step",
-      "id": "wait",
-      "handler": "noop",
-      "delay": "5s"
-    },
-    {
-      "type": "Step",
-      "id": "complete",
-      "handler": "noop",
-      "params": { "message": "Workflow complete." }
-    }
-  ]
-}
-"#;
-
 const DOCKER_COMPOSE_TEMPLATE: &str = r#"services:
   postgres:
     image: postgres:16-alpine
@@ -157,12 +135,12 @@ volumes:
   pgdata:
 "#;
 
-fn write_scaffolds(base: &Path) -> Result<()> {
+fn write_scaffolds(base: &Path, template: &templates::Template) -> Result<()> {
     let api_key = generate_api_key();
     #[allow(clippy::literal_string_with_formatting_args)]
     let orch8_toml = ORCH8_TOML_TEMPLATE.replace("{api_key}", &api_key);
     write_if_absent(&base.join("orch8.toml"), &orch8_toml)?;
-    write_if_absent(&base.join("sequence.json"), SEQUENCE_JSON_TEMPLATE)?;
+    write_if_absent(&base.join("sequence.json"), template.json)?;
     write_if_absent(&base.join("docker-compose.yml"), DOCKER_COMPOSE_TEMPLATE)
 }
 
@@ -180,4 +158,69 @@ fn write_if_absent(path: &Path, content: &str) -> Result<()> {
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_default_writes_all_scaffolds() {
+        let dir = tempfile::tempdir().unwrap();
+        run(dir.path().to_str().unwrap(), "default").unwrap();
+
+        for file in ["orch8.toml", "sequence.json", "docker-compose.yml"] {
+            assert!(dir.path().join(file).exists(), "{file} should be created");
+        }
+        // Default behavior unchanged: sequence.json is the default template.
+        let written = fs::read_to_string(dir.path().join("sequence.json")).unwrap();
+        assert_eq!(written, templates::find("default").unwrap().json);
+    }
+
+    #[test]
+    fn init_with_template_writes_that_template() {
+        let dir = tempfile::tempdir().unwrap();
+        run(dir.path().to_str().unwrap(), "react-loop").unwrap();
+
+        let written = fs::read_to_string(dir.path().join("sequence.json")).unwrap();
+        assert_eq!(written, templates::find("react-loop").unwrap().json);
+        // The rest of the scaffold is template-independent.
+        assert!(dir.path().join("orch8.toml").exists());
+        assert!(dir.path().join("docker-compose.yml").exists());
+    }
+
+    #[test]
+    fn init_unknown_template_errors_and_creates_nothing() {
+        let base = tempfile::tempdir().unwrap();
+        let target = base.path().join("project");
+        let err = run(target.to_str().unwrap(), "no-such-template").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown template `no-such-template`"), "{msg}");
+        assert!(
+            msg.contains("default") && msg.contains("react-loop"),
+            "{msg}"
+        );
+        // Failed before touching the filesystem.
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn init_does_not_overwrite_existing_sequence_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let sequence = dir.path().join("sequence.json");
+        fs::write(&sequence, "{\"custom\": true}").unwrap();
+
+        run(dir.path().to_str().unwrap(), "guardrail-validation").unwrap();
+
+        let written = fs::read_to_string(&sequence).unwrap();
+        assert_eq!(written, "{\"custom\": true}");
+    }
+
+    #[test]
+    fn init_creates_missing_directory() {
+        let base = tempfile::tempdir().unwrap();
+        let target = base.path().join("nested").join("project");
+        run(target.to_str().unwrap(), "default").unwrap();
+        assert!(target.join("sequence.json").exists());
+    }
 }

--- a/orch8-cli/src/commands/mod.rs
+++ b/orch8-cli/src/commands/mod.rs
@@ -6,3 +6,4 @@ pub mod init;
 pub mod instance;
 pub mod sequence;
 pub mod signal;
+pub mod templates;

--- a/orch8-cli/src/commands/templates.rs
+++ b/orch8-cli/src/commands/templates.rs
@@ -1,0 +1,44 @@
+use anyhow::Result;
+use clap::Subcommand;
+use tabled::{Table, Tabled};
+
+use crate::templates;
+
+/// Subcommands for browsing the built-in template gallery.
+#[derive(Subcommand)]
+pub enum TemplatesCmd {
+    /// List built-in sequence templates.
+    List,
+    /// Print the raw JSON of a template to stdout.
+    Show {
+        /// Template name (see `orch8 templates list`).
+        name: String,
+    },
+}
+
+#[derive(Tabled)]
+struct TemplateRow {
+    name: &'static str,
+    description: &'static str,
+}
+
+pub fn run(cmd: TemplatesCmd) -> Result<()> {
+    match cmd {
+        TemplatesCmd::List => {
+            let rows: Vec<TemplateRow> = templates::TEMPLATES
+                .iter()
+                .map(|t| TemplateRow {
+                    name: t.name,
+                    description: t.description,
+                })
+                .collect();
+            println!("{}", Table::new(rows));
+        }
+        TemplatesCmd::Show { name } => {
+            let template = templates::find(&name)?;
+            // Templates carry their own trailing newline.
+            print!("{}", template.json);
+        }
+    }
+    Ok(())
+}

--- a/orch8-cli/src/main.rs
+++ b/orch8-cli/src/main.rs
@@ -4,12 +4,14 @@ use reqwest::{header, Client};
 use serde_json::Value;
 
 mod commands;
+mod templates;
 
 use commands::checkpoint::CheckpointCmd;
 use commands::config::ConfigCmd;
 use commands::cron::CronCmd;
 use commands::instance::InstanceCmd;
 use commands::sequence::SequenceCmd;
+use commands::templates::TemplatesCmd;
 
 /// Output format for CLI commands.
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
@@ -87,7 +89,13 @@ enum Commands {
         /// Directory to initialize in (defaults to current directory).
         #[arg(default_value = ".")]
         dir: String,
+        /// Built-in template to write as sequence.json (see `orch8 templates list`).
+        #[arg(long, default_value = "default")]
+        template: String,
     },
+    /// Browse built-in sequence templates.
+    #[command(subcommand)]
+    Templates(TemplatesCmd),
     /// Run database migrations against Postgres. Use this in CI/CD pipelines
     /// or init containers instead of the server's built-in `run_migrations` flag
     /// so that rolling deployments are safe.
@@ -250,7 +258,8 @@ async fn main() -> Result<()> {
         }
         Commands::Checkpoint(cmd) => commands::checkpoint::run(&client, base, cmd, format).await?,
         Commands::Config(cmd) => commands::config::run(cmd)?,
-        Commands::Init { dir } => commands::init::run(&dir)?,
+        Commands::Init { dir, template } => commands::init::run(&dir, &template)?,
+        Commands::Templates(cmd) => commands::templates::run(cmd)?,
         Commands::Migrate { .. } | Commands::Completions { .. } => unreachable!(),
     }
 
@@ -376,6 +385,48 @@ mod tests {
         use clap::Parser;
         let cli = Cli::try_parse_from(["orch8", "completions", "bash"]);
         assert!(cli.is_ok());
+    }
+
+    #[test]
+    fn cli_parses_init_without_template_flag() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["orch8", "init", "my-project"]).unwrap();
+        match cli.command {
+            Commands::Init { dir, template } => {
+                assert_eq!(dir, "my-project");
+                assert_eq!(template, "default");
+            }
+            _ => panic!("expected init command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_init_with_template_flag() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["orch8", "init", ".", "--template", "react-loop"]).unwrap();
+        match cli.command {
+            Commands::Init { dir, template } => {
+                assert_eq!(dir, ".");
+                assert_eq!(template, "react-loop");
+            }
+            _ => panic!("expected init command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_templates_subcommands() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["orch8", "templates", "list"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Templates(TemplatesCmd::List)
+        ));
+
+        let cli = Cli::try_parse_from(["orch8", "templates", "show", "react-loop"]).unwrap();
+        match cli.command {
+            Commands::Templates(TemplatesCmd::Show { name }) => assert_eq!(name, "react-loop"),
+            _ => panic!("expected templates show command"),
+        }
     }
 
     #[test]

--- a/orch8-cli/src/templates.rs
+++ b/orch8-cli/src/templates.rs
@@ -1,0 +1,188 @@
+//! Built-in sequence templates embedded at compile time.
+//!
+//! Each template is a complete sequence JSON that `orch8 init --template`
+//! writes as `sequence.json` and `orch8 templates show` prints verbatim.
+//! The agent-pattern templates are embedded from `docs/agent-patterns/` via
+//! `include_str!`, so docs and CLI can never drift apart. Tests at the bottom
+//! guarantee every entry is valid JSON and that its `blocks` deserialize into
+//! the engine's `BlockDefinition` DSL.
+
+use anyhow::{anyhow, Result};
+
+/// A built-in sequence template shipped with the CLI.
+#[derive(Debug)]
+pub struct Template {
+    /// Kebab-case slug used for lookup (e.g. `react-loop`).
+    pub name: &'static str,
+    /// One-line summary shown by `orch8 templates list`.
+    pub description: &'static str,
+    /// Raw sequence definition JSON.
+    pub json: &'static str,
+}
+
+/// The scaffold written by `orch8 init` when no `--template` is given:
+/// a minimal three-step hello-world sequence.
+const DEFAULT_JSON: &str = r#"{
+  "tenant_id": "demo",
+  "namespace": "default",
+  "name": "hello-world",
+  "version": 1,
+  "blocks": [
+    {
+      "type": "step",
+      "id": "greet",
+      "handler": "greet_user",
+      "params": { "message": "Hello from Orch8!" }
+    },
+    {
+      "type": "step",
+      "id": "wait",
+      "handler": "noop",
+      "delay": { "duration": 5000 }
+    },
+    {
+      "type": "step",
+      "id": "complete",
+      "handler": "noop",
+      "params": { "message": "Workflow complete." }
+    }
+  ]
+}
+"#;
+
+/// Registry of all built-in templates, in display order.
+pub const TEMPLATES: &[Template] = &[
+    Template {
+        name: "default",
+        description: "Minimal hello-world sequence: greet, delayed wait, complete.",
+        json: DEFAULT_JSON,
+    },
+    Template {
+        name: "react-loop",
+        description: "Observe-Think-Act agent loop with tool calling, iterating until done.",
+        json: include_str!("../../docs/agent-patterns/react-loop.json"),
+    },
+    Template {
+        name: "tool-calling-pipeline",
+        description: "LLM plans, executes tools in sequence, then synthesizes the results.",
+        json: include_str!("../../docs/agent-patterns/tool-calling-pipeline.json"),
+    },
+    Template {
+        name: "guardrail-validation",
+        description: "Input guardrail, LLM generation, output guardrail, human review gate.",
+        json: include_str!("../../docs/agent-patterns/guardrail-validation.json"),
+    },
+    Template {
+        name: "multi-agent-delegation",
+        description: "Orchestrator decomposes a task and delegates sub-tasks to parallel agents.",
+        json: include_str!("../../docs/agent-patterns/multi-agent-delegation.json"),
+    },
+];
+
+/// Look up a template by name, or fail with an error that lists every
+/// available template so the user can self-correct.
+pub fn find(name: &str) -> Result<&'static Template> {
+    TEMPLATES.iter().find(|t| t.name == name).ok_or_else(|| {
+        anyhow!(
+            "unknown template `{name}` (available: {})",
+            available_names().join(", ")
+        )
+    })
+}
+
+/// Names of all built-in templates, in display order.
+pub fn available_names() -> Vec<&'static str> {
+    TEMPLATES.iter().map(|t| t.name).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_template_is_valid_json() {
+        for t in TEMPLATES {
+            let parsed: Result<serde_json::Value, _> = serde_json::from_str(t.json);
+            assert!(
+                parsed.is_ok(),
+                "template `{}` is not valid JSON: {:?}",
+                t.name,
+                parsed.err()
+            );
+        }
+    }
+
+    #[test]
+    fn every_template_has_name_and_blocks() {
+        for t in TEMPLATES {
+            let v: serde_json::Value = serde_json::from_str(t.json).unwrap();
+            let name = v.get("name").and_then(serde_json::Value::as_str);
+            assert!(
+                name.is_some_and(|n| !n.is_empty()),
+                "template `{}` is missing a non-empty top-level `name`",
+                t.name
+            );
+            let blocks = v.get("blocks").and_then(serde_json::Value::as_array);
+            assert!(
+                blocks.is_some_and(|b| !b.is_empty()),
+                "template `{}` is missing a non-empty top-level `blocks` array",
+                t.name
+            );
+        }
+    }
+
+    /// The full `SequenceDefinition` carries server-assigned fields (`id`,
+    /// `created_at`) that authoring payloads never include, so the typed
+    /// guarantee targets the part the engine actually interprets: every
+    /// template's `blocks` must deserialize into the workflow DSL.
+    #[test]
+    fn every_template_blocks_deserialize_into_block_definitions() {
+        for t in TEMPLATES {
+            let v: serde_json::Value = serde_json::from_str(t.json).unwrap();
+            let blocks = v.get("blocks").cloned().expect("blocks checked above");
+            let typed: Result<Vec<orch8_types::sequence::BlockDefinition>, _> =
+                serde_json::from_value(blocks);
+            assert!(
+                typed.is_ok(),
+                "template `{}` blocks do not deserialize into BlockDefinition: {:?}",
+                t.name,
+                typed.err()
+            );
+        }
+    }
+
+    #[test]
+    fn template_names_are_unique_kebab_case() {
+        let mut seen = std::collections::HashSet::new();
+        for t in TEMPLATES {
+            assert!(seen.insert(t.name), "duplicate template name `{}`", t.name);
+            assert!(
+                t.name
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "template name `{}` is not kebab-case",
+                t.name
+            );
+            assert!(
+                !t.description.is_empty(),
+                "template `{}` has an empty description",
+                t.name
+            );
+        }
+    }
+
+    #[test]
+    fn find_returns_known_templates() {
+        assert_eq!(find("default").unwrap().name, "default");
+        assert_eq!(find("react-loop").unwrap().name, "react-loop");
+    }
+
+    #[test]
+    fn find_unknown_lists_available_templates() {
+        let err = find("nope").unwrap_err().to_string();
+        assert!(err.contains("unknown template `nope`"), "got: {err}");
+        for name in available_names() {
+            assert!(err.contains(name), "error should list `{name}`: {err}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New compile-time template registry (`orch8-cli/src/templates.rs`) embedding the 4 agent-pattern JSONs from `docs/agent-patterns/` plus the default scaffold: `default`, `react-loop`, `tool-calling-pipeline`, `guardrail-validation`, `multi-agent-delegation`.
- `orch8 init <dir> --template <name>` (default `default`, backward compatible) — template resolved before any filesystem writes, so unknown names fail cleanly with the available list.
- New `orch8 templates list` (name/description table) and `orch8 templates show <name>` (raw JSON).
- **Bug fix found in the process:** the old hardcoded scaffold was invalid against the engine wire format — `"type": "Step"` (tags are snake_case `step`) and `"delay": "5s"` (`DelaySpec` requires `{"duration": <ms>}`). The default template now produces a sequence `POST /sequences` actually accepts.

## Tests
- 14 new tests (30 total in `orch8-cli`): every embedded template parses as JSON with non-empty `name`/`blocks` and blocks deserialize into `Vec<BlockDefinition>`; registry lookup + unknown-name error; tempdir init tests (content, no-overwrite, nested dirs, error-before-FS); clap parse tests. Binary smoke-tested.
- fmt/clippy/doc gates clean; `cargo check --workspace` clean.

## Note
`docs/QUICK_START.md` has the same invalid `"delay": "2s"` shape in its curl examples — pre-existing, not touched here, worth a follow-up docs fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)