### PR TITLE
feat(engine): budget-governed instances — token/step budgets with pause-on-breach

### DIFF
--- a/migrations/043_instance_budget.sql
+++ b/migrations/043_instance_budget.sql
@@ -1,0 +1,6 @@
+-- Optional per-instance budget: token/step caps enforced by the scheduler.
+-- NULL means "no budget" — the scheduler skips all budget bookkeeping.
+-- Shape mirrors orch8_types::instance::Budget:
+--   { "max_input_tokens": N, "max_output_tokens": N,
+--     "max_total_tokens": N, "max_steps": N }   (all fields optional)
+ALTER TABLE task_instances ADD COLUMN IF NOT EXISTS budget JSONB;

--- a/orch8-api/src/approvals.rs
+++ b/orch8-api/src/approvals.rs
@@ -427,6 +427,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }

--- a/orch8-api/src/instances/lifecycle.rs
+++ b/orch8-api/src/instances/lifecycle.rs
@@ -132,6 +132,7 @@ pub async fn create_instance(
         idempotency_key: effective_idem,
         session_id: None,
         parent_instance_id: None,
+        budget: req.budget,
         created_at: now,
         updated_at: now,
     };
@@ -242,6 +243,7 @@ pub async fn create_instances_batch(
                 idempotency_key,
                 session_id: None,
                 parent_instance_id: None,
+                budget: r.budget,
                 created_at: now,
                 updated_at: now,
             }

--- a/orch8-api/src/instances/types.rs
+++ b/orch8-api/src/instances/types.rs
@@ -40,6 +40,11 @@ pub struct CreateInstanceRequest {
     pub(crate) concurrency_key: Option<String>,
     pub(crate) max_concurrency: Option<u32>,
     pub(crate) idempotency_key: Option<String>,
+    /// Optional resource budget (token/step caps) enforced by the scheduler.
+    /// When any configured limit is exceeded the instance is paused with
+    /// `metadata.paused_reason = "budget_exceeded"`. Default: no budget.
+    #[serde(default)]
+    pub(crate) budget: Option<orch8_types::instance::Budget>,
 }
 
 pub fn default_timezone() -> String {

--- a/orch8-api/src/openapi.rs
+++ b/orch8-api/src/openapi.rs
@@ -112,6 +112,7 @@ use utoipa::OpenApi;
         // Instance
         orch8_types::instance::InstanceState,
         orch8_types::instance::Priority,
+        orch8_types::instance::Budget,
         orch8_types::instance::TaskInstance,
         // Context
         orch8_types::context::ExecutionContext,

--- a/orch8-api/tests/instances.rs
+++ b/orch8-api/tests/instances.rs
@@ -361,3 +361,83 @@ async fn invalid_state_transition_returns_400() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
+
+#[tokio::test]
+async fn create_instance_with_budget_echoes_budget_on_get() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+    let seq_id = create_sequence(&client, &srv.base_url).await;
+
+    let body = json!({
+        "sequence_id": seq_id,
+        "tenant_id": "t1",
+        "namespace": "ns1",
+        "context": { "data": {}, "config": {}, "audit": [] },
+        "budget": {
+            "max_input_tokens": 1000,
+            "max_total_tokens": 5000,
+            "max_steps": 10
+        }
+    });
+
+    let resp = client
+        .post(format!("{}/instances", srv.base_url))
+        .header("X-Tenant-Id", "t1")
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let created: serde_json::Value = resp.json().await.unwrap();
+    let inst_id = created["id"].as_str().unwrap();
+
+    let resp = client
+        .get(format!("{}/instances/{inst_id}", srv.base_url))
+        .header("X-Tenant-Id", "t1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let fetched: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(fetched["budget"]["max_input_tokens"], 1000);
+    assert_eq!(fetched["budget"]["max_total_tokens"], 5000);
+    assert_eq!(fetched["budget"]["max_steps"], 10);
+    // Unset limit is omitted from the serialized budget.
+    assert!(fetched["budget"].get("max_output_tokens").is_none());
+}
+
+#[tokio::test]
+async fn create_instance_without_budget_omits_budget_field() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+    let seq_id = create_sequence(&client, &srv.base_url).await;
+
+    let body = json!({
+        "sequence_id": seq_id,
+        "tenant_id": "t1",
+        "namespace": "ns1",
+        "context": { "data": {}, "config": {}, "audit": [] }
+    });
+
+    let resp = client
+        .post(format!("{}/instances", srv.base_url))
+        .header("X-Tenant-Id", "t1")
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let created: serde_json::Value = resp.json().await.unwrap();
+    let inst_id = created["id"].as_str().unwrap();
+
+    let resp = client
+        .get(format!("{}/instances/{inst_id}", srv.base_url))
+        .header("X-Tenant-Id", "t1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let fetched: serde_json::Value = resp.json().await.unwrap();
+    // skip_serializing_if = Option::is_none — the key is absent entirely.
+    assert!(fetched.get("budget").is_none());
+}

--- a/orch8-engine/benches/engine_bench.rs
+++ b/orch8-engine/benches/engine_bench.rs
@@ -68,6 +68,7 @@ fn make_instance(seq_id: SequenceId) -> TaskInstance {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     }
@@ -290,6 +291,7 @@ fn mk_instance(data: serde_json::Value) -> TaskInstance {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     }

--- a/orch8-engine/src/cron.rs
+++ b/orch8-engine/src/cron.rs
@@ -106,6 +106,7 @@ async fn trigger_cron_schedule(
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     };

--- a/orch8-engine/src/evaluator/dispatch.rs
+++ b/orch8-engine/src/evaluator/dispatch.rs
@@ -266,6 +266,7 @@ pub(super) async fn dispatch_block(
                     idempotency_key: None,
                     session_id: instance.session_id,
                     parent_instance_id: Some(instance.id),
+                    budget: None,
                     created_at: now,
                     updated_at: now,
                 };

--- a/orch8-engine/src/evaluator/tests.rs
+++ b/orch8-engine/src/evaluator/tests.rs
@@ -584,6 +584,7 @@ async fn seed_instance_ev(s: &SqliteStorage, id: InstanceId) {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     };

--- a/orch8-engine/src/handlers/ab_split.rs
+++ b/orch8-engine/src/handlers/ab_split.rs
@@ -167,6 +167,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }

--- a/orch8-engine/src/handlers/cancellation_scope.rs
+++ b/orch8-engine/src/handlers/cancellation_scope.rs
@@ -139,6 +139,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         };
@@ -163,6 +164,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }

--- a/orch8-engine/src/handlers/emit_event.rs
+++ b/orch8-engine/src/handlers/emit_event.rs
@@ -236,6 +236,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }

--- a/orch8-engine/src/handlers/for_each.rs
+++ b/orch8-engine/src/handlers/for_each.rs
@@ -484,6 +484,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         };
@@ -667,6 +668,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         };
@@ -696,6 +698,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }

--- a/orch8-engine/src/handlers/loop_block.rs
+++ b/orch8-engine/src/handlers/loop_block.rs
@@ -436,6 +436,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         };
@@ -742,6 +743,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }

--- a/orch8-engine/src/handlers/parallel.rs
+++ b/orch8-engine/src/handlers/parallel.rs
@@ -216,6 +216,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         };
@@ -240,6 +241,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }

--- a/orch8-engine/src/handlers/param_resolve.rs
+++ b/orch8-engine/src/handlers/param_resolve.rs
@@ -250,6 +250,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }

--- a/orch8-engine/src/handlers/query_instance.rs
+++ b/orch8-engine/src/handlers/query_instance.rs
@@ -135,6 +135,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }

--- a/orch8-engine/src/handlers/race.rs
+++ b/orch8-engine/src/handlers/race.rs
@@ -174,6 +174,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         };
@@ -198,6 +199,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }

--- a/orch8-engine/src/handlers/router.rs
+++ b/orch8-engine/src/handlers/router.rs
@@ -175,6 +175,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         };
@@ -345,6 +346,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }

--- a/orch8-engine/src/handlers/send_signal.rs
+++ b/orch8-engine/src/handlers/send_signal.rs
@@ -130,6 +130,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }

--- a/orch8-engine/src/handlers/step_block.rs
+++ b/orch8-engine/src/handlers/step_block.rs
@@ -654,6 +654,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         };
@@ -747,6 +748,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         };

--- a/orch8-engine/src/handlers/step_dispatch.rs
+++ b/orch8-engine/src/handlers/step_dispatch.rs
@@ -284,6 +284,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }

