### PR TITLE
feat(api): resume-from-block — re-run an instance from any step with context patch

### DIFF
--- a/orch8-api/src/instances.rs
+++ b/orch8-api/src/instances.rs
@@ -39,9 +39,9 @@ pub use inject::InjectBlocksRequest;
 pub(crate) use inject::{__path_inject_blocks, inject_blocks};
 pub(crate) use lifecycle::{
     __path_create_instance, __path_create_instances_batch, __path_get_instance,
-    __path_list_instances, __path_retry_instance, __path_update_context, __path_update_state,
-    create_instance, create_instances_batch, get_instance, list_instances, retry_instance,
-    update_context, update_state,
+    __path_list_instances, __path_resume_from_block, __path_retry_instance, __path_update_context,
+    __path_update_state, create_instance, create_instances_batch, get_instance, list_instances,
+    resume_from_block, retry_instance, update_context, update_state,
 };
 pub(crate) use outputs::{
     __path_get_execution_tree, __path_get_outputs, get_execution_tree, get_outputs,
@@ -61,6 +61,10 @@ pub fn routes() -> Router<AppState> {
         .route("/artifacts/{*key}", get(get_artifact_bytes))
         .route("/instances/{id}/tree", get(get_execution_tree))
         .route("/instances/{id}/retry", post(retry_instance))
+        .route(
+            "/instances/{id}/resume-from/{block_id}",
+            post(resume_from_block),
+        )
         .route(
             "/instances/{id}/checkpoints",
             get(list_checkpoints).post(save_checkpoint),

--- a/orch8-api/src/instances/lifecycle.rs
+++ b/orch8-api/src/instances/lifecycle.rs
@@ -8,12 +8,13 @@ use chrono::Utc;
 use uuid::Uuid;
 
 use orch8_types::filter::{InstanceFilter, Pagination};
-use orch8_types::ids::{InstanceId, Namespace, SequenceId, TenantId};
+use orch8_types::ids::{BlockId, InstanceId, Namespace, SequenceId, TenantId};
 use orch8_types::instance::{InstanceState, TaskInstance};
+use orch8_types::sequence::BlockDefinition;
 
 use super::types::{
     parse_states, BatchCreateRequest, CountResponse, CreateInstanceRequest, ListQuery,
-    UpdateContextRequest, UpdateStateRequest,
+    ResumeFromRequest, UpdateContextRequest, UpdateStateRequest,
 };
 use crate::error::ApiError;
 use crate::AppState;
@@ -518,5 +519,267 @@ pub async fn retry_instance(
     Ok((
         StatusCode::OK,
         Json(serde_json::json!({ "id": instance_id, "state": "scheduled" })),
+    ))
+}
+
+/// Recursively collect the IDs of `block` and every block nested inside it
+/// (composite branches, loop bodies, router routes, try/catch/finally arms,
+/// A/B variants, cancellation scopes).
+///
+/// Used by resume-from-block to wipe descendant outputs together with the
+/// composite that owns them — leaving a nested loop's iteration-counter
+/// marker or a nested step's output in place would make the re-run skip or
+/// short-circuit those blocks.
+fn collect_block_ids(block: &BlockDefinition, out: &mut Vec<BlockId>) {
+    fn collect_list(blocks: &[BlockDefinition], out: &mut Vec<BlockId>) {
+        for b in blocks {
+            collect_block_ids(b, out);
+        }
+    }
+    match block {
+        BlockDefinition::Step(s) => out.push(s.id.clone()),
+        BlockDefinition::Parallel(p) => {
+            out.push(p.id.clone());
+            for branch in &p.branches {
+                collect_list(branch, out);
+            }
+        }
+        BlockDefinition::Race(r) => {
+            out.push(r.id.clone());
+            for branch in &r.branches {
+                collect_list(branch, out);
+            }
+        }
+        BlockDefinition::Loop(l) => {
+            out.push(l.id.clone());
+            collect_list(&l.body, out);
+        }
+        BlockDefinition::ForEach(fe) => {
+            out.push(fe.id.clone());
+            collect_list(&fe.body, out);
+        }
+        BlockDefinition::Router(r) => {
+            out.push(r.id.clone());
+            for route in &r.routes {
+                collect_list(&route.blocks, out);
+            }
+            if let Some(default) = &r.default {
+                collect_list(default, out);
+            }
+        }
+        BlockDefinition::TryCatch(tc) => {
+            out.push(tc.id.clone());
+            collect_list(&tc.try_block, out);
+            collect_list(&tc.catch_block, out);
+            if let Some(finally) = &tc.finally_block {
+                collect_list(finally, out);
+            }
+        }
+        BlockDefinition::SubSequence(s) => out.push(s.id.clone()),
+        BlockDefinition::ABSplit(ab) => {
+            out.push(ab.id.clone());
+            for variant in &ab.variants {
+                collect_list(&variant.blocks, out);
+            }
+        }
+        BlockDefinition::CancellationScope(cs) => {
+            out.push(cs.id.clone());
+            collect_list(&cs.blocks, out);
+        }
+    }
+}
+
+/// The ID of a top-level block, regardless of variant.
+fn top_level_block_id(block: &BlockDefinition) -> &BlockId {
+    match block {
+        BlockDefinition::Step(s) => &s.id,
+        BlockDefinition::Parallel(p) => &p.id,
+        BlockDefinition::Race(r) => &r.id,
+        BlockDefinition::Loop(l) => &l.id,
+        BlockDefinition::ForEach(fe) => &fe.id,
+        BlockDefinition::Router(r) => &r.id,
+        BlockDefinition::TryCatch(tc) => &tc.id,
+        BlockDefinition::SubSequence(s) => &s.id,
+        BlockDefinition::ABSplit(ab) => &ab.id,
+        BlockDefinition::CancellationScope(cs) => &cs.id,
+    }
+}
+
+/// DLQ surgery: re-run an instance from an arbitrary block.
+///
+/// Wipes the target block's outputs and the outputs of every block at or
+/// after it in the sequence's top-level `blocks` array (including blocks
+/// nested inside wiped composites), optionally shallow-merges a context
+/// patch into `context.data`, and re-schedules the instance immediately.
+/// Earlier blocks keep their outputs: on the flat all-step execution path
+/// the completed-blocks check skips them, so side-effectful handlers do not
+/// run twice. On the tree path the execution tree is rebuilt from scratch —
+/// the exact same semantics as `POST /instances/{id}/retry`, which also
+/// deletes the tree while preserving real outputs.
+///
+/// Linear assumption: "after" is defined by position in the top-level
+/// `blocks` array, which is the order both execution paths (flat fast path
+/// and tree evaluator) run top-level blocks in. The target must itself be a
+/// top-level block — resuming from a block nested inside a composite is not
+/// supported.
+#[utoipa::path(post, path = "/instances/{id}/resume-from/{block_id}", tag = "instances",
+    params(
+        ("id" = Uuid, Path, description = "Instance ID"),
+        ("block_id" = String, Path, description = "Top-level block to resume from"),
+    ),
+    request_body = Option<ResumeFromRequest>,
+    responses(
+        (status = 200, description = "Instance re-scheduled from the given block", body = serde_json::Value),
+        (status = 400, description = "Unknown block, or instance is in a state that cannot be resumed"),
+        (status = 404, description = "Instance or sequence not found"),
+    )
+)]
+#[allow(clippy::too_many_lines)] // sequential surgery steps — splitting hurts readability
+pub async fn resume_from_block(
+    State(state): State<AppState>,
+    tenant_ctx: crate::auth::OptionalTenant,
+    Path((id, block_id)): Path<(Uuid, String)>,
+    req: Option<Json<ResumeFromRequest>>,
+) -> Result<impl IntoResponse, ApiError> {
+    let instance_id = InstanceId::from_uuid(id);
+    let req = req.map(|Json(r)| r).unwrap_or_default();
+
+    let instance = state
+        .storage
+        .get_instance(instance_id)
+        .await
+        .map_err(|e| ApiError::from_storage(e, "instance"))?
+        .ok_or_else(|| ApiError::NotFound(format!("instance {id}")))?;
+
+    crate::auth::enforce_tenant_access(
+        &tenant_ctx,
+        &instance.tenant_id,
+        &format!("instance {id}"),
+    )?;
+
+    // Only quiescent instances can be operated on. Running/Scheduled/Waiting
+    // instances must be paused or cancelled first — wiping outputs under a
+    // live execution would race the scheduler.
+    if !matches!(
+        instance.state,
+        InstanceState::Failed
+            | InstanceState::Paused
+            | InstanceState::Completed
+            | InstanceState::Cancelled
+    ) {
+        return Err(ApiError::InvalidArgument(format!(
+            "cannot resume-from in state {}: pause or cancel the instance first",
+            instance.state
+        )));
+    }
+
+    // Validate the context patch up-front, before any destructive write.
+    let patch = match req.context {
+        None => None,
+        Some(serde_json::Value::Object(map)) => Some(map),
+        Some(_) => {
+            return Err(ApiError::InvalidArgument(
+                "context patch must be a JSON object".into(),
+            ));
+        }
+    };
+
+    let sequence = state
+        .storage
+        .get_sequence(instance.sequence_id)
+        .await
+        .map_err(|e| ApiError::from_storage(e, "sequence"))?
+        .ok_or_else(|| {
+            ApiError::NotFound(format!("sequence {}", instance.sequence_id.into_uuid()))
+        })?;
+
+    let target_idx = sequence
+        .blocks
+        .iter()
+        .position(|b| top_level_block_id(b).as_str() == block_id)
+        .ok_or_else(|| {
+            ApiError::InvalidArgument(format!(
+                "block '{block_id}' is not a top-level block of sequence {}",
+                instance.sequence_id.into_uuid()
+            ))
+        })?;
+
+    // Wipe set: the target block and everything after it in top-level order,
+    // plus all blocks nested inside those (composite iteration markers, retry
+    // markers and in-progress sentinels all live in `block_outputs` under the
+    // block's own ID, so one batched delete clears them all).
+    let mut wipe_ids: Vec<BlockId> = Vec::new();
+    for block in &sequence.blocks[target_idx..] {
+        collect_block_ids(block, &mut wipe_ids);
+    }
+
+    // Delete the stale execution tree so the evaluator rebuilds it from
+    // scratch (same mechanics as `retry_instance`). Earlier blocks keep
+    // their outputs and are memoized on the re-run.
+    state
+        .storage
+        .delete_execution_tree(instance_id)
+        .await
+        .map_err(|e| ApiError::from_storage(e, "execution_tree"))?;
+
+    let outputs_deleted = state
+        .storage
+        .delete_block_outputs_batch(instance_id, &wipe_ids)
+        .await
+        .map_err(|e| ApiError::from_storage(e, "block_outputs"))?;
+
+    // Purge stale worker_tasks rows for the wiped blocks — the
+    // `UNIQUE(instance_id, block_id)` constraint would otherwise swallow the
+    // re-run's dispatch via `ON CONFLICT DO NOTHING` and strand the instance
+    // in Waiting (same purge the loop/for_each iteration reset performs).
+    let wipe_strs: Vec<String> = wipe_ids.iter().map(|b| b.as_str().to_owned()).collect();
+    state
+        .storage
+        .cancel_worker_tasks_for_blocks(instance_id.into_uuid(), &wipe_strs)
+        .await
+        .map_err(|e| ApiError::from_storage(e, "worker_tasks"))?;
+
+    // Apply the context patch: shallow per-key merge into `context.data`
+    // (the same per-key semantics as `StorageBackend::merge_context_data`,
+    // which the engine uses for handler-driven context writes).
+    if let Some(patch) = patch {
+        let mut context = instance.context.clone();
+        if !context.data.is_object() {
+            context.data = serde_json::json!({});
+        }
+        if let Some(data) = context.data.as_object_mut() {
+            for (key, value) in patch {
+                data.insert(key, value);
+            }
+        }
+        context.check_size(state.max_context_bytes)?;
+        state
+            .storage
+            .update_instance_context(instance_id, &context)
+            .await
+            .map_err(|e| ApiError::from_storage(e, "instance"))?;
+    }
+
+    state
+        .storage
+        .update_instance_state(instance_id, InstanceState::Scheduled, Some(Utc::now()))
+        .await
+        .map_err(|e| ApiError::from_storage(e, "instance"))?;
+
+    tracing::info!(
+        instance_id = %instance_id,
+        resumed_from = %block_id,
+        outputs_deleted = outputs_deleted,
+        "instance resumed from block"
+    );
+
+    Ok((
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "id": instance_id,
+            "state": "scheduled",
+            "resumed_from": block_id,
+            "outputs_deleted": outputs_deleted,
+        })),
     ))
 }

