### PR TITLE
feat(llm): response_schema validation with bounded auto-repair on llm_call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -445,6 +447,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +484,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "bumpalo"
@@ -1208,6 +1231,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "embedded-io"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1309,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,6 +1360,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1406,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1639,6 +1703,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -2132,6 +2198,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5fe5206f06e589caf25e79fc05ccdf91fca745685fe9fe1a13bbdfb479a631"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2352,6 +2445,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,6 +2592,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2519,6 +2632,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,6 +2668,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -2686,6 +2825,7 @@ dependencies = [
  "dashmap",
  "hmac",
  "http",
+ "jsonschema",
  "metrics",
  "moka",
  "notify",
@@ -2860,6 +3000,12 @@ dependencies = [
  "utoipa",
  "uuid",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "owo-colors"
@@ -3452,6 +3598,43 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "referencing"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e4e17ef386c5383591d07623d3de49cbc601156e7582973e6db98d66a57de2"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -4942,6 +5125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5203,6 +5392,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5219,6 +5418,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,11 @@ base64 = "0.22"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "http2", "multipart"] }
 url = "2"
 
+# JSON Schema validation (llm_call `response_schema`). default-features off:
+# the default feature set enables remote `$ref` resolution over HTTP, which
+# is an SSRF hazard for workflow-supplied schemas and drags in extra deps.
+jsonschema = { version = "0.46", default-features = false }
+
 # Object storage for artifacts — local FS, S3-compatible (R2/MinIO/S3), in-memory (tests)
 object_store = { version = "0.11", features = ["aws"] }
 futures = "0.3"

--- a/orch8-engine/Cargo.toml
+++ b/orch8-engine/Cargo.toml
@@ -26,6 +26,7 @@ moka.workspace = true
 dashmap.workspace = true
 reqwest.workspace = true
 url.workspace = true
+jsonschema.workspace = true
 bytes.workspace = true
 tokio-stream.workspace = true
 async-nats = { workspace = true, optional = true }

--- a/orch8-engine/src/handlers/llm/common.rs
+++ b/orch8-engine/src/handlers/llm/common.rs
@@ -16,6 +16,58 @@ pub(super) fn safe_truncate(s: &str, max_bytes: usize) -> &str {
     &s[..end]
 }
 
+/// Extract normalized `(input, output)` token counts from an LLM step
+/// output's `usage` object. Handles both `OpenAI` (`prompt_tokens` /
+/// `completion_tokens`) and `Anthropic` (`input_tokens` / `output_tokens`)
+/// shapes; missing fields count as 0.
+pub(super) fn usage_tokens(out: &Value) -> (i64, i64) {
+    let Some(usage) = out.get("usage") else {
+        return (0, 0);
+    };
+    let pick = |a: &str, b: &str| {
+        usage
+            .get(a)
+            .or_else(|| usage.get(b))
+            .and_then(Value::as_i64)
+            .unwrap_or(0)
+    };
+    (
+        pick("input_tokens", "prompt_tokens"),
+        pick("output_tokens", "completion_tokens"),
+    )
+}
+
+/// Overwrite the token counts in `out["usage"]` with accumulated totals
+/// (summed across schema-repair re-calls), updating whichever provider-style
+/// key names are present and falling back to the normalized
+/// `input_tokens` / `output_tokens` names when none are.
+pub(super) fn set_usage_totals(out: &mut Value, input: i64, output: i64) {
+    let Some(obj) = out.as_object_mut() else {
+        return;
+    };
+    let usage = obj
+        .entry("usage")
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    if !usage.is_object() {
+        *usage = Value::Object(serde_json::Map::new());
+    }
+    let Some(map) = usage.as_object_mut() else {
+        return;
+    };
+    let mut set_pair = |a: &str, b: &str, total: i64| {
+        let has_a = map.contains_key(a);
+        let has_b = map.contains_key(b);
+        if has_a || !has_b {
+            map.insert(a.to_string(), Value::from(total));
+        }
+        if has_b {
+            map.insert(b.to_string(), Value::from(total));
+        }
+    };
+    set_pair("input_tokens", "prompt_tokens", input);
+    set_pair("output_tokens", "completion_tokens", output);
+}
+
 pub(super) fn is_json_object_format(params: &Value) -> bool {
     params
         .get("response_format")
@@ -585,6 +637,44 @@ mod tests {
         for name in ["OPENAI_API_KEY", "CUSTOM_LLM_TOKEN", "MY_GROQ_KEY"] {
             assert!(is_allowed_api_key_env(name), "{name} should stay allowed");
         }
+    }
+
+    #[test]
+    fn usage_tokens_normalizes_both_shapes_and_missing() {
+        let openai = json!({"usage": {"prompt_tokens": 12, "completion_tokens": 7}});
+        assert_eq!(usage_tokens(&openai), (12, 7));
+        let anthropic = json!({"usage": {"input_tokens": 3, "output_tokens": 4}});
+        assert_eq!(usage_tokens(&anthropic), (3, 4));
+        assert_eq!(usage_tokens(&json!({})), (0, 0));
+        assert_eq!(usage_tokens(&json!({"usage": {}})), (0, 0));
+    }
+
+    #[test]
+    fn set_usage_totals_updates_present_keys() {
+        let mut out = json!({"usage": {"prompt_tokens": 5, "completion_tokens": 2}});
+        set_usage_totals(&mut out, 30, 11);
+        assert_eq!(out["usage"]["prompt_tokens"], 30);
+        assert_eq!(out["usage"]["completion_tokens"], 11);
+        assert!(out["usage"].get("input_tokens").is_none());
+
+        let mut out = json!({"usage": {"input_tokens": 1, "output_tokens": 1}});
+        set_usage_totals(&mut out, 8, 9);
+        assert_eq!(out["usage"]["input_tokens"], 8);
+        assert_eq!(out["usage"]["output_tokens"], 9);
+    }
+
+    #[test]
+    fn set_usage_totals_inserts_normalized_keys_when_absent() {
+        let mut out = json!({"usage": {}});
+        set_usage_totals(&mut out, 4, 6);
+        assert_eq!(out["usage"]["input_tokens"], 4);
+        assert_eq!(out["usage"]["output_tokens"], 6);
+
+        // Null usage (provider returned none) is replaced with an object.
+        let mut out = json!({"usage": null});
+        set_usage_totals(&mut out, 1, 2);
+        assert_eq!(out["usage"]["input_tokens"], 1);
+        assert_eq!(out["usage"]["output_tokens"], 2);
     }
 
     #[test]

--- a/orch8-engine/src/handlers/llm/mod.rs
+++ b/orch8-engine/src/handlers/llm/mod.rs
@@ -22,6 +22,8 @@
 //! | `tool_choice` | string/object | — | Tool selection strategy |
 //! | `total_timeout_secs` | number | `120` | Cumulative timeout across all failover attempts (0 disables) |
 //! | `per_provider_timeout_secs` | number | `60` | Per-provider timeout in failover mode |
+//! | `response_schema` | object | — | JSON Schema the response must satisfy (validated, auto-repaired) |
+//! | `max_repair_attempts` | number | `2` | Schema-repair re-calls per provider attempt (hard cap 5) |
 //!
 //! ## Providers
 //!
@@ -51,6 +53,7 @@
 mod anthropic;
 pub(crate) mod common;
 mod openai;
+mod schema;
 
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -79,7 +82,10 @@ use tracing::warn;
 
 use orch8_types::error::StepError;
 
-use self::common::{permanent, resolve_api_key, resolve_base_url, retryable};
+use self::common::{
+    merge_json_response_fields, permanent, resolve_api_key, resolve_base_url, retryable,
+    set_usage_totals, usage_tokens,
+};
 use super::StepContext;
 
 /// Shared HTTP client for all LLM calls (connection pooling, TLS, keep-alive).
@@ -118,6 +124,11 @@ pub(crate) fn http_client() -> &'static reqwest::Client {
 pub async fn handle_llm_call(ctx: StepContext) -> Result<Value, StepError> {
     let dry = ctx.is_dry_run();
 
+    // Compile `response_schema` once per step, BEFORE any provider call (and
+    // before the dry-run skip), so an invalid schema is surfaced as a config
+    // error without burning tokens.
+    let response_schema = schema::compile_response_schema(&ctx.params)?;
+
     if let Some(providers) = ctx.params.get("providers").and_then(Value::as_array) {
         if dry {
             // Validate before skipping: an empty providers array is a config
@@ -127,7 +138,7 @@ pub async fn handle_llm_call(ctx: StepContext) -> Result<Value, StepError> {
             }
             return Ok(llm_dry_run_stub(&ctx.params));
         }
-        return handle_llm_call_failover(&ctx.params, providers).await;
+        return handle_llm_call_failover(&ctx.params, providers, response_schema.as_ref()).await;
     }
 
     let provider = ctx
@@ -151,14 +162,153 @@ pub async fn handle_llm_call(ctx: StepContext) -> Result<Value, StepError> {
         return Ok(llm_dry_run_stub(&ctx.params));
     }
 
-    let out = if provider == "anthropic" {
-        anthropic::call_anthropic(&ctx.params, &api_key, &base).await?
-    } else {
-        openai::call_openai_compat(&ctx.params, &api_key, &base, provider).await?
+    let out = match response_schema.as_ref() {
+        Some(compiled) => {
+            call_provider_with_schema(&ctx.params, &api_key, &base, provider, compiled)
+                .await
+                .map_err(SchemaCallFailure::into_permanent)?
+        }
+        None => dispatch_provider(&ctx.params, &api_key, &base, provider).await?,
     };
     // Capture token usage for cost aggregation (best-effort — never fails the call).
     record_llm_usage(&ctx, &out).await;
     Ok(out)
+}
+
+/// Route a single call to the correct provider API.
+async fn dispatch_provider(
+    params: &Value,
+    api_key: &str,
+    base: &str,
+    provider: &str,
+) -> Result<Value, StepError> {
+    if provider == "anthropic" {
+        anthropic::call_anthropic(params, api_key, base).await
+    } else {
+        openai::call_openai_compat(params, api_key, base, provider).await
+    }
+}
+
+/// How a schema-validated provider attempt failed.
+enum SchemaCallFailure {
+    /// The underlying provider call failed (network, auth, API error, …).
+    Provider(StepError),
+    /// The provider responded, but every response failed schema validation
+    /// within the repair budget.
+    Exhausted { message: String, details: Value },
+}
+
+impl SchemaCallFailure {
+    /// Error for the single-provider path: validation exhaustion is permanent
+    /// (a step retry would just re-burn the same repair budget).
+    fn into_permanent(self) -> StepError {
+        match self {
+            Self::Provider(e) => e,
+            Self::Exhausted { message, details } => StepError::Permanent {
+                message,
+                details: Some(details),
+            },
+        }
+    }
+
+    /// Error for the failover loop: validation exhaustion is retryable so the
+    /// loop proceeds to the next provider. If ALL providers fail, the failover
+    /// aggregation converts the last error into a permanent one.
+    fn into_retryable_for_failover(self) -> StepError {
+        match self {
+            Self::Provider(e) => e,
+            Self::Exhausted { message, details } => StepError::Retryable {
+                message,
+                details: Some(details),
+            },
+        }
+    }
+}
+
+/// Call one provider with `response_schema` enforcement and bounded repair.
+///
+/// The assistant text is JSON-extracted (fences/prose tolerated) and validated
+/// against the compiled schema. On failure, a repair turn (raw response +
+/// corrective user message) is appended and the SAME provider is re-called, up
+/// to `max_repair_attempts` times. On success the validated object's top-level
+/// fields are merged into the output (existing keys win) and `schema_valid` /
+/// `repair_attempts` are added. Token usage is summed across repair calls into
+/// the final output's `usage` fields.
+async fn call_provider_with_schema(
+    params: &Value,
+    api_key: &str,
+    base: &str,
+    provider: &str,
+    compiled: &schema::CompiledSchema,
+) -> Result<Value, SchemaCallFailure> {
+    let mut work = params.clone();
+    // Nudge OpenAI-compatible providers toward raw JSON output, unless the
+    // step already chose a response_format. Anthropic has no equivalent —
+    // prompt + repair handle it.
+    if provider != "anthropic" {
+        if let Some(obj) = work.as_object_mut() {
+            obj.entry("response_format")
+                .or_insert_with(|| json!({"type": "json_object"}));
+        }
+    }
+
+    let max = compiled.max_repair_attempts;
+    let (mut total_input, mut total_output) = (0i64, 0i64);
+    let mut last_errors: Vec<String> = Vec::new();
+    let mut last_response = String::new();
+
+    for attempt in 0..=max {
+        let mut out = dispatch_provider(&work, api_key, base, provider)
+            .await
+            .map_err(SchemaCallFailure::Provider)?;
+        let (input, output) = usage_tokens(&out);
+        total_input += input;
+        total_output += output;
+
+        let content = out
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+
+        match compiled.validate_text(schema::extract_candidate_json(&content)) {
+            Ok(valid) => {
+                if attempt > 0 {
+                    // Account for the tokens burned by repair calls too.
+                    set_usage_totals(&mut out, total_input, total_output);
+                }
+                if let Ok(serialized) = serde_json::to_string(&valid) {
+                    merge_json_response_fields(&serialized, &mut out);
+                }
+                if let Some(obj) = out.as_object_mut() {
+                    obj.insert("schema_valid".into(), json!(true));
+                    obj.insert("repair_attempts".into(), json!(attempt));
+                }
+                return Ok(out);
+            }
+            Err(errors) => {
+                warn!(
+                    provider = %provider,
+                    attempt,
+                    errors = ?errors,
+                    "llm_call: response failed response_schema validation"
+                );
+                if attempt < max {
+                    schema::append_repair_turn(&mut work, &content, &errors);
+                }
+                last_errors = errors;
+                last_response = content;
+            }
+        }
+    }
+
+    Err(SchemaCallFailure::Exhausted {
+        message: format!(
+            "response failed response_schema validation after {max} repair attempt(s)"
+        ),
+        details: schema::exhaustion_details(&last_errors, &last_response),
+    })
 }
 
 /// Record LLM token usage as a `usage_event`. Normalizes the two provider usage
@@ -166,18 +316,7 @@ pub async fn handle_llm_call(ctx: StepContext) -> Result<Value, StepError> {
 /// `input_tokens`/`output_tokens`).
 /// Best-effort: a recording failure is logged, never propagated.
 async fn record_llm_usage(ctx: &StepContext, out: &Value) {
-    let Some(usage) = out.get("usage") else {
-        return;
-    };
-    let pick = |a: &str, b: &str| {
-        usage
-            .get(a)
-            .or_else(|| usage.get(b))
-            .and_then(Value::as_i64)
-            .unwrap_or(0)
-    };
-    let input = pick("input_tokens", "prompt_tokens");
-    let output = pick("output_tokens", "completion_tokens");
+    let (input, output) = usage_tokens(out);
     if input == 0 && output == 0 {
         return; // provider returned no usage — nothing to attribute.
     }
@@ -225,7 +364,15 @@ const DEFAULT_TOTAL_TIMEOUT: Duration = Duration::from_secs(120);
 ///
 /// Applies both a per-provider timeout and a cumulative timeout across all
 /// attempts. Override via `total_timeout_secs` (0 disables the cumulative cap).
-async fn handle_llm_call_failover(params: &Value, providers: &[Value]) -> Result<Value, StepError> {
+///
+/// When `response_schema` is set, validation + repair run per provider
+/// attempt (within that provider's timeout); a provider that exhausts its
+/// repair budget counts as a failed provider and failover proceeds.
+async fn handle_llm_call_failover(
+    params: &Value,
+    providers: &[Value],
+    response_schema: Option<&schema::CompiledSchema>,
+) -> Result<Value, StepError> {
     if providers.is_empty() {
         return Err(permanent("providers array is empty".to_string()));
     }
@@ -236,10 +383,15 @@ async fn handle_llm_call_failover(params: &Value, providers: &[Value]) -> Result
         .map_or(DEFAULT_TOTAL_TIMEOUT, Duration::from_secs);
 
     if total_timeout.is_zero() {
-        return failover_inner(params, providers).await;
+        return failover_inner(params, providers, response_schema).await;
     }
 
-    match tokio::time::timeout(total_timeout, failover_inner(params, providers)).await {
+    match tokio::time::timeout(
+        total_timeout,
+        failover_inner(params, providers, response_schema),
+    )
+    .await
+    {
         Ok(result) => result,
         Err(_) => Err(retryable(format!(
             "all providers exceeded total timeout of {total_timeout:?}"
@@ -247,7 +399,11 @@ async fn handle_llm_call_failover(params: &Value, providers: &[Value]) -> Result
     }
 }
 
-async fn failover_inner(params: &Value, providers: &[Value]) -> Result<Value, StepError> {
+async fn failover_inner(
+    params: &Value,
+    providers: &[Value],
+    response_schema: Option<&schema::CompiledSchema>,
+) -> Result<Value, StepError> {
     let per_attempt_timeout = params
         .get("per_provider_timeout_secs")
         .and_then(Value::as_u64)
@@ -285,10 +441,13 @@ async fn failover_inner(params: &Value, providers: &[Value]) -> Result<Value, St
         }
 
         let attempt = async {
-            if provider_name == "anthropic" {
-                anthropic::call_anthropic(&merged, &api_key, &base).await
-            } else {
-                openai::call_openai_compat(&merged, &api_key, &base, provider_name).await
+            match response_schema {
+                Some(compiled) => {
+                    call_provider_with_schema(&merged, &api_key, &base, provider_name, compiled)
+                        .await
+                        .map_err(SchemaCallFailure::into_retryable_for_failover)
+                }
+                None => dispatch_provider(&merged, &api_key, &base, provider_name).await,
             }
         };
 
@@ -317,12 +476,19 @@ async fn failover_inner(params: &Value, providers: &[Value]) -> Result<Value, St
         }
     }
 
-    let error_msg = match last_error.as_ref() {
-        Some(e) => format!("all providers failed, last error: {e}"),
-        None => "all providers failed".to_string(),
+    // Aggregate into a permanent error, carrying forward the last error's
+    // details (e.g. schema validation_errors / last_response) so they aren't
+    // lost when all providers fail.
+    let (message, details) = match last_error {
+        Some(e) => {
+            let message = format!("all providers failed, last error: {e}");
+            let (StepError::Retryable { details, .. } | StepError::Permanent { details, .. }) = e;
+            (message, details)
+        }
+        None => ("all providers failed".to_string(), None),
     };
 
-    Err(permanent(error_msg))
+    Err(StepError::Permanent { message, details })
 }
 
 fn merge_provider_params(base_params: &Value, provider_config: &Value) -> Value {
@@ -358,7 +524,7 @@ mod tests {
     fn empty_providers_returns_error() {
         let result = tokio::runtime::Runtime::new()
             .unwrap()
-            .block_on(handle_llm_call_failover(&json!({}), &[]));
+            .block_on(handle_llm_call_failover(&json!({}), &[], None));
         assert!(result.is_err());
     }
 
@@ -452,7 +618,7 @@ mod tests {
     fn cumulative_timeout_returns_error_on_empty_providers_before_timeout() {
         let result = tokio::runtime::Runtime::new()
             .unwrap()
-            .block_on(handle_llm_call_failover(&json!({}), &[]));
+            .block_on(handle_llm_call_failover(&json!({}), &[], None));
         assert!(matches!(result, Err(StepError::Permanent { .. })));
     }
 
@@ -461,7 +627,7 @@ mod tests {
         let params = json!({"total_timeout_secs": 0});
         let result = tokio::runtime::Runtime::new()
             .unwrap()
-            .block_on(handle_llm_call_failover(&params, &[]));
+            .block_on(handle_llm_call_failover(&params, &[], None));
         assert!(matches!(result, Err(StepError::Permanent { .. })));
     }
 
@@ -499,5 +665,339 @@ mod tests {
         assert_eq!(merged["model"], "gpt-4");
         assert!(merged.get("providers").is_none());
         assert!(merged.get("messages").is_some());
+    }
+
+    // --- response_schema validate + repair (mock OpenAI-compatible server) --
+    //
+    // Same dep-free pattern as the webhook delivery tests: a tiny TCP
+    // listener that answers each request with the next queued JSON body and
+    // records the parsed request bodies.
+
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// Read one HTTP/1.1 request (headers + Content-Length body bytes).
+    async fn read_http_request(stream: &mut tokio::net::TcpStream) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(1024);
+        let mut tmp = [0u8; 1024];
+        let mut header_end = None;
+        loop {
+            let n = stream.read(&mut tmp).await.unwrap_or(0);
+            if n == 0 {
+                break;
+            }
+            buf.extend_from_slice(&tmp[..n]);
+            if header_end.is_none() {
+                if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                    header_end = Some(pos + 4);
+                }
+            }
+            if let Some(end) = header_end {
+                let headers = std::str::from_utf8(&buf[..end]).unwrap_or("");
+                let cl: usize = headers
+                    .lines()
+                    .find_map(|l| {
+                        let l = l.to_ascii_lowercase();
+                        l.strip_prefix("content-length:")
+                            .map(|v| v.trim().parse::<usize>().unwrap_or(0))
+                    })
+                    .unwrap_or(0);
+                if buf.len() >= end + cl {
+                    break;
+                }
+            }
+        }
+        buf
+    }
+
+    /// Start a mock OpenAI-compatible server that answers each request with
+    /// the next queued response body (HTTP 200). Returns the base URL (already
+    /// marked SSRF-safe) and the parsed JSON request bodies received.
+    async fn start_openai_mock(
+        responses: Vec<Value>,
+    ) -> (String, Arc<tokio::sync::Mutex<Vec<Value>>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let base = format!("http://127.0.0.1:{port}");
+        let requests = Arc::new(tokio::sync::Mutex::new(Vec::<Value>::new()));
+        let requests_srv = Arc::clone(&requests);
+        let queue = Arc::new(tokio::sync::Mutex::new(VecDeque::from(responses)));
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let raw = read_http_request(&mut stream).await;
+                if let Some(pos) = raw.windows(4).position(|w| w == b"\r\n\r\n") {
+                    if let Ok(v) = serde_json::from_slice::<Value>(&raw[pos + 4..]) {
+                        requests_srv.lock().await.push(v);
+                    }
+                }
+                let body = queue.lock().await.pop_front().unwrap_or_else(
+                    || json!({"error": {"message": "mock response queue exhausted"}}),
+                );
+                let body = serde_json::to_string(&body).unwrap();
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                     Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len(),
+                );
+                let _ = stream.write_all(resp.as_bytes()).await;
+                let _ = stream.shutdown().await;
+            }
+        });
+
+        super::super::builtin::mark_url_safe_for_test(&base).await;
+        (base, requests)
+    }
+
+    /// `OpenAI` chat-completions shaped response with the given assistant text.
+    fn openai_resp(content: &str, prompt: i64, completion: i64) -> Value {
+        json!({
+            "model": "gpt-test",
+            "choices": [
+                {"message": {"role": "assistant", "content": content}, "finish_reason": "stop"}
+            ],
+            "usage": {"prompt_tokens": prompt, "completion_tokens": completion},
+        })
+    }
+
+    /// JSON Schema used by the validate+repair tests: `{"name": <string>}`.
+    fn name_schema() -> Value {
+        json!({
+            "type": "object",
+            "required": ["name"],
+            "properties": {"name": {"type": "string"}},
+        })
+    }
+
+    async fn test_ctx(params: Value) -> StepContext {
+        let storage: Arc<dyn orch8_storage::StorageBackend> = Arc::new(
+            orch8_storage::sqlite::SqliteStorage::in_memory()
+                .await
+                .unwrap(),
+        );
+        StepContext {
+            instance_id: orch8_types::ids::InstanceId::new(),
+            tenant_id: orch8_types::ids::TenantId::unchecked("t"),
+            block_id: orch8_types::ids::BlockId::new("b"),
+            params,
+            context: orch8_types::context::ExecutionContext::default(),
+            attempt: 0,
+            storage,
+            wait_for_input: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn response_schema_valid_on_first_try() {
+        let (base, requests) =
+            start_openai_mock(vec![openai_resp(r#"{"name": "ok"}"#, 10, 5)]).await;
+        let ctx = test_ctx(json!({
+            "provider": "openai",
+            "model": "gpt-test",
+            "api_key": "k",
+            "base_url": base,
+            "messages": [{"role": "user", "content": "emit json"}],
+            "response_schema": name_schema(),
+        }))
+        .await;
+
+        let out = handle_llm_call(ctx).await.unwrap();
+        assert_eq!(out["schema_valid"], true);
+        assert_eq!(out["repair_attempts"], 0);
+        assert_eq!(out["name"], "ok", "validated fields merged into output");
+        assert_eq!(out["usage"]["prompt_tokens"], 10);
+        assert_eq!(out["usage"]["completion_tokens"], 5);
+
+        let reqs = requests.lock().await;
+        assert_eq!(reqs.len(), 1, "exactly one provider call");
+        assert_eq!(
+            reqs[0]["response_format"]["type"], "json_object",
+            "json_object nudge injected for OpenAI-compatible provider"
+        );
+    }
+
+    #[tokio::test]
+    async fn response_schema_repaired_on_second_attempt() {
+        // First response: fenced + wrong type for `name`. Second: valid.
+        let (base, requests) = start_openai_mock(vec![
+            openai_resp("```json\n{\"name\": 42}\n```", 10, 5),
+            openai_resp(r#"{"name": "fixed"}"#, 20, 7),
+        ])
+        .await;
+        let ctx = test_ctx(json!({
+            "provider": "openai",
+            "model": "gpt-test",
+            "api_key": "k",
+            "base_url": base,
+            "messages": [{"role": "user", "content": "emit json"}],
+            "response_schema": name_schema(),
+        }))
+        .await;
+
+        let out = handle_llm_call(ctx).await.unwrap();
+        assert_eq!(out["schema_valid"], true);
+        assert_eq!(out["repair_attempts"], 1);
+        assert_eq!(out["name"], "fixed");
+        // Usage accumulated across the initial call + one repair call.
+        assert_eq!(out["usage"]["prompt_tokens"], 30);
+        assert_eq!(out["usage"]["completion_tokens"], 12);
+
+        let reqs = requests.lock().await;
+        assert_eq!(reqs.len(), 2);
+        // The repair call carries the raw failing response as an assistant
+        // message plus a corrective user message.
+        let msgs = reqs[1]["messages"].as_array().unwrap();
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[1]["role"], "assistant");
+        assert_eq!(msgs[1]["content"], "```json\n{\"name\": 42}\n```");
+        assert_eq!(msgs[2]["role"], "user");
+        let repair = msgs[2]["content"].as_str().unwrap();
+        assert!(repair.contains("Validation errors"), "{repair}");
+        assert!(
+            repair.contains("Return ONLY the corrected JSON"),
+            "{repair}"
+        );
+    }
+
+    #[tokio::test]
+    async fn response_schema_exhausted_repairs_is_permanent_with_details() {
+        let (base, requests) = start_openai_mock(vec![
+            openai_resp(r#"{"wrong": 1}"#, 10, 5),
+            openai_resp(r#"{"still": "wrong"}"#, 10, 5),
+        ])
+        .await;
+        let ctx = test_ctx(json!({
+            "provider": "openai",
+            "model": "gpt-test",
+            "api_key": "k",
+            "base_url": base,
+            "messages": [{"role": "user", "content": "emit json"}],
+            "response_schema": name_schema(),
+            "max_repair_attempts": 1,
+        }))
+        .await;
+
+        let err = handle_llm_call(ctx)
+            .await
+            .expect_err("must exhaust repairs");
+        match err {
+            StepError::Permanent { message, details } => {
+                assert!(
+                    message.contains("response_schema validation after 1 repair attempt"),
+                    "{message}"
+                );
+                let details = details.expect("details must be present");
+                let errors = details["validation_errors"].as_array().unwrap();
+                assert!(!errors.is_empty());
+                assert_eq!(details["last_response"], r#"{"still": "wrong"}"#);
+            }
+            other @ StepError::Retryable { .. } => panic!("expected Permanent, got {other}"),
+        }
+        assert_eq!(requests.lock().await.len(), 2, "initial call + 1 repair");
+    }
+
+    #[tokio::test]
+    async fn response_schema_failover_moves_to_next_provider() {
+        // Provider A keeps returning schema-invalid output; provider B is valid.
+        let (base_a, requests_a) =
+            start_openai_mock(vec![openai_resp(r#"{"nope": true}"#, 1, 1)]).await;
+        let (base_b, requests_b) =
+            start_openai_mock(vec![openai_resp(r#"{"name": "from-b"}"#, 2, 2)]).await;
+        let ctx = test_ctx(json!({
+            "messages": [{"role": "user", "content": "emit json"}],
+            "response_schema": name_schema(),
+            "max_repair_attempts": 0,
+            "providers": [
+                {"provider": "openai", "api_key": "k", "model": "m", "base_url": base_a},
+                {"provider": "openai", "api_key": "k", "model": "m", "base_url": base_b},
+            ],
+        }))
+        .await;
+
+        let out = handle_llm_call(ctx).await.unwrap();
+        assert_eq!(out["schema_valid"], true);
+        assert_eq!(out["repair_attempts"], 0);
+        assert_eq!(out["name"], "from-b");
+        assert_eq!(out["tried"], json!(["openai", "openai"]));
+        assert_eq!(requests_a.lock().await.len(), 1);
+        assert_eq!(requests_b.lock().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn response_schema_all_providers_fail_validation_is_permanent() {
+        let (base_a, _) = start_openai_mock(vec![openai_resp(r#"{"a": 1}"#, 1, 1)]).await;
+        let (base_b, _) = start_openai_mock(vec![openai_resp("not json at all", 1, 1)]).await;
+        let ctx = test_ctx(json!({
+            "messages": [{"role": "user", "content": "emit json"}],
+            "response_schema": name_schema(),
+            "max_repair_attempts": 0,
+            "providers": [
+                {"provider": "openai", "api_key": "k", "model": "m", "base_url": base_a},
+                {"provider": "openai", "api_key": "k", "model": "m", "base_url": base_b},
+            ],
+        }))
+        .await;
+
+        let err = handle_llm_call(ctx)
+            .await
+            .expect_err("all providers invalid");
+        match err {
+            StepError::Permanent { message, details } => {
+                assert!(message.contains("all providers failed"), "{message}");
+                let details = details.expect("last validation details carried forward");
+                assert!(!details["validation_errors"].as_array().unwrap().is_empty());
+                assert_eq!(details["last_response"], "not json at all");
+            }
+            other @ StepError::Retryable { .. } => panic!("expected Permanent, got {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_response_schema_fails_without_provider_call() {
+        let (base, requests) = start_openai_mock(vec![]).await;
+        let ctx = test_ctx(json!({
+            "provider": "openai",
+            "model": "gpt-test",
+            "api_key": "k",
+            "base_url": base,
+            "response_schema": {"type": "not-a-real-type"},
+        }))
+        .await;
+
+        let err = handle_llm_call(ctx)
+            .await
+            .expect_err("bad schema must fail");
+        assert!(matches!(err, StepError::Permanent { .. }), "{err}");
+        assert!(err.to_string().contains("not a valid JSON Schema"), "{err}");
+        assert_eq!(requests.lock().await.len(), 0, "no provider call made");
+    }
+
+    #[tokio::test]
+    async fn dry_run_with_response_schema_skips_validation() {
+        let base = "http://127.0.0.1:2";
+        super::super::builtin::mark_url_safe_for_test(base).await;
+        let mut ctx = test_ctx(json!({
+            "provider": "openai",
+            "model": "gpt-test",
+            "api_key": "k",
+            "base_url": base,
+            "response_schema": name_schema(),
+        }))
+        .await;
+        ctx.context.runtime.dry_run = true;
+
+        let out = handle_llm_call(ctx).await.unwrap();
+        assert_eq!(out["dry_run"], true);
+        assert_eq!(out["finish_reason"], "dry_run");
+        assert!(
+            out.get("schema_valid").is_none(),
+            "no validation in dry-run"
+        );
     }
 }

--- a/orch8-engine/src/handlers/llm/schema.rs
+++ b/orch8-engine/src/handlers/llm/schema.rs
@@ -1,0 +1,401 @@
+//! `response_schema` support for `llm_call` — structured output validated
+//! against a workflow-supplied JSON Schema, with bounded auto-repair.
+//!
+//! When a step declares `response_schema`, the assistant's text response is
+//! parsed as JSON (tolerating markdown fences and surrounding prose) and
+//! validated. On failure, the handler appends a repair turn (the raw response
+//! as an assistant message plus a corrective user message) and re-calls the
+//! *same* provider, up to `max_repair_attempts` times.
+
+use serde_json::{json, Value};
+
+use orch8_types::error::StepError;
+
+use super::common::safe_truncate;
+
+/// Default number of repair re-calls when `max_repair_attempts` is unset.
+const DEFAULT_MAX_REPAIR_ATTEMPTS: u32 = 2;
+
+/// Hard cap on `max_repair_attempts` — each repair is a real LLM call.
+const MAX_REPAIR_ATTEMPTS_CAP: u32 = 5;
+
+/// Max bytes of the last (failing) response echoed into error `details`.
+pub(super) const LAST_RESPONSE_TRUNCATE_BYTES: usize = 2000;
+
+/// A `response_schema` compiled once per step, plus the repair budget.
+#[derive(Debug)]
+pub(super) struct CompiledSchema {
+    validator: jsonschema::Validator,
+    /// Number of repair re-calls allowed after the initial call.
+    pub(super) max_repair_attempts: u32,
+}
+
+impl CompiledSchema {
+    /// Validate `candidate` (raw candidate JSON text) against the schema.
+    ///
+    /// Returns the parsed value on success, or a list of human-readable
+    /// validation errors (including JSON parse errors) on failure.
+    pub(super) fn validate_text(&self, candidate: &str) -> Result<Value, Vec<String>> {
+        let parsed: Value = serde_json::from_str(candidate)
+            .map_err(|e| vec![format!("response is not valid JSON: {e}")])?;
+        let errors: Vec<String> = self
+            .validator
+            .iter_errors(&parsed)
+            .map(|e| format!("at {}: {e}", e.instance_path()))
+            .collect();
+        if errors.is_empty() {
+            Ok(parsed)
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+/// Parse and compile the optional `response_schema` param.
+///
+/// Returns `Ok(None)` when the param is absent. A present-but-invalid schema
+/// (not a JSON object, or not a valid JSON Schema) is a configuration error:
+/// `StepError::Permanent`, raised before any provider call.
+pub(super) fn compile_response_schema(params: &Value) -> Result<Option<CompiledSchema>, StepError> {
+    let Some(schema) = params.get("response_schema") else {
+        return Ok(None);
+    };
+
+    if !schema.is_object() {
+        return Err(StepError::Permanent {
+            message: "response_schema must be a JSON Schema object".to_string(),
+            details: None,
+        });
+    }
+
+    let validator = jsonschema::validator_for(schema).map_err(|e| StepError::Permanent {
+        message: format!("response_schema is not a valid JSON Schema: {e}"),
+        details: None,
+    })?;
+
+    let max_repair_attempts = params
+        .get("max_repair_attempts")
+        .and_then(Value::as_u64)
+        .map_or(DEFAULT_MAX_REPAIR_ATTEMPTS, |n| {
+            u32::try_from(n)
+                .unwrap_or(MAX_REPAIR_ATTEMPTS_CAP)
+                .min(MAX_REPAIR_ATTEMPTS_CAP)
+        });
+
+    Ok(Some(CompiledSchema {
+        validator,
+        max_repair_attempts,
+    }))
+}
+
+/// Extract the most plausible JSON document from an LLM text response.
+///
+/// Steps: trim whitespace; strip a surrounding markdown code fence
+/// (```` ```json … ``` ```` or ```` ``` … ``` ````); if the remainder still
+/// isn't pure JSON, fall back to the first balanced top-level `{…}` or `[…]`.
+/// The returned slice may still fail to parse — validation reports that.
+pub(super) fn extract_candidate_json(text: &str) -> &str {
+    let trimmed = text.trim();
+    let unfenced = strip_code_fence(trimmed);
+    if serde_json::from_str::<Value>(unfenced).is_ok() {
+        return unfenced;
+    }
+    balanced_json_slice(unfenced).unwrap_or(unfenced)
+}
+
+/// Strip a single surrounding markdown code fence, tolerating a language tag
+/// on the opening fence (```` ```json ````). Returns the input unchanged when
+/// it isn't fenced.
+fn strip_code_fence(text: &str) -> &str {
+    let Some(rest) = text.strip_prefix("```") else {
+        return text;
+    };
+    // Drop the rest of the opening fence line (e.g. a `json` language tag).
+    let body = match rest.find('\n') {
+        Some(i) => &rest[i + 1..],
+        None => return text, // single-line ``` … without a body — not a fence
+    };
+    let Some(body) = body.trim_end().strip_suffix("```") else {
+        return text; // no closing fence — leave as-is
+    };
+    body.trim()
+}
+
+/// Find the first balanced top-level `{…}` or `[…]` in `text`, skipping
+/// braces inside JSON string literals (quote/escape aware).
+fn balanced_json_slice(text: &str) -> Option<&str> {
+    let bytes = text.as_bytes();
+    let start = bytes.iter().position(|&b| b == b'{' || b == b'[')?;
+    let (open, close) = if bytes[start] == b'{' {
+        (b'{', b'}')
+    } else {
+        (b'[', b']')
+    };
+
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (i, &b) in bytes.iter().enumerate().skip(start) {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if b == b'\\' {
+                escaped = true;
+            } else if b == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match b {
+            b'"' => in_string = true,
+            _ if b == open => depth += 1,
+            _ if b == close => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return Some(&text[start..=i]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Build the corrective user message for a repair turn.
+pub(super) fn repair_message(errors: &[String]) -> String {
+    let mut bullets = String::new();
+    for e in errors {
+        bullets.push_str("- ");
+        bullets.push_str(e);
+        bullets.push('\n');
+    }
+    format!(
+        "Your previous response was not valid against the required JSON schema. \
+         Validation errors:\n{bullets}Return ONLY the corrected JSON, no prose, no code fences."
+    )
+}
+
+/// Append a repair turn to `params["messages"]`: the model's raw response as
+/// an assistant message, then a corrective user message listing the errors.
+pub(super) fn append_repair_turn(params: &mut Value, raw_response: &str, errors: &[String]) {
+    let turn_assistant = json!({ "role": "assistant", "content": raw_response });
+    let turn_user = json!({ "role": "user", "content": repair_message(errors) });
+
+    let Some(obj) = params.as_object_mut() else {
+        return;
+    };
+    let messages = obj.entry("messages").or_insert_with(|| json!([]));
+    if let Some(arr) = messages.as_array_mut() {
+        arr.push(turn_assistant);
+        arr.push(turn_user);
+    }
+}
+
+/// Build the `details` payload for a schema-exhaustion failure.
+pub(super) fn exhaustion_details(errors: &[String], last_response: &str) -> Value {
+    json!({
+        "validation_errors": errors,
+        "last_response": safe_truncate(last_response, LAST_RESPONSE_TRUNCATE_BYTES),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- extract_candidate_json / fence stripping ---------------------------
+
+    #[test]
+    fn extract_pure_json_passthrough() {
+        assert_eq!(extract_candidate_json(r#"{"a": 1}"#), r#"{"a": 1}"#);
+        assert_eq!(extract_candidate_json("[1, 2]"), "[1, 2]");
+    }
+
+    #[test]
+    fn extract_trims_whitespace() {
+        assert_eq!(extract_candidate_json("  \n {\"a\": 1} \n"), "{\"a\": 1}");
+    }
+
+    #[test]
+    fn extract_strips_json_fence() {
+        let text = "```json\n{\"a\": 1}\n```";
+        assert_eq!(extract_candidate_json(text), "{\"a\": 1}");
+    }
+
+    #[test]
+    fn extract_strips_plain_fence() {
+        let text = "```\n[1, 2, 3]\n```";
+        assert_eq!(extract_candidate_json(text), "[1, 2, 3]");
+    }
+
+    #[test]
+    fn extract_balanced_object_from_prose() {
+        let text = "Sure! Here is the JSON: {\"a\": {\"b\": 2}} hope that helps";
+        assert_eq!(extract_candidate_json(text), "{\"a\": {\"b\": 2}}");
+    }
+
+    #[test]
+    fn extract_balanced_array_from_prose() {
+        let text = "Result: [1, [2, 3]] done";
+        assert_eq!(extract_candidate_json(text), "[1, [2, 3]]");
+    }
+
+    #[test]
+    fn extract_braces_inside_strings_are_skipped() {
+        let text = r#"note {"msg": "shape } is ok", "n": 1} tail"#;
+        assert_eq!(
+            extract_candidate_json(text),
+            r#"{"msg": "shape } is ok", "n": 1}"#
+        );
+    }
+
+    #[test]
+    fn extract_escaped_quote_in_string() {
+        let text = r#"x {"msg": "quote \" then }", "n": 2} y"#;
+        assert_eq!(
+            extract_candidate_json(text),
+            r#"{"msg": "quote \" then }", "n": 2}"#
+        );
+    }
+
+    #[test]
+    fn extract_unbalanced_returns_input() {
+        let text = "{\"a\": 1"; // never closed
+        assert_eq!(extract_candidate_json(text), text);
+    }
+
+    #[test]
+    fn extract_no_json_at_all_returns_input() {
+        assert_eq!(extract_candidate_json("just words"), "just words");
+    }
+
+    #[test]
+    fn extract_fence_without_closing_left_alone() {
+        let text = "```json\n{\"a\": 1}";
+        // No closing fence — fence stripping bails, balanced extraction finds the object.
+        assert_eq!(extract_candidate_json(text), "{\"a\": 1}");
+    }
+
+    #[test]
+    fn extract_fenced_json_with_prose_inside_falls_back_to_balanced() {
+        let text = "```\nhere: {\"a\": 1}\n```";
+        assert_eq!(extract_candidate_json(text), "{\"a\": 1}");
+    }
+
+    // --- compile_response_schema --------------------------------------------
+
+    #[test]
+    fn compile_absent_schema_is_none() {
+        assert!(compile_response_schema(&json!({}))
+            .expect("absent schema is fine")
+            .is_none());
+    }
+
+    #[test]
+    fn compile_non_object_schema_is_permanent() {
+        let err = compile_response_schema(&json!({"response_schema": "nope"}))
+            .expect_err("string schema must be rejected");
+        assert!(matches!(err, StepError::Permanent { .. }), "{err}");
+        assert!(err.to_string().contains("JSON Schema object"));
+    }
+
+    #[test]
+    fn compile_invalid_schema_is_permanent() {
+        let err = compile_response_schema(&json!({"response_schema": {"type": "not-a-real-type"}}))
+            .expect_err("bogus type keyword must fail compilation");
+        assert!(matches!(err, StepError::Permanent { .. }), "{err}");
+        assert!(err.to_string().contains("not a valid JSON Schema"));
+    }
+
+    #[test]
+    fn compile_defaults_and_caps_repair_attempts() {
+        let schema = json!({"type": "object"});
+        let c = compile_response_schema(&json!({"response_schema": schema}))
+            .unwrap()
+            .unwrap();
+        assert_eq!(c.max_repair_attempts, DEFAULT_MAX_REPAIR_ATTEMPTS);
+
+        let c = compile_response_schema(
+            &json!({"response_schema": {"type": "object"}, "max_repair_attempts": 99}),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(c.max_repair_attempts, MAX_REPAIR_ATTEMPTS_CAP);
+
+        let c = compile_response_schema(
+            &json!({"response_schema": {"type": "object"}, "max_repair_attempts": 0}),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(c.max_repair_attempts, 0);
+    }
+
+    #[test]
+    fn validate_text_reports_parse_and_schema_errors() {
+        let c = compile_response_schema(&json!({
+            "response_schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {"name": {"type": "string"}},
+            }
+        }))
+        .unwrap()
+        .unwrap();
+
+        // Parse error
+        let errs = c.validate_text("{not json").unwrap_err();
+        assert!(errs[0].contains("not valid JSON"), "{errs:?}");
+
+        // Schema violation
+        let errs = c.validate_text(r#"{"name": 42}"#).unwrap_err();
+        assert!(errs.iter().any(|e| e.contains("/name")), "{errs:?}");
+
+        // Valid
+        let v = c.validate_text(r#"{"name": "ok"}"#).unwrap();
+        assert_eq!(v["name"], "ok");
+    }
+
+    // --- repair turn construction --------------------------------------------
+
+    #[test]
+    fn repair_message_bullets_errors() {
+        let msg = repair_message(&["e1".into(), "e2".into()]);
+        assert!(msg.contains("- e1\n"));
+        assert!(msg.contains("- e2\n"));
+        assert!(msg.starts_with("Your previous response was not valid"));
+        assert!(msg.ends_with("Return ONLY the corrected JSON, no prose, no code fences."));
+    }
+
+    #[test]
+    fn append_repair_turn_appends_two_messages() {
+        let mut params = json!({"messages": [{"role": "user", "content": "go"}]});
+        append_repair_turn(&mut params, "bad output", &["missing field".into()]);
+        let msgs = params["messages"].as_array().unwrap();
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[1]["role"], "assistant");
+        assert_eq!(msgs[1]["content"], "bad output");
+        assert_eq!(msgs[2]["role"], "user");
+        assert!(msgs[2]["content"]
+            .as_str()
+            .unwrap()
+            .contains("- missing field"));
+    }
+
+    #[test]
+    fn append_repair_turn_creates_messages_when_absent() {
+        let mut params = json!({});
+        append_repair_turn(&mut params, "raw", &["err".into()]);
+        assert_eq!(params["messages"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn exhaustion_details_truncates_last_response() {
+        let long = "x".repeat(LAST_RESPONSE_TRUNCATE_BYTES + 500);
+        let d = exhaustion_details(&["e".into()], &long);
+        assert_eq!(
+            d["last_response"].as_str().unwrap().len(),
+            LAST_RESPONSE_TRUNCATE_BYTES
+        );
+        assert_eq!(d["validation_errors"], json!(["e"]));
+    }
+}


### PR DESCRIPTION
## Summary
- New `response_schema` param on `llm_call`: the assistant response is JSON-extracted (markdown fences and surrounding prose tolerated, string-literal-aware balanced-brace fallback) and validated against the supplied JSON Schema.
- On validation failure, a repair turn (raw assistant response + corrective user message listing the validation errors) is appended and the same provider is re-called — bounded by `max_repair_attempts` (default 2, hard cap 5).
- Schema compiled once per step before any provider call; invalid schema → `Permanent` config error with zero tokens burned (enforced even in dry-run).
- Works inside the provider failover loop: exhaustion at one provider fails over to the next; all-providers-failed aggregates into `Permanent` with `{validation_errors, last_response}` details.
- For OpenAI-compatible providers, `response_format: json_object` is injected when unset (Anthropic relies on prompt + repair).
- On success: validated top-level fields merged into the output (existing keys win) plus `schema_valid: true` and `repair_attempts: n`. Token usage is summed across repair calls into the final output's usage fields, so recorded cost reflects the full spend.
- `jsonschema` crate added with `default-features = false` — remote `$ref` resolution deliberately disabled (SSRF hazard for workflow-supplied schemas).

## Tests
- ~30 new tests: schema-extraction edge cases, no-call-on-bad-schema, and 7 mock-HTTP integration tests (valid first try, repaired on attempt 2 with usage accumulation asserted, exhausted → Permanent with details, failover to second provider, all-invalid → Permanent, dry-run skip) using the repo's dep-free TCP mock-server pattern.
- `cargo test -p orch8-engine`: 2057 passed. fmt/clippy/doc/deny gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)