--- a/orch8-engine/src/handlers/try_catch.rs
+++ b/orch8-engine/src/handlers/try_catch.rs
@@ -206,6 +206,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         };
@@ -230,6 +231,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }

--- a/orch8-engine/src/interceptors.rs
+++ b/orch8-engine/src/interceptors.rs
@@ -141,6 +141,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         };

--- a/orch8-engine/src/lifecycle.rs
+++ b/orch8-engine/src/lifecycle.rs
@@ -163,6 +163,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }

--- a/orch8-engine/src/preload.rs
+++ b/orch8-engine/src/preload.rs
@@ -160,6 +160,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }

--- a/orch8-engine/src/recovery.rs
+++ b/orch8-engine/src/recovery.rs
@@ -120,6 +120,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: Utc::now() - chrono::Duration::seconds(600),
             updated_at: Utc::now() - chrono::Duration::seconds(600),
         };
@@ -193,6 +194,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };

--- a/orch8-engine/src/scheduler.rs
+++ b/orch8-engine/src/scheduler.rs
@@ -1020,6 +1020,13 @@ async fn process_instance(
         }
     }
 
+    // Budget enforcement: if the instance carries a budget and any configured
+    // limit is already exceeded, pause it (pre-flight — before any step work
+    // this tick). Instances without a budget take zero extra queries here.
+    if step_exec::check_budget(storage, &instance).await? {
+        return Ok(());
+    }
+
     // Merge dynamically injected blocks with the sequence definition.
     let blocks = crate::evaluator::merged_blocks(storage.as_ref(), instance.id, &sequence).await?;
 

--- a/orch8-engine/src/scheduler/step_exec.rs
+++ b/orch8-engine/src/scheduler/step_exec.rs
@@ -40,6 +40,78 @@ pub(super) async fn check_step_deadline(
     .await
 }
 
+/// Budget enforcement pre-flight: pause the instance if any configured
+/// budget limit is exceeded. Returns `true` if the instance was paused (the
+/// caller must skip step execution for this tick).
+///
+/// Cost model: instances without a budget short-circuit with zero extra
+/// queries; instances with only `max_steps` use the in-memory
+/// `context.runtime.total_steps_executed` counter (still zero queries);
+/// token limits cost one `usage_events` aggregate query.
+///
+/// On breach the instance is paused via the same `transition_instance`
+/// pattern as `check_human_input` (CAS Running -> Paused) and the
+/// machine-readable reason is merged into `metadata`:
+/// `{"paused_reason": "budget_exceeded", "budget_breach": {...}}`.
+/// Resume via the normal `Paused -> Scheduled` transition; see
+/// [`orch8_types::instance::Budget`] for the one-more-tick v1 semantics.
+pub(super) async fn check_budget(
+    storage: &Arc<dyn StorageBackend>,
+    instance: &orch8_types::instance::TaskInstance,
+) -> Result<bool, EngineError> {
+    let Some(budget) = &instance.budget else {
+        return Ok(false);
+    };
+
+    let steps = i64::from(instance.context.runtime.total_steps_executed);
+    // Only pay for the usage_events aggregate when a token limit is set.
+    let (input_tokens, output_tokens) = if budget.has_token_limits() {
+        storage.query_instance_usage_totals(instance.id).await?
+    } else {
+        (0, 0)
+    };
+
+    let Some(breach) = budget.first_breach(input_tokens, output_tokens, steps) else {
+        return Ok(false);
+    };
+
+    warn!(
+        instance_id = %instance.id,
+        limit = breach.limit,
+        limit_value = breach.limit_value,
+        actual = breach.actual,
+        "instance exceeded budget, pausing"
+    );
+
+    // Record the machine-readable reason BEFORE the state flip so an observer
+    // who sees Paused is guaranteed to also see the breach metadata.
+    storage
+        .merge_instance_metadata(
+            instance.id,
+            &serde_json::json!({
+                "paused_reason": "budget_exceeded",
+                "budget_breach": {
+                    "limit": breach.limit,
+                    "limit_value": breach.limit_value,
+                    "actual": breach.actual,
+                },
+            }),
+        )
+        .await?;
+
+    crate::lifecycle::transition_instance(
+        storage.as_ref(),
+        instance.id,
+        Some(&instance.tenant_id),
+        InstanceState::Running,
+        InstanceState::Paused,
+        None,
+    )
+    .await?;
+
+    Ok(true) // Paused — skip step execution this tick.
+}
+
 /// Check if the step has a delay and defer if so. Returns `true` if deferred.
 pub(super) async fn check_step_delay(
     storage: &dyn StorageBackend,

--- a/orch8-engine/src/scheduler/tests.rs
+++ b/orch8-engine/src/scheduler/tests.rs
@@ -117,6 +117,7 @@ async fn seed_instance_with_context(
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     };
@@ -482,6 +483,7 @@ async fn seed_instance_in_state(
         idempotency_key: None,
         session_id: None,
         parent_instance_id: parent,
+        budget: None,
         created_at: now,
         updated_at: now,
     };
@@ -736,6 +738,7 @@ async fn seed_instance_with_concurrency(
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     };

--- a/orch8-engine/src/signals.rs
+++ b/orch8-engine/src/signals.rs
@@ -446,6 +446,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }

--- a/orch8-engine/src/triggers.rs
+++ b/orch8-engine/src/triggers.rs
@@ -188,6 +188,7 @@ pub(crate) fn build_trigger_instance(
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     }