--- a/orch8-api/src/instances/types.rs
+++ b/orch8-api/src/instances/types.rs
@@ -62,6 +62,16 @@ pub struct UpdateContextRequest {
     pub(crate) context: ExecutionContext,
 }
 
+/// Body for `POST /instances/{id}/resume-from/{block_id}`. The whole body is
+/// optional; when present, `context` must be a JSON object whose top-level
+/// keys are shallow-merged into `context.data` (same per-key semantics as
+/// `StorageBackend::merge_context_data`) before the instance is re-scheduled.
+#[derive(Default, Deserialize, ToSchema)]
+pub struct ResumeFromRequest {
+    #[serde(default)]
+    pub(crate) context: Option<serde_json::Value>,
+}
+
 #[derive(Deserialize, ToSchema)]
 pub struct SendSignalRequest {
     pub(crate) signal_type: SignalType,

--- a/orch8-api/src/openapi.rs
+++ b/orch8-api/src/openapi.rs
@@ -40,6 +40,7 @@ use utoipa::OpenApi;
         crate::instances::get_artifact_bytes,
         crate::instances::get_execution_tree,
         crate::instances::retry_instance,
+        crate::instances::resume_from_block,
         crate::instances::bulk_update_state,
         crate::instances::bulk_reschedule,
         crate::instances::list_dlq,

--- a/orch8-api/tests/resume_from.rs
+++ b/orch8-api/tests/resume_from.rs
@@ -1,0 +1,370 @@
+//! E2E tests for `POST /instances/{id}/resume-from/{block_id}` (DLQ surgery).
+//!
+//! The API test harness has no engine loop, so executed steps are simulated
+//! by writing `block_outputs` rows and driving instance state directly
+//! through the storage handle exposed by `spawn_test_server()`.
+
+use chrono::Utc;
+use orch8_api::test_harness::spawn_test_server;
+use orch8_storage::{InstanceStore, OutputStore};
+use orch8_types::ids::{BlockId, InstanceId};
+use orch8_types::instance::InstanceState;
+use orch8_types::output::BlockOutput;
+use reqwest::StatusCode;
+use serde_json::json;
+use uuid::Uuid;
+
+fn step(id: &str) -> serde_json::Value {
+    json!({
+        "type": "step",
+        "id": id,
+        "handler": "noop",
+        "params": {},
+        "cancellable": true
+    })
+}
+
+fn mk_sequence_body(id: Uuid) -> serde_json::Value {
+    json!({
+        "id": id,
+        "tenant_id": "t1",
+        "namespace": "ns1",
+        "name": "resume-seq",
+        "version": 1,
+        "deprecated": false,
+        "blocks": [step("s1"), step("s2"), step("s3")],
+        "interceptors": null,
+        "created_at": Utc::now().to_rfc3339()
+    })
+}
+
+async fn create_sequence(client: &reqwest::Client, base_url: &str) -> Uuid {
+    let seq_id = Uuid::now_v7();
+    let resp = client
+        .post(format!("{base_url}/sequences"))
+        .header("X-Tenant-Id", "t1")
+        .json(&mk_sequence_body(seq_id))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    seq_id
+}
+
+async fn create_instance(client: &reqwest::Client, base_url: &str, seq_id: Uuid) -> Uuid {
+    let body = json!({
+        "sequence_id": seq_id,
+        "tenant_id": "t1",
+        "namespace": "ns1",
+        "context": { "data": { "seed": 1 }, "config": {}, "audit": [] }
+    });
+    let resp = client
+        .post(format!("{base_url}/instances"))
+        .header("X-Tenant-Id", "t1")
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let created: serde_json::Value = resp.json().await.unwrap();
+    created["id"].as_str().unwrap().parse().unwrap()
+}
+
+fn mk_output(inst: Uuid, block: &str) -> BlockOutput {
+    BlockOutput {
+        id: Uuid::now_v7(),
+        instance_id: InstanceId::from_uuid(inst),
+        block_id: BlockId::new(block),
+        output: json!({"result": format!("{block}-ok")}),
+        output_ref: None,
+        output_size: 0,
+        attempt: 0,
+        created_at: Utc::now(),
+    }
+}
+
+#[tokio::test]
+async fn resume_from_middle_block_wipes_tail_and_reschedules() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+    let seq_id = create_sequence(&client, &srv.base_url).await;
+    let inst = create_instance(&client, &srv.base_url, seq_id).await;
+
+    // Simulate: s1 completed, s2 has a real output, a __retry__ marker and an
+    // __in_progress__ sentinel (failed mid-flight), s3 completed.
+    srv.storage
+        .save_block_output(&mk_output(inst, "s1"))
+        .await
+        .unwrap();
+    srv.storage
+        .save_block_output(&mk_output(inst, "s2"))
+        .await
+        .unwrap();
+    let mut retry_marker = mk_output(inst, "s2");
+    retry_marker.output_ref = Some("__retry__".into());
+    srv.storage.save_block_output(&retry_marker).await.unwrap();
+    let mut sentinel = mk_output(inst, "s2");
+    sentinel.output_ref = Some("__in_progress__".into());
+    srv.storage.save_block_output(&sentinel).await.unwrap();
+    srv.storage
+        .save_block_output(&mk_output(inst, "s3"))
+        .await
+        .unwrap();
+
+    srv.storage
+        .update_instance_state(InstanceId::from_uuid(inst), InstanceState::Failed, None)
+        .await
+        .unwrap();
+
+    let resp = client
+        .post(format!("{}/instances/{inst}/resume-from/s2", srv.base_url))
+        .header("X-Tenant-Id", "t1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["state"], "scheduled");
+    assert_eq!(body["resumed_from"], "s2");
+    // s2 real output + retry marker + sentinel + s3 output = 4 rows.
+    assert_eq!(body["outputs_deleted"], 4);
+
+    // Only s1's output survives.
+    let outputs = srv
+        .storage
+        .get_all_outputs(InstanceId::from_uuid(inst))
+        .await
+        .unwrap();
+    assert_eq!(outputs.len(), 1);
+    assert_eq!(outputs[0].block_id.as_str(), "s1");
+
+    // Instance is back to scheduled with an immediate fire time.
+    let resp = client
+        .get(format!("{}/instances/{inst}", srv.base_url))
+        .header("X-Tenant-Id", "t1")
+        .send()
+        .await
+        .unwrap();
+    let fetched: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(fetched["state"], "scheduled");
+    assert!(fetched["next_fire_at"].is_string());
+}
+
+#[tokio::test]
+async fn resume_from_applies_context_patch_shallow_merge() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+    let seq_id = create_sequence(&client, &srv.base_url).await;
+    let inst = create_instance(&client, &srv.base_url, seq_id).await;
+
+    srv.storage
+        .update_instance_state(InstanceId::from_uuid(inst), InstanceState::Failed, None)
+        .await
+        .unwrap();
+
+    let resp = client
+        .post(format!("{}/instances/{inst}/resume-from/s1", srv.base_url))
+        .header("X-Tenant-Id", "t1")
+        .json(&json!({ "context": { "api_key": "fixed", "retries": 3 } }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let resp = client
+        .get(format!("{}/instances/{inst}", srv.base_url))
+        .header("X-Tenant-Id", "t1")
+        .send()
+        .await
+        .unwrap();
+    let fetched: serde_json::Value = resp.json().await.unwrap();
+    // Patched keys are merged in; pre-existing keys are preserved.
+    assert_eq!(fetched["context"]["data"]["api_key"], "fixed");
+    assert_eq!(fetched["context"]["data"]["retries"], 3);
+    assert_eq!(fetched["context"]["data"]["seed"], 1);
+}
+
+#[tokio::test]
+async fn resume_from_rejects_non_object_context_patch() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+    let seq_id = create_sequence(&client, &srv.base_url).await;
+    let inst = create_instance(&client, &srv.base_url, seq_id).await;
+
+    srv.storage
+        .update_instance_state(InstanceId::from_uuid(inst), InstanceState::Failed, None)
+        .await
+        .unwrap();
+
+    let resp = client
+        .post(format!("{}/instances/{inst}/resume-from/s1", srv.base_url))
+        .header("X-Tenant-Id", "t1")
+        .json(&json!({ "context": [1, 2, 3] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn resume_from_unknown_block_returns_400() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+    let seq_id = create_sequence(&client, &srv.base_url).await;
+    let inst = create_instance(&client, &srv.base_url, seq_id).await;
+
+    srv.storage
+        .update_instance_state(InstanceId::from_uuid(inst), InstanceState::Failed, None)
+        .await
+        .unwrap();
+
+    let resp = client
+        .post(format!(
+            "{}/instances/{inst}/resume-from/no-such-block",
+            srv.base_url
+        ))
+        .header("X-Tenant-Id", "t1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["error"].as_str().unwrap().contains("no-such-block"));
+}
+
+#[tokio::test]
+async fn resume_from_running_instance_returns_400() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+    let seq_id = create_sequence(&client, &srv.base_url).await;
+    let inst = create_instance(&client, &srv.base_url, seq_id).await;
+
+    srv.storage
+        .update_instance_state(InstanceId::from_uuid(inst), InstanceState::Running, None)
+        .await
+        .unwrap();
+
+    let resp = client
+        .post(format!("{}/instances/{inst}/resume-from/s1", srv.base_url))
+        .header("X-Tenant-Id", "t1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["error"].as_str().unwrap().contains("running"));
+}
+
+#[tokio::test]
+async fn resume_from_completed_instance_reruns_tail() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+    let seq_id = create_sequence(&client, &srv.base_url).await;
+    let inst = create_instance(&client, &srv.base_url, seq_id).await;
+
+    // All three blocks completed; instance reached Completed.
+    for block in ["s1", "s2", "s3"] {
+        srv.storage
+            .save_block_output(&mk_output(inst, block))
+            .await
+            .unwrap();
+    }
+    srv.storage
+        .update_instance_state(InstanceId::from_uuid(inst), InstanceState::Completed, None)
+        .await
+        .unwrap();
+
+    let resp = client
+        .post(format!("{}/instances/{inst}/resume-from/s3", srv.base_url))
+        .header("X-Tenant-Id", "t1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["state"], "scheduled");
+    assert_eq!(body["outputs_deleted"], 1);
+
+    let outputs = srv
+        .storage
+        .get_all_outputs(InstanceId::from_uuid(inst))
+        .await
+        .unwrap();
+    let mut remaining: Vec<&str> = outputs.iter().map(|o| o.block_id.as_str()).collect();
+    remaining.sort_unstable();
+    assert_eq!(remaining, ["s1", "s2"]);
+}
+
+#[tokio::test]
+async fn resume_from_unknown_instance_returns_404() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!(
+            "{}/instances/{}/resume-from/s1",
+            srv.base_url,
+            Uuid::now_v7()
+        ))
+        .header("X-Tenant-Id", "t1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn resume_from_cross_tenant_returns_404() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+    let seq_id = create_sequence(&client, &srv.base_url).await;
+    let inst = create_instance(&client, &srv.base_url, seq_id).await;
+
+    srv.storage
+        .update_instance_state(InstanceId::from_uuid(inst), InstanceState::Failed, None)
+        .await
+        .unwrap();
+
+    // A different tenant must not see (or resume) the instance.
+    let resp = client
+        .post(format!("{}/instances/{inst}/resume-from/s1", srv.base_url))
+        .header("X-Tenant-Id", "t2")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    // Untouched: still failed, outputs intact.
+    let resp = client
+        .get(format!("{}/instances/{inst}", srv.base_url))
+        .header("X-Tenant-Id", "t1")
+        .send()
+        .await
+        .unwrap();
+    let fetched: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(fetched["state"], "failed");
+}
+
+#[tokio::test]
+async fn resume_from_paused_instance_works_via_v1_prefix() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+    let seq_id = create_sequence(&client, &srv.base_url).await;
+    let inst = create_instance(&client, &srv.base_url, seq_id).await;
+
+    srv.storage
+        .update_instance_state(InstanceId::from_uuid(inst), InstanceState::Paused, None)
+        .await
+        .unwrap();
+
+    let resp = client
+        .post(format!("{}/instances/{inst}/resume-from/s1", srv.v1_url()))
+        .header("X-Tenant-Id", "t1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["state"], "scheduled");
+    assert_eq!(body["outputs_deleted"], 0);
+}

--- a/orch8-engine/tests/resume_from_block_e2e.rs
+++ b/orch8-engine/tests/resume_from_block_e2e.rs
@@ -1,0 +1,164 @@
+//! Engine-level e2e for resume-from-block (DLQ surgery).
+//!
+//! Drives a flat 3-step sequence through the real scheduler (`tick_once`)
+//! until it fails at the middle step, then performs the same storage surgery
+//! the `POST /instances/{id}/resume-from/{block_id}` handler performs (wipe
+//! tree + tail outputs, patch context, re-schedule) and ticks the scheduler
+//! to completion. Verifies the patched context unblocks the failing step and
+//! that the already-completed first step is NOT re-executed.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+use chrono::Utc;
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+
+use orch8_engine::handlers::HandlerRegistry;
+use orch8_engine::scheduler::tick_once;
+use orch8_storage::StorageBackend;
+use orch8_types::error::StepError;
+use orch8_types::ids::{BlockId, InstanceId};
+use orch8_types::instance::InstanceState;
+
+mod common;
+use common::*;
+
+/// Tick the scheduler until the instance reaches `target` (or panic).
+async fn tick_until(
+    storage: &Arc<dyn StorageBackend>,
+    handlers: &Arc<HandlerRegistry>,
+    instance_id: InstanceId,
+    target: InstanceState,
+) {
+    let sem = semaphore(128);
+    let config = default_config();
+    let seq_cache = cache();
+    let cancel = CancellationToken::new();
+    for _ in 0..50 {
+        tick_once(storage, handlers, &sem, &config, &seq_cache, &cancel)
+            .await
+            .unwrap();
+        let inst = storage.get_instance(instance_id).await.unwrap().unwrap();
+        if inst.state == target {
+            return;
+        }
+    }
+    let inst = storage.get_instance(instance_id).await.unwrap().unwrap();
+    panic!("instance never reached {target}, stuck in {}", inst.state);
+}
+
+#[tokio::test]
+async fn resume_from_failed_block_with_context_patch_runs_to_completion() {
+    // s1 counts its executions; s2 fails permanently while
+    // `context.data.broken == true`; s3 is a plain noop.
+    let s1_runs = Arc::new(AtomicU32::new(0));
+    let mut reg = registry();
+    {
+        let s1_runs = Arc::clone(&s1_runs);
+        reg.register("count_me", move |_ctx| {
+            let s1_runs = Arc::clone(&s1_runs);
+            Box::pin(async move {
+                s1_runs.fetch_add(1, Ordering::SeqCst);
+                Ok(json!({"counted": true}))
+            })
+        });
+    }
+    reg.register("fail_if_broken", |ctx| {
+        Box::pin(async move {
+            if ctx
+                .context
+                .data
+                .get("broken")
+                .and_then(serde_json::Value::as_bool)
+                == Some(true)
+            {
+                Err(StepError::Permanent {
+                    message: "dependency broken".into(),
+                    details: None,
+                })
+            } else {
+                Ok(json!({"repaired": true}))
+            }
+        })
+    });
+    let handlers = Arc::new(reg);
+
+    let storage: Arc<dyn StorageBackend> = Arc::new(
+        orch8_storage::sqlite::SqliteStorage::in_memory()
+            .await
+            .unwrap(),
+    );
+    let seq = mk_sequence(vec![
+        mk_step("s1", "count_me"),
+        mk_step("s2", "fail_if_broken"),
+        mk_step("s3", "noop"),
+    ]);
+    storage.create_sequence(&seq).await.unwrap();
+    let inst = mk_instance_scheduled(seq.id, json!({"broken": true}));
+    storage.create_instance(&inst).await.unwrap();
+
+    // Run until the instance fails at s2.
+    tick_until(&storage, &handlers, inst.id, InstanceState::Failed).await;
+    assert_eq!(s1_runs.load(Ordering::SeqCst), 1, "s1 ran exactly once");
+    assert!(
+        storage
+            .get_block_output(inst.id, &BlockId::new("s1"))
+            .await
+            .unwrap()
+            .is_some(),
+        "s1 output persisted before the failure"
+    );
+
+    // --- Resume-from surgery (mirrors the API handler) ---
+    // Wipe the stale tree, the target block's and later blocks' outputs
+    // (including s2's kept __in_progress__ sentinel), purge stale worker
+    // tasks, patch the context so s2 now succeeds, and re-schedule.
+    storage.delete_execution_tree(inst.id).await.unwrap();
+    let wiped = storage
+        .delete_block_outputs_batch(inst.id, &[BlockId::new("s2"), BlockId::new("s3")])
+        .await
+        .unwrap();
+    assert!(wiped >= 1, "s2's sentinel/marker rows must be wiped");
+    storage
+        .cancel_worker_tasks_for_blocks(inst.id.into_uuid(), &["s2".into(), "s3".into()])
+        .await
+        .unwrap();
+    let mut current = storage.get_instance(inst.id).await.unwrap().unwrap();
+    current.context.data["broken"] = json!(false);
+    storage
+        .update_instance_context(inst.id, &current.context)
+        .await
+        .unwrap();
+    storage
+        .update_instance_state(
+            inst.id,
+            InstanceState::Scheduled,
+            Some(Utc::now() - chrono::Duration::seconds(5)),
+        )
+        .await
+        .unwrap();
+
+    // The re-run completes: s2 succeeds with the patched context, s3 runs.
+    tick_until(&storage, &handlers, inst.id, InstanceState::Completed).await;
+
+    assert_eq!(
+        s1_runs.load(Ordering::SeqCst),
+        1,
+        "s1 must NOT re-execute — its preserved output short-circuits the fast path"
+    );
+    let s2_out = storage
+        .get_block_output(inst.id, &BlockId::new("s2"))
+        .await
+        .unwrap()
+        .expect("s2 re-ran and produced a real output");
+    assert_eq!(s2_out.output["repaired"], true);
+    assert!(
+        storage
+            .get_block_output(inst.id, &BlockId::new("s3"))
+            .await
+            .unwrap()
+            .is_some(),
+        "s3 ran on the resumed pass"
+    );
+}

--- a/orch8-storage/tests/storage_integration.rs
+++ b/orch8-storage/tests/storage_integration.rs
@@ -1502,6 +1502,105 @@ async fn delete_block_outputs_no_effect_on_different_block_ids_at_same_instance(
     assert_eq!(step_row.output["result"], "ok");
 }
 
+// ---------------------------------------------------------------------------
+// delete_block_outputs_batch — single round-trip wipe over a set of block IDs.
+// Used by loop/for_each subtree resets and by the resume-from-block API to
+// wipe the target block and everything after it.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn delete_block_outputs_batch_removes_only_listed_blocks() {
+    let s = store().await;
+    let inst = InstanceId::new();
+    seed_instance(&s, inst).await;
+
+    for block in ["s1", "s2", "s3"] {
+        s.save_block_output(&mk_output(inst, block, 0))
+            .await
+            .unwrap();
+    }
+    // Two rows for s2 (real output + a later attempt) — both must go.
+    s.save_block_output(&mk_output(inst, "s2", 1))
+        .await
+        .unwrap();
+
+    let removed = s
+        .delete_block_outputs_batch(inst, &[BlockId::new("s2"), BlockId::new("s3")])
+        .await
+        .unwrap();
+    assert_eq!(removed, 3);
+
+    let remaining = s.get_all_outputs(inst).await.unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].block_id.as_str(), "s1");
+}
+
+#[tokio::test]
+async fn delete_block_outputs_batch_removes_retry_and_sentinel_markers() {
+    let s = store().await;
+    let inst = InstanceId::new();
+    seed_instance(&s, inst).await;
+
+    let mut retry_marker = mk_output(inst, "s2", 1);
+    retry_marker.output_ref = Some("__retry__".into());
+    s.save_block_output(&retry_marker).await.unwrap();
+    let mut sentinel = mk_output(inst, "s2", 0);
+    sentinel.output_ref = Some("__in_progress__".into());
+    s.save_block_output(&sentinel).await.unwrap();
+
+    let removed = s
+        .delete_block_outputs_batch(inst, &[BlockId::new("s2")])
+        .await
+        .unwrap();
+    assert_eq!(removed, 2);
+    assert!(s
+        .get_block_output(inst, &BlockId::new("s2"))
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn delete_block_outputs_batch_empty_list_is_noop() {
+    let s = store().await;
+    let inst = InstanceId::new();
+    seed_instance(&s, inst).await;
+    s.save_block_output(&mk_output(inst, "s1", 0))
+        .await
+        .unwrap();
+
+    let removed = s.delete_block_outputs_batch(inst, &[]).await.unwrap();
+    assert_eq!(removed, 0);
+    assert_eq!(s.get_all_outputs(inst).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn delete_block_outputs_batch_scoped_to_instance() {
+    let s = store().await;
+    let inst1 = InstanceId::new();
+    let inst2 = InstanceId::new();
+    seed_instance(&s, inst1).await;
+    seed_instance(&s, inst2).await;
+
+    s.save_block_output(&mk_output(inst1, "shared", 0))
+        .await
+        .unwrap();
+    s.save_block_output(&mk_output(inst2, "shared", 0))
+        .await
+        .unwrap();
+
+    let removed = s
+        .delete_block_outputs_batch(inst1, &[BlockId::new("shared")])
+        .await
+        .unwrap();
+    assert_eq!(removed, 1);
+    assert!(s
+        .get_block_output(inst2, &BlockId::new("shared"))
+        .await
+        .unwrap()
+        .is_some());
+}
+
 // ===========================================================================
 // Complex Scenarios
 // ===========================================================================

--- a/orch8-types/src/instance.rs
+++ b/orch8-types/src/instance.rs
@@ -80,7 +80,17 @@ impl InstanceState {
                 Self::Waiting,
                 Self::Running | Self::Scheduled | Self::Cancelled | Self::Failed
             ) | (Self::Paused, Self::Scheduled | Self::Cancelled)
-                | (Self::Failed, Self::Scheduled) // retry from DLQ
+                // Failed -> Scheduled is retry from the DLQ.
+                // Completed / Cancelled -> Scheduled is resume-from-block
+                // surgery: an operator may re-run a finished instance from an
+                // arbitrary block (wiping that block's and all later outputs
+                // first), which requires re-scheduling instances that already
+                // reached a terminal state. All other exits from the terminal
+                // states remain invalid.
+                | (
+                    Self::Failed | Self::Completed | Self::Cancelled,
+                    Self::Scheduled
+                )
         )
     }
 
@@ -191,7 +201,7 @@ mod tests {
     #[test]
     fn invalid_transitions() {
         assert!(!InstanceState::Completed.can_transition_to(InstanceState::Running));
-        assert!(!InstanceState::Cancelled.can_transition_to(InstanceState::Scheduled));
+        assert!(!InstanceState::Cancelled.can_transition_to(InstanceState::Running));
         assert!(!InstanceState::Failed.can_transition_to(InstanceState::Completed));
     }
 
@@ -252,9 +262,10 @@ mod tests {
     }
 
     #[test]
-    fn completed_is_terminal_rejects_all_targets() {
+    fn completed_rejects_all_targets_except_scheduled() {
+        // `Completed -> Scheduled` is the resume-from-block escape hatch;
+        // every other exit from Completed remains invalid.
         for target in [
-            InstanceState::Scheduled,
             InstanceState::Running,
             InstanceState::Waiting,
             InstanceState::Paused,
@@ -267,6 +278,7 @@ mod tests {
                 "Completed -> {target:?} must be invalid"
             );
         }
+        assert!(InstanceState::Completed.can_transition_to(InstanceState::Scheduled));
     }
 
     #[test]
@@ -298,9 +310,10 @@ mod tests {
     }
 
     #[test]
-    fn cancelled_is_terminal_rejects_all_targets() {
+    fn cancelled_rejects_all_targets_except_scheduled() {
+        // `Cancelled -> Scheduled` is the resume-from-block escape hatch;
+        // every other exit from Cancelled remains invalid.
         for target in [
-            InstanceState::Scheduled,
             InstanceState::Running,
             InstanceState::Waiting,
             InstanceState::Paused,
@@ -313,6 +326,7 @@ mod tests {
                 "Cancelled -> {target:?} must be invalid"
             );
         }
+        assert!(InstanceState::Cancelled.can_transition_to(InstanceState::Scheduled));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
New `POST /instances/{id}/resume-from/{block_id}` — DLQ surgery. Pick any top-level block of a Failed/Paused/Completed/Cancelled instance, optionally patch `context.data`, and re-run from there:
- Wipes outputs for the target block, every later top-level block, and all blocks nested in those composites (recursive over all 10 `BlockDefinition` variants). Retry/in-progress sentinels live in `block_outputs`, so the batch delete clears them too; stale `worker_tasks` rows are purged so external-worker steps can't strand in Waiting.
- Context patch is a shallow per-top-level-key merge into `context.data` (same semantics as the engine's `merge_context_data`), size-checked before write.
- Transitions to `Scheduled` with `next_fire_at = now`; earlier outputs are preserved and skipped on re-execution (engine e2e proves the pre-target handler runs exactly once across fail→surgery→complete).
- Tenant-scoped (cross-tenant → 404); invalid states → 400 per this API's convention; reuses the existing `delete_block_outputs_batch` storage method (already implemented in postgres, sqlite, and the encrypting wrapper).

## ⚠️ Semantic change worth review
The state machine gains `Completed → Scheduled` and `Cancelled → Scheduled` edges (resume-from-block escape hatch). Side effect: `PATCH /state` can now also re-schedule completed/cancelled instances. All other terminal exits remain invalid; `is_terminal()` unchanged.

## Tests
9 API e2e (wipe + markers, patch merge, non-object patch, unknown block, running rejection, completed re-run, 404s, tenant isolation), 4 sqlite storage tests, 1 engine e2e through the real scheduler, transition-table tests updated to pin the exact new edges. `cargo test` across the 4 touched crates: 3097 passed. fmt/clippy/doc gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)