--- a/orch8-engine/tests/budget_coverage.rs
+++ b/orch8-engine/tests/budget_coverage.rs
@@ -1,0 +1,287 @@
+#![allow(clippy::items_after_statements)]
+//! E2E tests for budget-governed instances: token/step budgets enforced by
+//! the scheduler with pause-on-breach.
+//!
+//! Running only this file:
+//!
+//! ```text
+//! cargo test -p orch8-engine --test budget_coverage
+//! ```
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+
+use orch8_engine::handlers::HandlerRegistry;
+use orch8_engine::scheduler::tick_once;
+use orch8_storage::StorageBackend;
+use orch8_types::ids::{InstanceId, SequenceId};
+use orch8_types::instance::{Budget, InstanceState, TaskInstance};
+
+mod common;
+use common::*;
+
+async fn tick(storage: &Arc<dyn StorageBackend>, handlers: &Arc<HandlerRegistry>) {
+    let sem = semaphore(128);
+    let config = default_config();
+    let seq_cache = cache();
+    let cancel = CancellationToken::new();
+    tick_once(storage, handlers, &sem, &config, &seq_cache, &cancel)
+        .await
+        .unwrap();
+}
+
+fn mk_budgeted_instance(seq_id: SequenceId, budget: Budget) -> TaskInstance {
+    let mut inst = mk_instance_scheduled(seq_id, json!({}));
+    inst.budget = Some(budget);
+    inst
+}
+
+fn mk_usage_event(instance_id: InstanceId, input: i64, output: i64) -> orch8_storage::UsageEvent {
+    orch8_storage::UsageEvent {
+        tenant_id: "t".into(),
+        instance_id: Some(instance_id),
+        block_id: Some("s1".into()),
+        kind: "llm_tokens".into(),
+        model: "test-model".into(),
+        input_tokens: input,
+        output_tokens: output,
+        created_at: Utc::now(),
+    }
+}
+
+async fn fetch(storage: &Arc<dyn StorageBackend>, id: InstanceId) -> TaskInstance {
+    storage.get_instance(id).await.unwrap().unwrap()
+}
+
+/// Token budget exceeded before the tick: the scheduler pauses the instance
+/// with a machine-readable breach reason instead of executing steps.
+#[tokio::test]
+async fn budget_total_tokens_exceeded_pauses_instance_with_reason() {
+    let storage = storage().await;
+    let seq = mk_sequence(vec![mk_step("s1", "noop")]);
+    storage.create_sequence(&seq).await.unwrap();
+
+    let inst = mk_budgeted_instance(
+        seq.id,
+        Budget {
+            max_total_tokens: Some(100),
+            ..Budget::default()
+        },
+    );
+    storage.create_instance(&inst).await.unwrap();
+
+    // Recorded usage already exceeds the budget (60 + 50 = 110 > 100).
+    storage
+        .record_usage_event(&mk_usage_event(inst.id, 60, 50))
+        .await
+        .unwrap();
+
+    let handlers = Arc::new(registry());
+    tick(&storage, &handlers).await;
+
+    let fetched = fetch(&storage, inst.id).await;
+    assert_eq!(fetched.state, InstanceState::Paused);
+    assert_eq!(fetched.metadata["paused_reason"], "budget_exceeded");
+    assert_eq!(
+        fetched.metadata["budget_breach"]["limit"],
+        "max_total_tokens"
+    );
+    assert_eq!(fetched.metadata["budget_breach"]["limit_value"], 100);
+    assert_eq!(fetched.metadata["budget_breach"]["actual"], 110);
+
+    // No step output: the pause happened before any work this tick.
+    let outputs = storage.get_all_outputs(inst.id).await.unwrap();
+    assert!(outputs.is_empty(), "no steps should have executed");
+}
+
+/// Input-token limit breach reports the specific limit that tripped.
+#[tokio::test]
+async fn budget_input_tokens_exceeded_reports_input_limit() {
+    let storage = storage().await;
+    let seq = mk_sequence(vec![mk_step("s1", "noop")]);
+    storage.create_sequence(&seq).await.unwrap();
+
+    let inst = mk_budgeted_instance(
+        seq.id,
+        Budget {
+            max_input_tokens: Some(10),
+            ..Budget::default()
+        },
+    );
+    storage.create_instance(&inst).await.unwrap();
+    storage
+        .record_usage_event(&mk_usage_event(inst.id, 11, 0))
+        .await
+        .unwrap();
+
+    let handlers = Arc::new(registry());
+    tick(&storage, &handlers).await;
+
+    let fetched = fetch(&storage, inst.id).await;
+    assert_eq!(fetched.state, InstanceState::Paused);
+    assert_eq!(
+        fetched.metadata["budget_breach"]["limit"],
+        "max_input_tokens"
+    );
+}
+
+/// An instance with a budget that is NOT exceeded proceeds normally.
+#[tokio::test]
+async fn budget_within_limits_instance_completes_normally() {
+    let storage = storage().await;
+    let seq = mk_sequence(vec![mk_step("s1", "noop")]);
+    storage.create_sequence(&seq).await.unwrap();
+
+    let inst = mk_budgeted_instance(
+        seq.id,
+        Budget {
+            max_total_tokens: Some(1_000),
+            max_steps: Some(100),
+            ..Budget::default()
+        },
+    );
+    storage.create_instance(&inst).await.unwrap();
+    storage
+        .record_usage_event(&mk_usage_event(inst.id, 10, 10))
+        .await
+        .unwrap();
+
+    let handlers = Arc::new(registry());
+    tick(&storage, &handlers).await;
+
+    let fetched = fetch(&storage, inst.id).await;
+    assert_eq!(fetched.state, InstanceState::Completed);
+    assert!(fetched.metadata.get("paused_reason").is_none());
+}
+
+/// An instance without a budget is unaffected by recorded usage.
+#[tokio::test]
+async fn no_budget_instance_unaffected_by_heavy_usage() {
+    let storage = storage().await;
+    let seq = mk_sequence(vec![mk_step("s1", "noop")]);
+    storage.create_sequence(&seq).await.unwrap();
+
+    let inst = mk_instance_scheduled(seq.id, json!({}));
+    storage.create_instance(&inst).await.unwrap();
+    storage
+        .record_usage_event(&mk_usage_event(inst.id, 1_000_000, 1_000_000))
+        .await
+        .unwrap();
+
+    let handlers = Arc::new(registry());
+    tick(&storage, &handlers).await;
+
+    let fetched = fetch(&storage, inst.id).await;
+    assert_eq!(fetched.state, InstanceState::Completed);
+    assert!(fetched.metadata.get("paused_reason").is_none());
+}
+
+/// Step-count budget breach (no token limits configured — zero usage queries).
+#[tokio::test]
+async fn budget_max_steps_exceeded_pauses_instance() {
+    let storage = storage().await;
+    let seq = mk_sequence(vec![mk_step("s1", "noop"), mk_step("s2", "noop")]);
+    storage.create_sequence(&seq).await.unwrap();
+
+    let mut inst = mk_budgeted_instance(
+        seq.id,
+        Budget {
+            max_steps: Some(3),
+            ..Budget::default()
+        },
+    );
+    // Simulate prior ticks having executed 4 steps already.
+    inst.context.runtime.total_steps_executed = 4;
+    storage.create_instance(&inst).await.unwrap();
+
+    let handlers = Arc::new(registry());
+    tick(&storage, &handlers).await;
+
+    let fetched = fetch(&storage, inst.id).await;
+    assert_eq!(fetched.state, InstanceState::Paused);
+    assert_eq!(fetched.metadata["paused_reason"], "budget_exceeded");
+    assert_eq!(fetched.metadata["budget_breach"]["limit"], "max_steps");
+    assert_eq!(fetched.metadata["budget_breach"]["limit_value"], 3);
+    assert_eq!(fetched.metadata["budget_breach"]["actual"], 4);
+}
+
+/// Breach metadata merges into existing metadata instead of clobbering it.
+#[tokio::test]
+async fn budget_breach_preserves_existing_metadata() {
+    let storage = storage().await;
+    let seq = mk_sequence(vec![mk_step("s1", "noop")]);
+    storage.create_sequence(&seq).await.unwrap();
+
+    let mut inst = mk_budgeted_instance(
+        seq.id,
+        Budget {
+            max_output_tokens: Some(5),
+            ..Budget::default()
+        },
+    );
+    inst.metadata = json!({"owner": "alice"});
+    storage.create_instance(&inst).await.unwrap();
+    storage
+        .record_usage_event(&mk_usage_event(inst.id, 0, 6))
+        .await
+        .unwrap();
+
+    let handlers = Arc::new(registry());
+    tick(&storage, &handlers).await;
+
+    let fetched = fetch(&storage, inst.id).await;
+    assert_eq!(fetched.state, InstanceState::Paused);
+    assert_eq!(fetched.metadata["owner"], "alice");
+    assert_eq!(fetched.metadata["paused_reason"], "budget_exceeded");
+    assert_eq!(
+        fetched.metadata["budget_breach"]["limit"],
+        "max_output_tokens"
+    );
+}
+
+/// Resume semantics: a Paused -> Scheduled transition lets the instance run
+/// one more tick; if the budget is still exceeded it pauses again (no
+/// infinite loop — Paused instances leave the claim set).
+#[tokio::test]
+async fn resumed_instance_pauses_again_when_budget_still_exceeded() {
+    let storage = storage().await;
+    let seq = mk_sequence(vec![mk_step("s1", "noop")]);
+    storage.create_sequence(&seq).await.unwrap();
+
+    let inst = mk_budgeted_instance(
+        seq.id,
+        Budget {
+            max_total_tokens: Some(10),
+            ..Budget::default()
+        },
+    );
+    storage.create_instance(&inst).await.unwrap();
+    storage
+        .record_usage_event(&mk_usage_event(inst.id, 20, 0))
+        .await
+        .unwrap();
+
+    let handlers = Arc::new(registry());
+    tick(&storage, &handlers).await;
+    assert_eq!(fetch(&storage, inst.id).await.state, InstanceState::Paused);
+
+    // Resume via the existing Paused -> Scheduled transition.
+    storage
+        .update_instance_state(inst.id, InstanceState::Scheduled, Some(Utc::now()))
+        .await
+        .unwrap();
+
+    // The budget is still exceeded — the next tick pauses again.
+    tick(&storage, &handlers).await;
+    let fetched = fetch(&storage, inst.id).await;
+    assert_eq!(fetched.state, InstanceState::Paused);
+    assert_eq!(fetched.metadata["paused_reason"], "budget_exceeded");
+
+    // A further tick must not touch the paused instance (it is out of the
+    // claim set), so this is not an infinite pause/claim loop.
+    tick(&storage, &handlers).await;
+    assert_eq!(fetch(&storage, inst.id).await.state, InstanceState::Paused);
+}

--- a/orch8-engine/tests/cancellation_scope_coverage.rs
+++ b/orch8-engine/tests/cancellation_scope_coverage.rs
@@ -88,6 +88,7 @@ async fn setup(
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     };

--- a/orch8-engine/tests/common/mod.rs
+++ b/orch8-engine/tests/common/mod.rs
@@ -418,6 +418,7 @@ pub fn mk_instance_with_ctx(seq_id: SequenceId, data: Value) -> TaskInstance {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     }

--- a/orch8-engine/tests/engine_bugs_group_a.rs
+++ b/orch8-engine/tests/engine_bugs_group_a.rs
@@ -90,6 +90,7 @@ fn mk_instance(ctx_data: serde_json::Value, seq_id: SequenceId) -> TaskInstance 
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     }
@@ -2218,6 +2219,7 @@ async fn a15_workers_receive_fair_share_under_load() {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };

--- a/orch8-engine/tests/engine_bugs_group_b.rs
+++ b/orch8-engine/tests/engine_bugs_group_b.rs
@@ -99,6 +99,7 @@ fn mk_instance(seq_id: SequenceId) -> TaskInstance {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     }

--- a/orch8-engine/tests/engine_coverage.rs
+++ b/orch8-engine/tests/engine_coverage.rs
@@ -3884,6 +3884,7 @@ async fn sequence_config_accessible_in_steps() {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     };
@@ -3972,6 +3973,7 @@ async fn sequence_priority_ordering() {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     };

--- a/orch8-engine/tests/feature_gaps.rs
+++ b/orch8-engine/tests/feature_gaps.rs
@@ -71,6 +71,7 @@ fn mk_instance(seq_id: SequenceId) -> TaskInstance {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     }

--- a/orch8-engine/tests/flows_auto_test.rs
+++ b/orch8-engine/tests/flows_auto_test.rs
@@ -93,6 +93,7 @@ fn mk_instance(seq_id: SequenceId) -> TaskInstance {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     }

--- a/orch8-engine/tests/human_input_coverage.rs
+++ b/orch8-engine/tests/human_input_coverage.rs
@@ -94,6 +94,7 @@ async fn setup(step: StepDef) -> (SqliteStorage, TaskInstance, StepDef) {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     };

--- a/orch8-engine/tests/internals_coverage.rs
+++ b/orch8-engine/tests/internals_coverage.rs
@@ -119,6 +119,7 @@ async fn seed_instance(storage: &dyn StorageBackend, id: InstanceId) {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     };
@@ -148,6 +149,7 @@ fn mk_handler_instance(tenant: &str, state: InstanceState) -> TaskInstance {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     }
@@ -1501,6 +1503,7 @@ async fn recovery_83_stale_instance_recovered() {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now - chrono::Duration::seconds(600),
         updated_at: now - chrono::Duration::seconds(600),
     };
@@ -1534,6 +1537,7 @@ async fn recovery_84_fresh_instance_untouched() {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     };
@@ -1568,6 +1572,7 @@ async fn recovery_85_multiple_stale() {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now - chrono::Duration::seconds(600),
             updated_at: now - chrono::Duration::seconds(600),
         };

--- a/orch8-engine/tests/loop_for_each_coverage.rs
+++ b/orch8-engine/tests/loop_for_each_coverage.rs
@@ -92,6 +92,7 @@ async fn setup(
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     };

--- a/orch8-engine/tests/loop_in_foreach.rs
+++ b/orch8-engine/tests/loop_in_foreach.rs
@@ -105,6 +105,7 @@ fn mk_instance(seq_id: SequenceId, items: &serde_json::Value) -> TaskInstance {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     }

--- a/orch8-engine/tests/new_features_031.rs
+++ b/orch8-engine/tests/new_features_031.rs
@@ -352,6 +352,7 @@ async fn cache_key_serves_from_cache_on_second_instance() {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     };

--- a/orch8-engine/tests/race_parallel_coverage.rs
+++ b/orch8-engine/tests/race_parallel_coverage.rs
@@ -79,6 +79,7 @@ async fn setup(blocks: Vec<BlockDefinition>) -> (SqliteStorage, TaskInstance, Ve
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     };

--- a/orch8-engine/tests/router_coverage.rs
+++ b/orch8-engine/tests/router_coverage.rs
@@ -91,6 +91,7 @@ async fn setup(
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     };

--- a/orch8-engine/tests/try_catch_coverage.rs
+++ b/orch8-engine/tests/try_catch_coverage.rs
@@ -87,6 +87,7 @@ async fn setup(
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     };

--- a/orch8-mobile/src/lib.rs
+++ b/orch8-mobile/src/lib.rs
@@ -1559,6 +1559,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: chrono::Utc::now() - chrono::Duration::hours(48),
             updated_at: chrono::Utc::now() - chrono::Duration::hours(48),
         };

--- a/orch8-mobile/src/lifecycle.rs
+++ b/orch8-mobile/src/lifecycle.rs
@@ -129,6 +129,7 @@ impl InstanceLifecycleManager {
             idempotency_key: dedup_key.map(std::string::ToString::to_string),
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         };
@@ -608,6 +609,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: chrono::Utc::now() - chrono::Duration::hours(48),
             updated_at: chrono::Utc::now() - chrono::Duration::hours(48),
         };

--- a/orch8-server/src/bench.rs
+++ b/orch8-server/src/bench.rs
@@ -87,6 +87,7 @@ fn make_instances(count: usize, seq_id: SequenceId, tenant: &str) -> Vec<TaskIns
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         })

--- a/orch8-storage/benches/storage_bench.rs
+++ b/orch8-storage/benches/storage_bench.rs
@@ -68,6 +68,7 @@ fn make_instance(seq_id: SequenceId) -> TaskInstance {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     }

--- a/orch8-storage/src/artifacts.rs
+++ b/orch8-storage/src/artifacts.rs
@@ -343,6 +343,7 @@ mod tests {
                 idempotency_key: None,
                 session_id: None,
                 parent_instance_id: None,
+                budget: None,
                 created_at: now,
                 updated_at: now,
             }

--- a/orch8-storage/src/encrypting.rs
+++ b/orch8-storage/src/encrypting.rs
@@ -325,6 +325,15 @@ impl crate::InstanceStore for EncryptingStorage {
         )))
     }
 
+    async fn merge_instance_metadata(
+        &self,
+        id: InstanceId,
+        patch: &serde_json::Value,
+    ) -> Result<(), StorageError> {
+        // Metadata is never encrypted (only `context.data` is) — pure pass-through.
+        self.inner.merge_instance_metadata(id, patch).await
+    }
+
     async fn list_instances(
         &self,
         filter: &orch8_types::filter::InstanceFilter,
@@ -1462,6 +1471,12 @@ impl crate::TelemetryStore for EncryptingStorage {
         end: DateTime<Utc>,
     ) -> Result<Vec<crate::UsageAggregate>, StorageError> {
         self.inner.query_usage(tenant_id, start, end).await
+    }
+    async fn query_instance_usage_totals(
+        &self,
+        instance_id: InstanceId,
+    ) -> Result<(i64, i64), StorageError> {
+        self.inner.query_instance_usage_totals(instance_id).await
     }
 }
 

--- a/orch8-storage/src/lib.rs
+++ b/orch8-storage/src/lib.rs
@@ -393,6 +393,23 @@ pub trait InstanceStore: Send + Sync + 'static {
         value: &serde_json::Value,
     ) -> Result<(), StorageError>;
 
+    /// Shallow-merge `patch` into the instance's `metadata` JSON object.
+    ///
+    /// Existing keys not present in `patch` are preserved; keys present in
+    /// `patch` overwrite. Used by the scheduler's budget enforcement to record
+    /// `paused_reason` / `budget_breach` without clobbering caller-supplied
+    /// metadata.
+    ///
+    /// Every backend MUST implement this -- there is deliberately no default
+    /// impl so a missing implementation fails at compile time rather than
+    /// silently dropping the patch (same convention as
+    /// [`Self::record_or_get_emit_dedupe`]).
+    async fn merge_instance_metadata(
+        &self,
+        id: InstanceId,
+        patch: &serde_json::Value,
+    ) -> Result<(), StorageError>;
+
     async fn list_instances(
         &self,
         filter: &InstanceFilter,
@@ -1480,6 +1497,19 @@ pub trait TelemetryStore: Send + Sync + 'static {
         _end: DateTime<Utc>,
     ) -> Result<Vec<UsageAggregate>, StorageError> {
         Ok(Vec::new())
+    }
+
+    /// Sum recorded usage for a single instance across all `usage_events`
+    /// rows. Returns `(input_tokens, output_tokens)`.
+    ///
+    /// Used by the scheduler's budget enforcement — only called for instances
+    /// that actually carry a token budget, so backends without usage tracking
+    /// can keep the default `(0, 0)` (a budgetless deployment never breaches).
+    async fn query_instance_usage_totals(
+        &self,
+        _instance_id: InstanceId,
+    ) -> Result<(i64, i64), StorageError> {
+        Ok((0, 0))
     }
 }
 

--- a/orch8-storage/src/postgres/instances.rs
+++ b/orch8-storage/src/postgres/instances.rs
@@ -20,9 +20,9 @@ pub(super) const INSTANCE_INSERT_SQL: &str = r"
         (id, sequence_id, tenant_id, namespace, state, next_fire_at,
          priority, timezone, metadata, context,
          concurrency_key, max_concurrency, idempotency_key,
-         session_id, parent_instance_id,
+         session_id, parent_instance_id, budget,
          created_at, updated_at)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
 ";
 
 /// Bind a `TaskInstance` to an already-prepared query in the canonical column
@@ -50,6 +50,11 @@ pub(super) fn bind_instance_insert<'q>(
         .bind(
             inst.parent_instance_id
                 .map(orch8_types::InstanceId::into_uuid),
+        )
+        .bind(
+            inst.budget
+                .as_ref()
+                .and_then(|b| serde_json::to_value(b).ok()),
         )
         .bind(inst.created_at)
         .bind(inst.updated_at)
@@ -83,7 +88,7 @@ pub(super) async fn create_batch(
                 (id, sequence_id, tenant_id, namespace, state, next_fire_at,
                  priority, timezone, metadata, context,
                  concurrency_key, max_concurrency, idempotency_key,
-                 session_id, parent_instance_id,
+                 session_id, parent_instance_id, budget,
                  created_at, updated_at) ",
         );
         qb.push_values(chunk, |mut b, inst| {
@@ -107,6 +112,11 @@ pub(super) async fn create_batch(
                     inst.parent_instance_id
                         .map(orch8_types::InstanceId::into_uuid),
                 )
+                .push_bind(
+                    inst.budget
+                        .as_ref()
+                        .and_then(|b| serde_json::to_value(b).ok()),
+                )
                 .push_bind(inst.created_at)
                 .push_bind(inst.updated_at);
         });
@@ -126,7 +136,7 @@ pub(super) async fn get(
         r"SELECT id, sequence_id, tenant_id, namespace, state, next_fire_at,
                   priority, timezone, metadata, context,
                   concurrency_key, max_concurrency, idempotency_key,
-                  session_id, parent_instance_id, created_at, updated_at
+                  session_id, parent_instance_id, budget, created_at, updated_at
            FROM task_instances WHERE id = $1",
     )
     .bind(id.into_uuid())
@@ -590,7 +600,7 @@ pub(super) async fn create_batch_externalized(
                 (id, sequence_id, tenant_id, namespace, state, next_fire_at,
                  priority, timezone, metadata, context,
                  concurrency_key, max_concurrency, idempotency_key,
-                 session_id, parent_instance_id,
+                 session_id, parent_instance_id, budget,
                  created_at, updated_at) ",
         );
         qb.push_values(chunk, |mut b, (inst, _)| {
@@ -613,6 +623,11 @@ pub(super) async fn create_batch_externalized(
                 .push_bind(
                     inst.parent_instance_id
                         .map(orch8_types::InstanceId::into_uuid),
+                )
+                .push_bind(
+                    inst.budget
+                        .as_ref()
+                        .and_then(|b| serde_json::to_value(b).ok()),
                 )
                 .push_bind(inst.created_at)
                 .push_bind(inst.updated_at);
@@ -732,6 +747,27 @@ pub(super) async fn merge_context_data(
     Ok(())
 }
 
+/// Shallow-merge `patch` into the instance's `metadata` JSONB object (`||`
+/// concatenation — top-level keys in `patch` overwrite, others are
+/// preserved). See [`crate::InstanceStore::merge_instance_metadata`].
+pub(super) async fn merge_metadata(
+    store: &PostgresStorage,
+    id: InstanceId,
+    patch: &serde_json::Value,
+) -> Result<(), StorageError> {
+    sqlx::query(
+        r"UPDATE task_instances
+          SET metadata = COALESCE(metadata, '{}'::jsonb) || $2,
+              updated_at = NOW()
+          WHERE id = $1",
+    )
+    .bind(id.into_uuid())
+    .bind(patch)
+    .execute(&store.pool)
+    .await?;
+    Ok(())
+}
+
 pub(super) async fn list(
     store: &PostgresStorage,
     filter: &InstanceFilter,
@@ -741,7 +777,7 @@ pub(super) async fn list(
         r"SELECT id, sequence_id, tenant_id, namespace, state, next_fire_at,
                   priority, timezone, metadata, context,
                   concurrency_key, max_concurrency, idempotency_key,
-                  session_id, parent_instance_id, created_at, updated_at
+                  session_id, parent_instance_id, budget, created_at, updated_at
            FROM task_instances WHERE 1=1",
     );
     apply_instance_filter(&mut qb, filter);

--- a/orch8-storage/src/postgres/misc.rs
+++ b/orch8-storage/src/postgres/misc.rs
@@ -19,7 +19,7 @@ pub(super) async fn find_by_idempotency_key(
         r"SELECT id, sequence_id, tenant_id, namespace, state, next_fire_at,
                   priority, timezone, metadata, context,
                   concurrency_key, max_concurrency, idempotency_key,
-                  session_id, parent_instance_id, created_at, updated_at
+                  session_id, parent_instance_id, budget, created_at, updated_at
            FROM task_instances
            WHERE tenant_id = $1 AND idempotency_key = $2",
     )
@@ -119,7 +119,7 @@ pub(super) async fn get_child_instances(
         r"SELECT id, sequence_id, tenant_id, namespace, state, next_fire_at,
                   priority, timezone, metadata, context,
                   concurrency_key, max_concurrency, idempotency_key,
-                  session_id, parent_instance_id, created_at, updated_at
+                  session_id, parent_instance_id, budget, created_at, updated_at
            FROM task_instances WHERE parent_instance_id = $1 ORDER BY created_at",
     )
     .bind(parent_instance_id.into_uuid())

--- a/orch8-storage/src/postgres/mod.rs
+++ b/orch8-storage/src/postgres/mod.rs
@@ -330,6 +330,14 @@ impl crate::InstanceStore for PostgresStorage {
         instances::merge_context_data(self, id, key, value).await
     }
 
+    async fn merge_instance_metadata(
+        &self,
+        id: InstanceId,
+        patch: &serde_json::Value,
+    ) -> Result<(), StorageError> {
+        instances::merge_metadata(self, id, patch).await
+    }
+
     async fn list_instances(
         &self,
         filter: &InstanceFilter,
@@ -1574,6 +1582,23 @@ impl crate::TelemetryStore for PostgresStorage {
                 output_tokens: r.get("output_tokens"),
             })
             .collect())
+    }
+
+    async fn query_instance_usage_totals(
+        &self,
+        instance_id: InstanceId,
+    ) -> Result<(i64, i64), StorageError> {
+        use sqlx::Row;
+        // SUM(bigint) is NUMERIC in Postgres — cast back to BIGINT for i64 decode.
+        let row = sqlx::query(
+            r"SELECT COALESCE(SUM(input_tokens), 0)::BIGINT AS input_tokens,
+                     COALESCE(SUM(output_tokens), 0)::BIGINT AS output_tokens
+              FROM usage_events WHERE instance_id = $1",
+        )
+        .bind(instance_id.into_uuid())
+        .fetch_one(&self.pool)
+        .await?;
+        Ok((row.get("input_tokens"), row.get("output_tokens")))
     }
 
     async fn ingest_telemetry_events_batch(

--- a/orch8-storage/src/postgres/rows.rs
+++ b/orch8-storage/src/postgres/rows.rs
@@ -81,6 +81,7 @@ pub(super) struct InstanceRow {
     pub idempotency_key: Option<String>,
     pub session_id: Option<Uuid>,
     pub parent_instance_id: Option<Uuid>,
+    pub budget: Option<serde_json::Value>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -90,6 +91,7 @@ impl InstanceRow {
         let state = InstanceState::from_str(&self.state).map_err(StorageError::Query)?;
         let priority = Priority::try_from(self.priority).unwrap_or(Priority::Normal);
         let context = serde_json::from_value(self.context)?;
+        let budget = self.budget.map(serde_json::from_value).transpose()?;
 
         Ok(TaskInstance {
             id: InstanceId::from_uuid(self.id),
@@ -107,6 +109,7 @@ impl InstanceRow {
             idempotency_key: self.idempotency_key,
             session_id: self.session_id,
             parent_instance_id: self.parent_instance_id.map(InstanceId::from_uuid),
+            budget,
             created_at: self.created_at,
             updated_at: self.updated_at,
         })

--- a/orch8-storage/src/postgres/sessions.rs
+++ b/orch8-storage/src/postgres/sessions.rs
@@ -92,7 +92,7 @@ pub(super) async fn list_instances(
         r"SELECT id, sequence_id, tenant_id, namespace, state, next_fire_at,
                   priority, timezone, metadata, context,
                   concurrency_key, max_concurrency, idempotency_key,
-                  session_id, parent_instance_id, created_at, updated_at
+                  session_id, parent_instance_id, budget, created_at, updated_at
            FROM task_instances WHERE session_id = $1 ORDER BY created_at",
     )
     .bind(session_id)

--- a/orch8-storage/src/sqlite/helpers.rs
+++ b/orch8-storage/src/sqlite/helpers.rs
@@ -81,6 +81,11 @@ pub(super) fn row_to_instance(row: &sqlx::sqlite::SqliteRow) -> Result<TaskInsta
             .get::<Option<String>, _>("parent_instance_id")
             .and_then(|s| Uuid::parse_str(&s).ok())
             .map(InstanceId::from_uuid),
+        budget: row
+            .get::<Option<String>, _>("budget")
+            .as_deref()
+            .map(parse_json)
+            .transpose()?,
         created_at: parse_ts(row.get::<&str, _>("created_at"))?,
         updated_at: parse_ts(row.get::<&str, _>("updated_at"))?,
     })

--- a/orch8-storage/src/sqlite/instances.rs
+++ b/orch8-storage/src/sqlite/instances.rs
@@ -18,7 +18,7 @@ use super::SqliteStorage;
 /// insert sites (`create`, `create_batch`, `create_externalized`,
 /// `create_batch_externalized`, `create_instance_with_dedupe`) bind against
 /// this string via [`bind_instance_insert`].
-pub(super) const INSTANCE_INSERT_SQL: &str = "INSERT INTO task_instances (id,sequence_id,tenant_id,namespace,state,next_fire_at,priority,timezone,metadata,context,concurrency_key,max_concurrency,idempotency_key,session_id,parent_instance_id,created_at,updated_at) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17)";
+pub(super) const INSTANCE_INSERT_SQL: &str = "INSERT INTO task_instances (id,sequence_id,tenant_id,namespace,state,next_fire_at,priority,timezone,metadata,context,concurrency_key,max_concurrency,idempotency_key,session_id,parent_instance_id,budget,created_at,updated_at) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18)";
 
 /// Bind a `TaskInstance` to an already-prepared query in the canonical column
 /// order used by [`INSTANCE_INSERT_SQL`]. Kept out of `sqlx::query(...)` so
@@ -43,6 +43,7 @@ pub(super) fn bind_instance_insert<'q>(
         .bind(&i.idempotency_key)
         .bind(i.session_id.map(|u| u.to_string()))
         .bind(i.parent_instance_id.map(|u| u.into_uuid().to_string()))
+        .bind(i.budget.as_ref().map(serde_json::to_string).transpose()?)
         .bind(ts(i.created_at))
         .bind(ts(i.updated_at)))
 }
@@ -67,11 +68,15 @@ pub(super) async fn create_batch(
 
     for chunk in instances.chunks(500) {
         let mut qb = sqlx::QueryBuilder::new(
-            "INSERT INTO task_instances (id,sequence_id,tenant_id,namespace,state,next_fire_at,priority,timezone,metadata,context,concurrency_key,max_concurrency,idempotency_key,session_id,parent_instance_id,created_at,updated_at) ",
+            "INSERT INTO task_instances (id,sequence_id,tenant_id,namespace,state,next_fire_at,priority,timezone,metadata,context,concurrency_key,max_concurrency,idempotency_key,session_id,parent_instance_id,budget,created_at,updated_at) ",
         );
         qb.push_values(chunk, |mut b, i| {
             let metadata = serde_json::to_string(&i.metadata).unwrap_or_else(|_| "{}".to_string());
             let context = serde_json::to_string(&i.context).unwrap_or_else(|_| "{}".to_string());
+            let budget = i
+                .budget
+                .as_ref()
+                .and_then(|bd| serde_json::to_string(bd).ok());
             b.push_bind(i.id.into_uuid().to_string())
                 .push_bind(i.sequence_id.into_uuid().to_string())
                 .push_bind(i.tenant_id.as_str())
@@ -87,6 +92,7 @@ pub(super) async fn create_batch(
                 .push_bind(&i.idempotency_key)
                 .push_bind(i.session_id.map(|u| u.to_string()))
                 .push_bind(i.parent_instance_id.map(|u| u.into_uuid().to_string()))
+                .push_bind(budget)
                 .push_bind(ts(i.created_at))
                 .push_bind(ts(i.updated_at));
         });
@@ -629,6 +635,27 @@ pub(super) async fn merge_context_data(
             .await?;
     }
     tx.commit().await?;
+    Ok(())
+}
+
+/// Shallow-merge `patch` into the instance's `metadata` object using SQLite's
+/// `json_patch` (RFC 7386 merge — top-level keys in `patch` overwrite, others
+/// are preserved). See [`crate::InstanceStore::merge_instance_metadata`].
+pub(super) async fn merge_metadata(
+    storage: &SqliteStorage,
+    id: InstanceId,
+    patch: &serde_json::Value,
+) -> Result<(), StorageError> {
+    sqlx::query(
+        "UPDATE task_instances \
+         SET metadata = json_patch(coalesce(metadata, '{}'), ?2), updated_at = ?3 \
+         WHERE id = ?1",
+    )
+    .bind(id.to_string())
+    .bind(serde_json::to_string(patch)?)
+    .bind(ts(Utc::now()))
+    .execute(&storage.pool)
+    .await?;
     Ok(())
 }
 

--- a/orch8-storage/src/sqlite/mod.rs
+++ b/orch8-storage/src/sqlite/mod.rs
@@ -413,6 +413,14 @@ impl crate::InstanceStore for SqliteStorage {
         instances::merge_context_data(self, id, key, value).await
     }
 
+    async fn merge_instance_metadata(
+        &self,
+        id: InstanceId,
+        patch: &serde_json::Value,
+    ) -> Result<(), StorageError> {
+        instances::merge_metadata(self, id, patch).await
+    }
+
     async fn list_instances(
         &self,
         filter: &InstanceFilter,
@@ -1756,6 +1764,22 @@ impl crate::TelemetryStore for SqliteStorage {
             .collect())
     }
 
+    async fn query_instance_usage_totals(
+        &self,
+        instance_id: InstanceId,
+    ) -> Result<(i64, i64), StorageError> {
+        use sqlx::Row;
+        let row = sqlx::query(
+            "SELECT COALESCE(SUM(input_tokens), 0) AS input_tokens, \
+                    COALESCE(SUM(output_tokens), 0) AS output_tokens \
+             FROM usage_events WHERE instance_id = ?1",
+        )
+        .bind(instance_id.to_string())
+        .fetch_one(self.pool())
+        .await?;
+        Ok((row.get("input_tokens"), row.get("output_tokens")))
+    }
+
     async fn ingest_telemetry_events_batch(
         &self,
         events: &[crate::TelemetryEvent],
@@ -2788,6 +2812,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         };
@@ -2817,6 +2842,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         };
@@ -3021,6 +3047,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         }
@@ -3448,6 +3475,7 @@ mod tests {
             idempotency_key: None,
             session_id: None,
             parent_instance_id: None,
+            budget: None,
             created_at: now,
             updated_at: now,
         };

--- a/orch8-storage/src/sqlite/schema.rs
+++ b/orch8-storage/src/sqlite/schema.rs
@@ -28,6 +28,7 @@ CREATE TABLE IF NOT EXISTS task_instances (
     idempotency_key TEXT,
     session_id TEXT,
     parent_instance_id TEXT,
+    budget TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );
@@ -468,4 +469,4 @@ CREATE INDEX IF NOT EXISTS idx_api_keys_tenant ON api_keys(tenant_id);
 /// Current bundled schema version. Bump when the `SCHEMA` string above is
 /// edited in a non-idempotent way (e.g. adding a new column whose default
 /// matters for code that reads the column).
-pub(super) const SCHEMA_VERSION: i64 = 7;
+pub(super) const SCHEMA_VERSION: i64 = 8;

--- a/orch8-storage/tests/bugs_group_b.rs
+++ b/orch8-storage/tests/bugs_group_b.rs
@@ -57,6 +57,7 @@ fn make_instance(
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     }

--- a/orch8-storage/tests/encrypting_coverage.rs
+++ b/orch8-storage/tests/encrypting_coverage.rs
@@ -50,6 +50,7 @@ fn mk_instance(tenant: &str, data: serde_json::Value) -> TaskInstance {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     }

--- a/orch8-storage/tests/encryption_e2e.rs
+++ b/orch8-storage/tests/encryption_e2e.rs
@@ -68,6 +68,7 @@ fn make_instance(seq_id: SequenceId) -> TaskInstance {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     }

--- a/orch8-storage/tests/storage_coverage.rs
+++ b/orch8-storage/tests/storage_coverage.rs
@@ -95,6 +95,7 @@ fn make_instance(tenant: &str, seq_id: SequenceId) -> TaskInstance {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     }
@@ -2012,4 +2013,138 @@ async fn t90_storage_handles_empty_string_fields() {
     assert_eq!(fetched.metadata["nested"]["empty"], "");
     assert_eq!(fetched.context.data["empty_field"], "");
     assert_eq!(fetched.context.data["array"], json!([]));
+}
+
+// ---------------------------------------------------------------------------
+// Budget-governed instances (feature: instance budgets)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn t91_budget_column_round_trips() {
+    let s = store().await;
+    let seq = make_sequence("t");
+    s.create_sequence(&seq).await.unwrap();
+
+    let mut inst = make_instance("t", seq.id);
+    inst.budget = Some(orch8_types::instance::Budget {
+        max_input_tokens: Some(1_000),
+        max_output_tokens: None,
+        max_total_tokens: Some(5_000),
+        max_steps: Some(7),
+    });
+    s.create_instance(&inst).await.unwrap();
+
+    let fetched = s.get_instance(inst.id).await.unwrap().unwrap();
+    let budget = fetched.budget.expect("budget persisted");
+    assert_eq!(budget.max_input_tokens, Some(1_000));
+    assert_eq!(budget.max_output_tokens, None);
+    assert_eq!(budget.max_total_tokens, Some(5_000));
+    assert_eq!(budget.max_steps, Some(7));
+}
+
+#[tokio::test]
+async fn t92_budget_absent_reads_back_as_none() {
+    let s = store().await;
+    let seq = make_sequence("t");
+    s.create_sequence(&seq).await.unwrap();
+
+    let inst = make_instance("t", seq.id);
+    s.create_instance(&inst).await.unwrap();
+
+    let fetched = s.get_instance(inst.id).await.unwrap().unwrap();
+    assert!(fetched.budget.is_none());
+}
+
+#[tokio::test]
+async fn t93_budget_round_trips_through_batch_create_and_list() {
+    let s = store().await;
+    let seq = make_sequence("t");
+    s.create_sequence(&seq).await.unwrap();
+
+    let mut with_budget = make_instance("t", seq.id);
+    with_budget.budget = Some(orch8_types::instance::Budget {
+        max_steps: Some(3),
+        ..Default::default()
+    });
+    let without_budget = make_instance("t", seq.id);
+    s.create_instances_batch(&[with_budget.clone(), without_budget.clone()])
+        .await
+        .unwrap();
+
+    let fetched = s.get_instance(with_budget.id).await.unwrap().unwrap();
+    assert_eq!(fetched.budget.unwrap().max_steps, Some(3));
+    let fetched = s.get_instance(without_budget.id).await.unwrap().unwrap();
+    assert!(fetched.budget.is_none());
+}
+
+#[tokio::test]
+async fn t94_merge_instance_metadata_preserves_existing_keys() {
+    let s = store().await;
+    let seq = make_sequence("t");
+    s.create_sequence(&seq).await.unwrap();
+
+    let mut inst = make_instance("t", seq.id);
+    inst.metadata = json!({"owner": "alice", "env": "prod"});
+    s.create_instance(&inst).await.unwrap();
+
+    s.merge_instance_metadata(
+        inst.id,
+        &json!({
+            "paused_reason": "budget_exceeded",
+            "budget_breach": {"limit": "max_steps", "limit_value": 3, "actual": 4},
+        }),
+    )
+    .await
+    .unwrap();
+
+    let fetched = s.get_instance(inst.id).await.unwrap().unwrap();
+    assert_eq!(fetched.metadata["owner"], "alice");
+    assert_eq!(fetched.metadata["env"], "prod");
+    assert_eq!(fetched.metadata["paused_reason"], "budget_exceeded");
+    assert_eq!(fetched.metadata["budget_breach"]["limit"], "max_steps");
+    assert_eq!(fetched.metadata["budget_breach"]["actual"], 4);
+}
+
+#[tokio::test]
+async fn t95_query_instance_usage_totals_sums_per_instance() {
+    use orch8_storage::TelemetryStore;
+
+    let s = store().await;
+    let seq = make_sequence("t");
+    s.create_sequence(&seq).await.unwrap();
+    let inst = make_instance("t", seq.id);
+    s.create_instance(&inst).await.unwrap();
+    let other = make_instance("t", seq.id);
+    s.create_instance(&other).await.unwrap();
+
+    let mk_event = |instance_id, input, output| orch8_storage::UsageEvent {
+        tenant_id: "t".into(),
+        instance_id: Some(instance_id),
+        block_id: Some("s1".into()),
+        kind: "llm_tokens".into(),
+        model: "test-model".into(),
+        input_tokens: input,
+        output_tokens: output,
+        created_at: Utc::now(),
+    };
+    s.record_usage_event(&mk_event(inst.id, 100, 40))
+        .await
+        .unwrap();
+    s.record_usage_event(&mk_event(inst.id, 25, 10))
+        .await
+        .unwrap();
+    // Another instance's usage must not bleed into the totals.
+    s.record_usage_event(&mk_event(other.id, 999, 999))
+        .await
+        .unwrap();
+
+    let (input, output) = s.query_instance_usage_totals(inst.id).await.unwrap();
+    assert_eq!(input, 125);
+    assert_eq!(output, 50);
+
+    // Instance with no usage rows sums to zero.
+    let empty = make_instance("t", seq.id);
+    s.create_instance(&empty).await.unwrap();
+    let (input, output) = s.query_instance_usage_totals(empty.id).await.unwrap();
+    assert_eq!((input, output), (0, 0));
 }

--- a/orch8-storage/tests/storage_integration.rs
+++ b/orch8-storage/tests/storage_integration.rs
@@ -98,6 +98,7 @@ fn make_instance(tenant: &str, seq_id: SequenceId) -> TaskInstance {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: now,
         updated_at: now,
     }

--- a/orch8-types/src/instance.rs
+++ b/orch8-types/src/instance.rs
@@ -144,6 +144,90 @@ impl TryFrom<i16> for Priority {
     }
 }
 
+/// A single budget breach detected by [`Budget::first_breach`].
+///
+/// `limit` names the breached field (e.g. `"max_total_tokens"`), `limit_value`
+/// is the configured cap and `actual` the observed consumption.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BudgetBreach {
+    /// Name of the breached limit field (e.g. `"max_input_tokens"`).
+    pub limit: &'static str,
+    /// The configured limit value.
+    pub limit_value: i64,
+    /// The actual observed value that exceeded the limit.
+    pub actual: i64,
+}
+
+/// Optional per-instance resource budget enforced by the scheduler.
+///
+/// When any configured limit is exceeded (recorded LLM token usage or
+/// executed step count), the scheduler pauses the instance with
+/// `metadata.paused_reason = "budget_exceeded"` instead of letting it keep
+/// spending. Resume via the normal `Paused -> Scheduled` transition.
+///
+/// v1 semantics: the budget is checked when the scheduler claims the
+/// instance, *before* executing work for that tick. A resumed instance
+/// therefore gets one more tick of work before the check fires again; if the
+/// budget is still exceeded it pauses again on the next claim. A single
+/// tick's work may also overshoot the limit slightly (the check is
+/// pre-flight, not mid-step).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct Budget {
+    /// Max total LLM input (prompt) tokens recorded for this instance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_input_tokens: Option<i64>,
+    /// Max total LLM output (completion) tokens recorded for this instance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_output_tokens: Option<i64>,
+    /// Max combined (input + output) LLM tokens recorded for this instance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_total_tokens: Option<i64>,
+    /// Max executed steps (`context.runtime.total_steps_executed`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_steps: Option<i64>,
+}
+
+impl Budget {
+    /// True if any token-based limit is configured (callers can skip the
+    /// usage-totals query entirely when this is false).
+    #[must_use]
+    pub const fn has_token_limits(&self) -> bool {
+        self.max_input_tokens.is_some()
+            || self.max_output_tokens.is_some()
+            || self.max_total_tokens.is_some()
+    }
+
+    /// Return the first configured limit exceeded by the observed usage, or
+    /// `None` when the instance is within budget. A limit is breached when
+    /// the actual value is strictly greater than the configured cap.
+    #[must_use]
+    pub fn first_breach(
+        &self,
+        input_tokens: i64,
+        output_tokens: i64,
+        steps: i64,
+    ) -> Option<BudgetBreach> {
+        let checks = [
+            ("max_input_tokens", self.max_input_tokens, input_tokens),
+            ("max_output_tokens", self.max_output_tokens, output_tokens),
+            (
+                "max_total_tokens",
+                self.max_total_tokens,
+                input_tokens.saturating_add(output_tokens),
+            ),
+            ("max_steps", self.max_steps, steps),
+        ];
+        checks.into_iter().find_map(|(limit, cap, actual)| {
+            cap.filter(|&limit_value| actual > limit_value)
+                .map(|limit_value| BudgetBreach {
+                    limit,
+                    limit_value,
+                    actual,
+                })
+        })
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct TaskInstance {
     pub id: InstanceId,
@@ -171,6 +255,9 @@ pub struct TaskInstance {
     /// Parent instance ID (set when this instance is a sub-sequence child).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_instance_id: Option<InstanceId>,
+    /// Optional resource budget enforced by the scheduler (see [`Budget`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget: Option<Budget>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -313,6 +400,132 @@ mod tests {
                 "Cancelled -> {target:?} must be invalid"
             );
         }
+    }
+
+    // --- Budget ---
+
+    #[test]
+    fn budget_serde_round_trip() {
+        let budget = Budget {
+            max_input_tokens: Some(1_000),
+            max_output_tokens: None,
+            max_total_tokens: Some(5_000),
+            max_steps: Some(10),
+        };
+        let json = serde_json::to_string(&budget).unwrap();
+        let back: Budget = serde_json::from_str(&json).unwrap();
+        assert_eq!(budget, back);
+        // Unset fields are skipped entirely, not serialized as null.
+        assert!(!json.contains("max_output_tokens"), "got: {json}");
+    }
+
+    #[test]
+    fn budget_deserializes_from_empty_object() {
+        let budget: Budget = serde_json::from_str("{}").unwrap();
+        assert_eq!(budget, Budget::default());
+        assert!(!budget.has_token_limits());
+    }
+
+    #[test]
+    fn task_instance_json_without_budget_field_deserializes() {
+        // JSON produced before the budget field existed must still load.
+        let json = serde_json::json!({
+            "id": uuid::Uuid::now_v7(),
+            "sequence_id": uuid::Uuid::now_v7(),
+            "tenant_id": "t1",
+            "namespace": "ns",
+            "state": "scheduled",
+            "next_fire_at": null,
+            "priority": "Normal",
+            "timezone": "UTC",
+            "metadata": {},
+            "context": { "data": {}, "config": {}, "audit": [] },
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+        });
+        let inst: TaskInstance = serde_json::from_value(json).unwrap();
+        assert!(inst.budget.is_none());
+    }
+
+    #[test]
+    fn task_instance_budget_round_trips_through_json() {
+        let json = serde_json::json!({
+            "id": uuid::Uuid::now_v7(),
+            "sequence_id": uuid::Uuid::now_v7(),
+            "tenant_id": "t1",
+            "namespace": "ns",
+            "state": "scheduled",
+            "next_fire_at": null,
+            "priority": "Normal",
+            "timezone": "UTC",
+            "metadata": {},
+            "context": { "data": {}, "config": {}, "audit": [] },
+            "budget": { "max_total_tokens": 100 },
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+        });
+        let inst: TaskInstance = serde_json::from_value(json).unwrap();
+        let budget = inst.budget.as_ref().expect("budget present");
+        assert_eq!(budget.max_total_tokens, Some(100));
+        let back = serde_json::to_value(&inst).unwrap();
+        assert_eq!(back["budget"]["max_total_tokens"], 100);
+    }
+
+    #[test]
+    fn budget_first_breach_within_limits_is_none() {
+        let budget = Budget {
+            max_input_tokens: Some(100),
+            max_output_tokens: Some(100),
+            max_total_tokens: Some(200),
+            max_steps: Some(5),
+        };
+        assert_eq!(budget.first_breach(100, 100, 5), None);
+    }
+
+    #[test]
+    fn budget_first_breach_reports_each_limit() {
+        let input_breach = Budget {
+            max_input_tokens: Some(10),
+            ..Budget::default()
+        }
+        .first_breach(11, 0, 0)
+        .unwrap();
+        assert_eq!(input_breach.limit, "max_input_tokens");
+        assert_eq!(input_breach.limit_value, 10);
+        assert_eq!(input_breach.actual, 11);
+
+        let output_breach = Budget {
+            max_output_tokens: Some(10),
+            ..Budget::default()
+        }
+        .first_breach(0, 11, 0)
+        .unwrap();
+        assert_eq!(output_breach.limit, "max_output_tokens");
+
+        let total_breach = Budget {
+            max_total_tokens: Some(10),
+            ..Budget::default()
+        }
+        .first_breach(6, 6, 0)
+        .unwrap();
+        assert_eq!(total_breach.limit, "max_total_tokens");
+        assert_eq!(total_breach.actual, 12);
+
+        let steps_breach = Budget {
+            max_steps: Some(3),
+            ..Budget::default()
+        }
+        .first_breach(0, 0, 4)
+        .unwrap();
+        assert_eq!(steps_breach.limit, "max_steps");
+    }
+
+    #[test]
+    fn budget_with_no_limits_never_breaches() {
+        assert_eq!(
+            Budget::default().first_breach(i64::MAX, i64::MAX, i64::MAX),
+            None
+        );
     }
 
     #[test]

--- a/orch8-types/src/lib.rs
+++ b/orch8-types/src/lib.rs
@@ -34,7 +34,7 @@ pub mod worker_filter;
 pub use config::{EngineConfig, SecretString};
 pub use error::{StepError, StorageError};
 pub use ids::*;
-pub use instance::{InstanceState, Priority, TaskInstance};
+pub use instance::{Budget, BudgetBreach, InstanceState, Priority, TaskInstance};
 
 /// Shared serde default value functions used across types.
 pub mod serde_defaults {

--- a/orch8-types/tests/types_coverage_extra.rs
+++ b/orch8-types/tests/types_coverage_extra.rs
@@ -508,6 +508,7 @@ fn inst_46_task_instance_serde_round_trip_all_fields() {
         idempotency_key: Some("idem-123".into()),
         session_id: Some(Uuid::now_v7()),
         parent_instance_id: Some(InstanceId::new()),
+        budget: None,
         created_at: Utc::now(),
         updated_at: Utc::now(),
     };
@@ -543,6 +544,7 @@ fn inst_47_task_instance_optional_fields_none() {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: Utc::now(),
         updated_at: Utc::now(),
     };
@@ -572,6 +574,7 @@ fn inst_48_task_instance_metadata_json() {
         idempotency_key: None,
         session_id: None,
         parent_instance_id: None,
+        budget: None,
         created_at: Utc::now(),
         updated_at: Utc::now(),
     };


### PR DESCRIPTION
## Summary
An instance can now carry an optional `Budget` (`max_input_tokens`, `max_output_tokens`, `max_total_tokens`, `max_steps`). On each scheduler claim, if recorded LLM token usage (from `usage_events`) or executed step count exceeds any configured limit, the instance is paused instead of continuing to spend:
- Pause mimics the `check_human_input` pattern (Running→Paused), with `metadata.paused_reason = "budget_exceeded"` and a `budget_breach` object (`limit`, `limit_value`, `actual`) written *before* the transition, plus a `tracing::warn!`.
- Resume via existing `PATCH /instances/{id}/state` (Paused→Scheduled); a still-exceeded instance gets one more tick of work and pauses again — documented v1 semantics, no tick-loop spin since Paused leaves the claim set.
- Enforcement on tokens is exact (token counts, not dollar estimates). Cost: one aggregate query per claim, only when token limits are set; step limits use the in-memory runtime counter (zero queries); budgetless instances take zero extra queries.
- Persistence: postgres migration `043_instance_budget.sql` (JSONB, matches the 017 convention); sqlite bundled schema v7→8 (`budget TEXT`). New storage methods `query_instance_usage_totals` and `merge_instance_metadata` in both backends + encrypting wrapper.
- API: `budget` on single + batch instance create, echoed on GET, in OpenAPI components.
- Child instances do not inherit the parent's budget (v1; budgets are per-instance).

## Tests
23 new tests: Budget serde + old-JSON compat, breach logic; storage round-trips (single/batch/absent), metadata merge, per-instance usage isolation; 7 engine e2e (token breach pauses with reason and no step output, input-limit reporting, within-budget completes, no-budget unaffected, max_steps breach, resume→re-pause); API echo tests. `cargo test` across the 4 crates: 3104 passed. fmt/clippy/doc gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)