### PR TITLE
feat(api): MCP server mode — drive Orch8 from any MCP client

### DIFF
--- a/orch8-api/src/instances.rs
+++ b/orch8-api/src/instances.rs
@@ -47,6 +47,9 @@ pub(crate) use outputs::{
     __path_get_execution_tree, __path_get_outputs, get_execution_tree, get_outputs,
 };
 pub(crate) use signals::{__path_send_signal, send_signal};
+// Request/query types the MCP server reuses so its tools/call dispatch goes
+// through the exact same wire shapes as the REST endpoints.
+pub(crate) use types::{CreateInstanceRequest, ListQuery, SendSignalRequest};
 
 pub fn routes() -> Router<AppState> {
     Router::new()

--- a/orch8-api/src/lib.rs
+++ b/orch8-api/src/lib.rs
@@ -8,6 +8,7 @@ pub mod cron;
 pub mod error;
 pub mod health;
 pub mod instances;
+pub mod mcp_server;
 pub mod metrics;
 pub mod mobile_sync;
 pub mod model_pricing;
@@ -94,6 +95,7 @@ fn api_routes() -> Router<AppState> {
         .merge(telemetry::routes())
         .merge(rollback::routes())
         .merge(usage::routes())
+        .merge(mcp_server::routes())
 }
 
 /// Build the axum router with all routes.

--- a/orch8-api/src/mcp_server.rs
+++ b/orch8-api/src/mcp_server.rs
@@ -264,24 +264,11 @@ async fn tool_create_instance(
         seq.id.into_uuid()
     };
 
-    // Budget-style controls have no first-class field on the create request;
-    // they ride inside the read-only `context.config` section, where step
-    // handlers (agent loops, LLM calls) can observe them.
-    let mut context = args
+    let context = args
         .get("context")
         .filter(|c| c.is_object())
         .cloned()
         .unwrap_or_else(|| json!({}));
-    if let Some(budget) = args.get("budget") {
-        let config = context
-            .as_object_mut()
-            .expect("context defaulted to an object above")
-            .entry("config")
-            .or_insert_with(|| json!({}));
-        if let Some(cfg) = config.as_object_mut() {
-            cfg.insert("budget".into(), budget.clone());
-        }
-    }
 
     let mut body = json!({
         "sequence_id": sequence_id,
@@ -289,7 +276,7 @@ async fn tool_create_instance(
         "namespace": namespace,
         "context": context,
     });
-    for key in ["metadata", "dry_run", "idempotency_key"] {
+    for key in ["metadata", "dry_run", "idempotency_key", "budget"] {
         if let Some(v) = args.get(key) {
             body[key] = v.clone();
         }
@@ -485,7 +472,9 @@ fn tool_catalog() -> Value {
                                  "description": "Initial execution context ({data, config, ...})" },
                     "metadata": { "type": "object", "description": "Opaque instance metadata" },
                     "budget": { "type": "object",
-                                "description": "Budget hints, stored under context.config.budget" },
+                                "description": "Instance budget enforced by the scheduler \
+                                                (max_input_tokens, max_output_tokens, \
+                                                max_total_tokens, max_steps)" },
                     "dry_run": { "type": "boolean",
                                  "description": "Simulate side-effecting steps (default false)" },
                     "idempotency_key": { "type": "string",

--- a/orch8-api/src/mcp_server.rs
+++ b/orch8-api/src/mcp_server.rs
@@ -1,0 +1,637 @@
+//! MCP server mode — expose Orch8 operations as Model Context Protocol tools.
+//!
+//! The mirror image of `orch8-engine/src/handlers/mcp.rs` (the MCP *client*):
+//! this module makes Orch8 itself an MCP **server** over the Streamable HTTP
+//! transport, so Claude Code / Cursor / any MCP host can launch and supervise
+//! durable workflows — a durable arm for an otherwise ephemeral agent.
+//!
+//! ## Protocol surface (v1)
+//!
+//! A single `POST /mcp` endpoint speaking JSON-RPC 2.0, one message per POST
+//! (no batches), always answering with `Content-Type: application/json` —
+//! SSE-framed streaming responses are intentionally out of scope for v1.
+//!
+//! - `initialize` → protocol version + `{"tools": {}}` capabilities.
+//! - any notification (no `id`, e.g. `notifications/initialized`) → HTTP 202.
+//! - `ping` → `{}` (keepalive; some hosts poll it).
+//! - `tools/list` → the eight-tool catalog below.
+//! - `tools/call` → dispatch to the matching REST handler logic.
+//!
+//! Error contract: **domain** failures (instance not found, wrong state, …)
+//! come back as a successful `tools/call` result with `isError: true`, so an
+//! agent loop can read the message and react. **Protocol** failures map to
+//! JSON-RPC error objects: `-32700` malformed JSON, `-32600` invalid request,
+//! `-32601` unknown method, `-32602` invalid `tools/call` params — including
+//! an unknown tool name, which we surface as `-32602` (not `isError`) because
+//! the catalog is static and a bad name is a caller bug, not a domain outcome.
+//!
+//! Tenant scoping flows through unchanged: the route is mounted inside
+//! `api_routes` (in `lib.rs`), so the same auth / tenant middleware that guards the
+//! REST routes injects a [`crate::auth::TenantContext`], and every tool calls
+//! the very REST handlers that enforce it.
+//!
+//! ## Quickstart
+//!
+//! ```bash
+//! # 1. handshake
+//! curl -s http://localhost:8080/api/v1/mcp \
+//!   -H 'Content-Type: application/json' \
+//!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize",
+//!        "params":{"protocolVersion":"2025-06-18","capabilities":{},
+//!                  "clientInfo":{"name":"curl","version":"0"}}}'
+//!
+//! # 2. launch a workflow
+//! curl -s http://localhost:8080/api/v1/mcp \
+//!   -H 'Content-Type: application/json' -H 'X-Tenant-Id: acme' \
+//!   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call",
+//!        "params":{"name":"create_instance",
+//!                  "arguments":{"sequence_name":"daily-report"}}}'
+//! ```
+
+use axum::body::Bytes;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use orch8_types::ids::{Namespace, TenantId};
+use orch8_types::signal::SignalType;
+
+use crate::auth::OptionalTenant;
+use crate::error::ApiError;
+use crate::AppState;
+
+/// Protocol version advertised when the client requests one we don't know.
+const DEFAULT_PROTOCOL_VERSION: &str = "2025-06-18";
+/// Versions we echo back verbatim when a client pins one of them.
+const KNOWN_PROTOCOL_VERSIONS: &[&str] = &["2024-11-05", "2025-03-26", "2025-06-18"];
+
+/// JSON-RPC 2.0 error codes (protocol-level failures only — domain failures
+/// surface as `isError: true` tool results instead, see module docs).
+const PARSE_ERROR: i64 = -32700;
+const INVALID_REQUEST: i64 = -32600;
+const METHOD_NOT_FOUND: i64 = -32601;
+const INVALID_PARAMS: i64 = -32602;
+
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/mcp", post(handle_mcp))
+}
+
+/// A tool invocation outcome: `Ok` is the domain result rendered into the
+/// `content` array; `Err` is a domain failure message (`isError: true`).
+type ToolResult = Result<Value, String>;
+
+/// Single MCP endpoint: parse one JSON-RPC message and dispatch it.
+///
+/// The body is taken raw (not via [`Json`]) so malformed JSON can be answered
+/// with a proper `-32700` JSON-RPC error instead of an opaque axum 400.
+async fn handle_mcp(
+    State(state): State<AppState>,
+    tenant_ctx: OptionalTenant,
+    body: Bytes,
+) -> Response {
+    let msg: Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => return rpc_error(&Value::Null, PARSE_ERROR, format!("parse error: {e}")),
+    };
+    if !msg.is_object() {
+        return rpc_error(
+            &Value::Null,
+            INVALID_REQUEST,
+            "expected a single JSON-RPC object (batch requests are not supported)",
+        );
+    }
+    let id = msg.get("id").cloned();
+    if msg.get("jsonrpc").and_then(Value::as_str) != Some("2.0") {
+        return rpc_error(
+            id.as_ref().unwrap_or(&Value::Null),
+            INVALID_REQUEST,
+            "missing or invalid jsonrpc field (expected \"2.0\")",
+        );
+    }
+    let Some(method) = msg.get("method").and_then(Value::as_str) else {
+        return rpc_error(
+            id.as_ref().unwrap_or(&Value::Null),
+            INVALID_REQUEST,
+            "missing method",
+        );
+    };
+
+    // Notifications (no id) expect no JSON-RPC reply: 202 Accepted, empty
+    // body — mirrors what the engine-side MCP client tolerates on
+    // `notifications/initialized`.
+    let Some(id) = id else {
+        return StatusCode::ACCEPTED.into_response();
+    };
+
+    let params = msg.get("params").cloned().unwrap_or(Value::Null);
+    let outcome = match method {
+        "initialize" => Ok(initialize_result(&params)),
+        "ping" => Ok(json!({})),
+        "tools/list" => Ok(json!({ "tools": tool_catalog() })),
+        "tools/call" => tools_call(state, tenant_ctx, &params).await,
+        other => Err((METHOD_NOT_FOUND, format!("method not found: {other}"))),
+    };
+    match outcome {
+        Ok(result) => rpc_result(&id, &result),
+        Err((code, message)) => rpc_error(&id, code, message),
+    }
+}
+
+/// Build the `initialize` result: echo the client's protocol version when we
+/// know it, otherwise advertise our default.
+fn initialize_result(params: &Value) -> Value {
+    let requested = params.get("protocolVersion").and_then(Value::as_str);
+    let version = requested
+        .filter(|v| KNOWN_PROTOCOL_VERSIONS.contains(v))
+        .unwrap_or(DEFAULT_PROTOCOL_VERSION);
+    json!({
+        "protocolVersion": version,
+        "capabilities": { "tools": {} },
+        "serverInfo": { "name": "orch8", "version": env!("CARGO_PKG_VERSION") },
+    })
+}
+
+/// Dispatch a `tools/call` request to the matching tool implementation.
+///
+/// Returns the MCP `tools/call` result envelope; only structurally invalid
+/// params (missing/unknown tool name) escape as JSON-RPC errors.
+async fn tools_call(
+    state: AppState,
+    tenant_ctx: OptionalTenant,
+    params: &Value,
+) -> Result<Value, (i64, String)> {
+    let Some(name) = params.get("name").and_then(Value::as_str) else {
+        return Err((INVALID_PARAMS, "tools/call requires params.name".into()));
+    };
+    let args = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+
+    let result = match name {
+        "list_sequences" => tool_list_sequences(state, tenant_ctx, &args).await,
+        "create_instance" => tool_create_instance(state, tenant_ctx, &args).await,
+        "get_instance_status" => tool_get_instance_status(state, tenant_ctx, &args).await,
+        "get_instance_outputs" => tool_get_instance_outputs(state, tenant_ctx, &args).await,
+        "send_signal" => tool_send_signal(state, tenant_ctx, &args).await,
+        "retry_instance" => tool_retry_instance(state, tenant_ctx, &args).await,
+        "list_dlq" => tool_list_dlq(state, tenant_ctx, &args).await,
+        "get_usage" => tool_get_usage(state, tenant_ctx, &args).await,
+        // Unknown tool name → -32602 (documented choice, see module docs):
+        // the catalog is static, so a bad name is a protocol-level caller
+        // bug rather than a domain outcome.
+        other => return Err((INVALID_PARAMS, format!("unknown tool: {other}"))),
+    };
+
+    Ok(match result {
+        Ok(value) => tool_ok(&value),
+        Err(message) => tool_err(&message),
+    })
+}
+
+// ---- Tool implementations ---------------------------------------------------
+//
+// Each tool funnels into the corresponding REST handler so behaviour — tenant
+// enforcement, validation, status semantics — cannot drift between the two
+// surfaces. The handler's `impl IntoResponse` body is decoded back to JSON;
+// its `ApiError` becomes the domain-error text.
+
+/// `list_sequences`: tenant-scoped sequence catalog, optional namespace filter.
+async fn tool_list_sequences(
+    state: AppState,
+    tenant_ctx: OptionalTenant,
+    args: &Value,
+) -> ToolResult {
+    let mut query = serde_json::Map::new();
+    if let Some(ns) = args.get("namespace").and_then(Value::as_str) {
+        query.insert("namespace".into(), json!(ns));
+    }
+    if let Some(limit) = args.get("limit").and_then(Value::as_u64) {
+        query.insert("limit".into(), json!(limit));
+    }
+    let q: crate::sequences::ListSequencesQuery = parse_args(Value::Object(query))?;
+    rest_json(crate::sequences::list_sequences(State(state), tenant_ctx, Query(q)).await).await
+}
+
+/// `create_instance`: launch a durable workflow from a sequence id or name.
+async fn tool_create_instance(
+    state: AppState,
+    tenant_ctx: OptionalTenant,
+    args: &Value,
+) -> ToolResult {
+    let namespace = args
+        .get("namespace")
+        .and_then(Value::as_str)
+        .unwrap_or("default");
+    // Tenant resolution order: explicit argument, then the middleware-bound
+    // tenant, then "default". `create_instance` (REST) re-checks the result
+    // against the header context, so a mismatching explicit arg still 403s.
+    let tenant = args
+        .get("tenant_id")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| {
+            tenant_ctx
+                .as_ref()
+                .map(|axum::Extension(ctx)| ctx.tenant_id.as_str().to_owned())
+        })
+        .unwrap_or_else(|| "default".to_owned());
+
+    let sequence_id = if let Some(raw) = args.get("sequence_id").and_then(Value::as_str) {
+        Uuid::parse_str(raw).map_err(|e| format!("invalid sequence_id: {e}"))?
+    } else {
+        let name = args
+            .get("sequence_name")
+            .and_then(Value::as_str)
+            .ok_or("create_instance requires sequence_id or sequence_name")?;
+        let seq = state
+            .storage
+            .get_sequence_by_name(
+                &TenantId::unchecked(tenant.clone()),
+                &Namespace::new(namespace.to_owned()),
+                name,
+                None,
+            )
+            .await
+            .map_err(|e| format!("storage error: {e}"))?
+            .ok_or_else(|| {
+                format!("not found: sequence {name:?} (tenant {tenant:?}, namespace {namespace:?})")
+            })?;
+        seq.id.into_uuid()
+    };
+
+    // Budget-style controls have no first-class field on the create request;
+    // they ride inside the read-only `context.config` section, where step
+    // handlers (agent loops, LLM calls) can observe them.
+    let mut context = args
+        .get("context")
+        .filter(|c| c.is_object())
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    if let Some(budget) = args.get("budget") {
+        let config = context
+            .as_object_mut()
+            .expect("context defaulted to an object above")
+            .entry("config")
+            .or_insert_with(|| json!({}));
+        if let Some(cfg) = config.as_object_mut() {
+            cfg.insert("budget".into(), budget.clone());
+        }
+    }
+
+    let mut body = json!({
+        "sequence_id": sequence_id,
+        "tenant_id": tenant,
+        "namespace": namespace,
+        "context": context,
+    });
+    for key in ["metadata", "dry_run", "idempotency_key"] {
+        if let Some(v) = args.get(key) {
+            body[key] = v.clone();
+        }
+    }
+
+    let req: crate::instances::CreateInstanceRequest = parse_args(body)?;
+    rest_json(crate::instances::create_instance(State(state), tenant_ctx, Json(req)).await).await
+}
+
+/// `get_instance_status`: condensed view of one instance — state, timestamps,
+/// and a top-level `paused_reason` when the metadata carries one.
+async fn tool_get_instance_status(
+    state: AppState,
+    tenant_ctx: OptionalTenant,
+    args: &Value,
+) -> ToolResult {
+    let id = arg_uuid(args, "instance_id")?;
+    let instance =
+        rest_json(crate::instances::get_instance(State(state), tenant_ctx, Path(id)).await).await?;
+    let mut status = json!({
+        "id": instance["id"],
+        "state": instance["state"],
+        "sequence_id": instance["sequence_id"],
+        "namespace": instance["namespace"],
+        "created_at": instance["created_at"],
+        "updated_at": instance["updated_at"],
+        "next_fire_at": instance["next_fire_at"],
+        "metadata": instance["metadata"],
+    });
+    if let Some(reason) = instance
+        .get("metadata")
+        .and_then(|m| m.get("paused_reason"))
+    {
+        status["paused_reason"] = reason.clone();
+    }
+    Ok(status)
+}
+
+/// `get_instance_outputs`: per-block outputs of one instance.
+async fn tool_get_instance_outputs(
+    state: AppState,
+    tenant_ctx: OptionalTenant,
+    args: &Value,
+) -> ToolResult {
+    let id = arg_uuid(args, "instance_id")?;
+    rest_json(crate::instances::get_outputs(State(state), tenant_ctx, Path(id)).await).await
+}
+
+/// `send_signal`: enqueue a signal (`pause` / `resume` / `cancel` /
+/// `update_context` / `custom:<name>`) with an optional payload.
+async fn tool_send_signal(state: AppState, tenant_ctx: OptionalTenant, args: &Value) -> ToolResult {
+    let id = arg_uuid(args, "instance_id")?;
+    let signal_type = arg_str(args, "signal")?
+        .parse::<SignalType>()
+        .map_err(|e| e.to_string())?;
+    let req = crate::instances::SendSignalRequest {
+        signal_type,
+        payload: args.get("payload").cloned().unwrap_or(Value::Null),
+    };
+    rest_json(crate::instances::send_signal(State(state), tenant_ctx, Path(id), Json(req)).await)
+        .await
+}
+
+/// `retry_instance`: reschedule a Failed instance for immediate re-execution.
+async fn tool_retry_instance(
+    state: AppState,
+    tenant_ctx: OptionalTenant,
+    args: &Value,
+) -> ToolResult {
+    let id = arg_uuid(args, "instance_id")?;
+    rest_json(crate::instances::retry_instance(State(state), tenant_ctx, Path(id)).await).await
+}
+
+/// `list_dlq`: failed instances (the dead-letter queue), optional limit.
+async fn tool_list_dlq(state: AppState, tenant_ctx: OptionalTenant, args: &Value) -> ToolResult {
+    let mut query = serde_json::Map::new();
+    if let Some(limit) = args.get("limit").and_then(Value::as_u64) {
+        query.insert("limit".into(), json!(limit));
+    }
+    let q: crate::instances::ListQuery = parse_args(Value::Object(query))?;
+    rest_json(crate::instances::list_dlq(State(state), tenant_ctx, Query(q)).await).await
+}
+
+/// `get_usage`: tenant-scoped LLM token/cost aggregation over a time window.
+async fn tool_get_usage(state: AppState, tenant_ctx: OptionalTenant, args: &Value) -> ToolResult {
+    let mut query = serde_json::Map::new();
+    for key in ["tenant", "start", "end"] {
+        if let Some(v) = args.get(key) {
+            query.insert(key.into(), v.clone());
+        }
+    }
+    let q: crate::usage::UsageQuery = parse_args(Value::Object(query))?;
+    rest_json(crate::usage::get_usage(State(state), tenant_ctx, Query(q)).await).await
+}
+
+// ---- Plumbing ---------------------------------------------------------------
+
+/// Decode a REST handler outcome into JSON: `Ok` bodies are parsed back into
+/// a [`Value`], `Err(ApiError)` becomes the domain-error message.
+async fn rest_json<T: IntoResponse>(res: Result<T, ApiError>) -> ToolResult {
+    let resp = res.map_err(|e| e.to_string())?.into_response();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .map_err(|e| format!("internal: failed to read handler response: {e}"))?;
+    if bytes.is_empty() {
+        return Ok(json!({}));
+    }
+    serde_json::from_slice(&bytes)
+        .map_err(|e| format!("internal: handler returned non-JSON body: {e}"))
+}
+
+/// Deserialize composed tool arguments into a REST request/query type.
+fn parse_args<T: serde::de::DeserializeOwned>(value: Value) -> Result<T, String> {
+    serde_json::from_value(value).map_err(|e| format!("invalid arguments: {e}"))
+}
+
+/// Fetch a required string argument.
+fn arg_str<'a>(args: &'a Value, key: &str) -> Result<&'a str, String> {
+    args.get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("missing required argument: {key}"))
+}
+
+/// Fetch a required UUID argument.
+fn arg_uuid(args: &Value, key: &str) -> Result<Uuid, String> {
+    Uuid::parse_str(arg_str(args, key)?).map_err(|e| format!("invalid {key}: {e}"))
+}
+
+/// Successful `tools/call` envelope: pretty-printed JSON as text content.
+fn tool_ok(value: &Value) -> Value {
+    let text = serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string());
+    json!({ "content": [{ "type": "text", "text": text }], "isError": false })
+}
+
+/// Domain-failure `tools/call` envelope (`isError: true`, NOT a JSON-RPC error).
+fn tool_err(message: &str) -> Value {
+    json!({ "content": [{ "type": "text", "text": message }], "isError": true })
+}
+
+/// JSON-RPC success response.
+fn rpc_result(id: &Value, result: &Value) -> Response {
+    Json(json!({ "jsonrpc": "2.0", "id": id, "result": result })).into_response()
+}
+
+/// JSON-RPC error response. HTTP status stays 200 so MCP clients parse the
+/// error object instead of bailing on the transport.
+fn rpc_error(id: &Value, code: i64, message: impl Into<String>) -> Response {
+    Json(json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": { "code": code, "message": message.into() },
+    }))
+    .into_response()
+}
+
+/// The static tool catalog served by `tools/list`.
+// One declarative literal per tool keeps the catalog greppable; the length is
+// schema data, not logic.
+#[allow(clippy::too_many_lines)]
+fn tool_catalog() -> Value {
+    fn instance_id() -> Value {
+        json!({ "type": "string", "format": "uuid", "description": "Instance UUID" })
+    }
+    json!([
+        {
+            "name": "list_sequences",
+            "description": "List workflow sequence definitions visible to the caller's tenant.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "namespace": { "type": "string", "description": "Filter by namespace" },
+                    "limit": { "type": "integer", "minimum": 1, "maximum": 1000,
+                               "description": "Max rows (default 200)" },
+                },
+                "additionalProperties": false,
+            },
+        },
+        {
+            "name": "create_instance",
+            "description": "Launch a durable workflow instance from a sequence. \
+                            Provide either sequence_id or sequence_name.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "sequence_id": { "type": "string", "format": "uuid",
+                                     "description": "Target sequence UUID" },
+                    "sequence_name": { "type": "string",
+                                       "description": "Target sequence name (latest version)" },
+                    "tenant_id": { "type": "string",
+                                   "description": "Tenant (defaults to the caller's tenant)" },
+                    "namespace": { "type": "string", "description": "Namespace (default: \"default\")" },
+                    "context": { "type": "object",
+                                 "description": "Initial execution context ({data, config, ...})" },
+                    "metadata": { "type": "object", "description": "Opaque instance metadata" },
+                    "budget": { "type": "object",
+                                "description": "Budget hints, stored under context.config.budget" },
+                    "dry_run": { "type": "boolean",
+                                 "description": "Simulate side-effecting steps (default false)" },
+                    "idempotency_key": { "type": "string",
+                                         "description": "Dedup key for at-most-once creation" },
+                },
+                "additionalProperties": false,
+            },
+        },
+        {
+            "name": "get_instance_status",
+            "description": "Get an instance's state, timestamps, and paused_reason metadata if present.",
+            "inputSchema": {
+                "type": "object",
+                "properties": { "instance_id": instance_id() },
+                "required": ["instance_id"],
+                "additionalProperties": false,
+            },
+        },
+        {
+            "name": "get_instance_outputs",
+            "description": "Get the per-block outputs an instance has produced so far.",
+            "inputSchema": {
+                "type": "object",
+                "properties": { "instance_id": instance_id() },
+                "required": ["instance_id"],
+                "additionalProperties": false,
+            },
+        },
+        {
+            "name": "send_signal",
+            "description": "Send a signal to a running instance (pause/resume/cancel/update_context/custom:<name>).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "instance_id": instance_id(),
+                    "signal": { "type": "string",
+                                "description": "pause | resume | cancel | update_context | custom:<name>" },
+                    "payload": { "description": "Optional signal payload (any JSON)" },
+                },
+                "required": ["instance_id", "signal"],
+                "additionalProperties": false,
+            },
+        },
+        {
+            "name": "retry_instance",
+            "description": "Retry a failed instance: reset it to scheduled with an immediate fire time.",
+            "inputSchema": {
+                "type": "object",
+                "properties": { "instance_id": instance_id() },
+                "required": ["instance_id"],
+                "additionalProperties": false,
+            },
+        },
+        {
+            "name": "list_dlq",
+            "description": "List failed instances (the dead-letter queue).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "limit": { "type": "integer", "minimum": 1, "maximum": 1000,
+                               "description": "Max rows (default 100)" },
+                },
+                "additionalProperties": false,
+            },
+        },
+        {
+            "name": "get_usage",
+            "description": "Aggregate LLM token usage and estimated cost for a tenant over a time window.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "tenant": { "type": "string",
+                                "description": "Tenant to report on (required unless tenant-scoped)" },
+                    "start": { "type": "string", "format": "date-time",
+                               "description": "Window start, RFC 3339 (default: end - 30d)" },
+                    "end": { "type": "string", "format": "date-time",
+                             "description": "Window end, RFC 3339 (default: now)" },
+                },
+                "additionalProperties": false,
+            },
+        },
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initialize_echoes_known_protocol_version() {
+        let result = initialize_result(&json!({ "protocolVersion": "2025-03-26" }));
+        assert_eq!(result["protocolVersion"], "2025-03-26");
+        assert_eq!(result["serverInfo"]["name"], "orch8");
+        assert!(result["capabilities"]["tools"].is_object());
+    }
+
+    #[test]
+    fn initialize_falls_back_on_unknown_protocol_version() {
+        let result = initialize_result(&json!({ "protocolVersion": "1999-01-01" }));
+        assert_eq!(result["protocolVersion"], DEFAULT_PROTOCOL_VERSION);
+    }
+
+    #[test]
+    fn initialize_falls_back_when_version_absent() {
+        let result = initialize_result(&Value::Null);
+        assert_eq!(result["protocolVersion"], DEFAULT_PROTOCOL_VERSION);
+        assert_eq!(result["serverInfo"]["version"], env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn catalog_lists_eight_tools_with_object_schemas() {
+        let catalog = tool_catalog();
+        let tools = catalog.as_array().expect("catalog is an array");
+        assert_eq!(tools.len(), 8);
+        for tool in tools {
+            assert!(tool["name"].is_string());
+            assert!(tool["description"].is_string());
+            assert_eq!(tool["inputSchema"]["type"], "object");
+            assert!(tool["inputSchema"]["properties"].is_object());
+        }
+    }
+
+    #[test]
+    fn tool_envelopes_flag_errors() {
+        let ok = tool_ok(&json!({ "id": 1 }));
+        assert_eq!(ok["isError"], false);
+        assert_eq!(ok["content"][0]["type"], "text");
+        assert!(ok["content"][0]["text"]
+            .as_str()
+            .expect("text content")
+            .contains("\"id\": 1"));
+
+        let err = tool_err("not found: instance x");
+        assert_eq!(err["isError"], true);
+        assert_eq!(err["content"][0]["text"], "not found: instance x");
+    }
+
+    #[test]
+    fn arg_helpers_report_missing_and_invalid() {
+        let args = json!({ "instance_id": "not-a-uuid", "signal": "pause" });
+        assert!(arg_uuid(&args, "instance_id")
+            .expect_err("invalid uuid")
+            .contains("invalid instance_id"));
+        assert!(arg_str(&args, "missing")
+            .expect_err("missing key")
+            .contains("missing required argument"));
+        assert_eq!(arg_str(&args, "signal").expect("present"), "pause");
+    }
+}

--- a/orch8-api/tests/mcp_server.rs
+++ b/orch8-api/tests/mcp_server.rs
@@ -520,3 +520,37 @@ async fn tenant_isolation_hides_foreign_instances() {
     let listed = tool_json(&result);
     assert!(listed["items"].as_array().unwrap().is_empty());
 }
+
+#[tokio::test]
+async fn create_instance_passes_budget_first_class() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+    let v1 = srv.v1_url();
+    let tenant = "tb";
+
+    let seq_id = create_sequence(&client, &v1, tenant, "budgeted").await;
+    let inst_id = mcp_create_instance(
+        &client,
+        &v1,
+        tenant,
+        json!({
+            "sequence_id": seq_id,
+            "budget": { "max_total_tokens": 5000, "max_steps": 10 }
+        }),
+    )
+    .await;
+
+    // The budget must land on the instance itself (scheduler-enforced),
+    // not inside context.config.
+    let resp = client
+        .get(format!("{v1}/instances/{inst_id}"))
+        .header("X-Tenant-Id", tenant)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let inst: Value = resp.json().await.unwrap();
+    assert_eq!(inst["budget"]["max_total_tokens"], 5000);
+    assert_eq!(inst["budget"]["max_steps"], 10);
+    assert!(inst["context"]["config"].get("budget").is_none());
+}

--- a/orch8-api/tests/mcp_server.rs
+++ b/orch8-api/tests/mcp_server.rs
@@ -1,0 +1,522 @@
+//! E2E tests for the MCP server endpoint (`POST /api/v1/mcp`).
+//!
+//! Drives the JSON-RPC 2.0 surface over plain reqwest: handshake, tool
+//! catalog, tools/call round-trips, the domain-vs-protocol error split, and
+//! tenant isolation.
+
+use orch8_api::test_harness::spawn_test_server;
+use orch8_storage::InstanceStore;
+use orch8_types::ids::InstanceId;
+use orch8_types::instance::InstanceState;
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+/// POST one JSON-RPC message; return (status, parsed body or Null when empty).
+async fn rpc(
+    client: &reqwest::Client,
+    url: &str,
+    tenant: &str,
+    body: &Value,
+) -> (StatusCode, Value) {
+    let resp = client
+        .post(format!("{url}/mcp"))
+        .header("X-Tenant-Id", tenant)
+        .json(body)
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let bytes = resp.bytes().await.unwrap();
+    let value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap()
+    };
+    (status, value)
+}
+
+/// Call an MCP tool, asserting the JSON-RPC layer succeeded. Returns the
+/// `tools/call` result envelope (`{content, isError}`).
+async fn call_tool(
+    client: &reqwest::Client,
+    url: &str,
+    tenant: &str,
+    tool: &str,
+    arguments: Value,
+) -> Value {
+    let (status, body) = rpc(
+        client,
+        url,
+        tenant,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": tool, "arguments": arguments },
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body.get("error").is_none(),
+        "unexpected JSON-RPC error: {body}"
+    );
+    body["result"].clone()
+}
+
+/// Parse the text content of a tool result back into JSON.
+fn tool_json(result: &Value) -> Value {
+    assert_eq!(result["isError"], false, "tool errored: {result}");
+    let text = result["content"][0]["text"].as_str().unwrap();
+    serde_json::from_str(text).unwrap()
+}
+
+fn mk_sequence_body(id: Uuid, tenant: &str, name: &str) -> Value {
+    json!({
+        "id": id,
+        "tenant_id": tenant,
+        "namespace": "default",
+        "name": name,
+        "version": 1,
+        "deprecated": false,
+        "blocks": [
+            {
+                "type": "step",
+                "id": "s1",
+                "handler": "noop",
+                "params": {},
+                "cancellable": true
+            }
+        ],
+        "interceptors": null,
+        "created_at": chrono::Utc::now().to_rfc3339()
+    })
+}
+
+/// Create a sequence via REST (the MCP tools are then exercised against it).
+async fn create_sequence(client: &reqwest::Client, v1: &str, tenant: &str, name: &str) -> Uuid {
+    let seq_id = Uuid::now_v7();
+    let resp = client
+        .post(format!("{v1}/sequences"))
+        .header("X-Tenant-Id", tenant)
+        .json(&mk_sequence_body(seq_id, tenant, name))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    seq_id
+}
+
+/// Create an instance through the MCP tool; returns its id.
+async fn mcp_create_instance(
+    client: &reqwest::Client,
+    v1: &str,
+    tenant: &str,
+    args: Value,
+) -> Uuid {
+    let result = call_tool(client, v1, tenant, "create_instance", args).await;
+    let created = tool_json(&result);
+    created["id"].as_str().unwrap().parse().unwrap()
+}
+
+#[tokio::test]
+async fn initialize_handshake_and_notification() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+    let v1 = srv.v1_url();
+
+    let (status, body) = rpc(
+        &client,
+        &v1,
+        "t1",
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": { "name": "test", "version": "0" }
+            }
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["jsonrpc"], "2.0");
+    assert_eq!(body["id"], 1);
+    assert_eq!(body["result"]["protocolVersion"], "2025-06-18");
+    assert_eq!(body["result"]["serverInfo"]["name"], "orch8");
+    assert!(body["result"]["serverInfo"]["version"].is_string());
+    assert!(body["result"]["capabilities"]["tools"].is_object());
+
+    // An unknown protocol version falls back to the server default.
+    let (_, body) = rpc(
+        &client,
+        &v1,
+        "t1",
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "initialize",
+            "params": { "protocolVersion": "1999-01-01" }
+        }),
+    )
+    .await;
+    assert_eq!(body["result"]["protocolVersion"], "2025-06-18");
+
+    // Notifications (no id) get 202 with an empty body.
+    let (status, body) = rpc(
+        &client,
+        &v1,
+        "t1",
+        &json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+    assert_eq!(body, Value::Null);
+}
+
+#[tokio::test]
+async fn tools_list_returns_all_eight_tools_with_schemas() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+
+    let (status, body) = rpc(
+        &client,
+        &srv.v1_url(),
+        "t1",
+        &json!({ "jsonrpc": "2.0", "id": 7, "method": "tools/list" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let tools = body["result"]["tools"].as_array().unwrap();
+    assert_eq!(tools.len(), 8);
+
+    let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+    for expected in [
+        "list_sequences",
+        "create_instance",
+        "get_instance_status",
+        "get_instance_outputs",
+        "send_signal",
+        "retry_instance",
+        "list_dlq",
+        "get_usage",
+    ] {
+        assert!(names.contains(&expected), "missing tool {expected}");
+    }
+    for tool in tools {
+        let schema = &tool["inputSchema"];
+        assert_eq!(schema["type"], "object", "bad schema for {}", tool["name"]);
+        assert!(schema["properties"].is_object());
+    }
+}
+
+#[tokio::test]
+async fn create_instance_and_get_status_round_trip() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+    let v1 = srv.v1_url();
+    let seq_id = create_sequence(&client, &v1, "t1", "round-trip-seq").await;
+
+    // list_sequences sees the REST-created sequence.
+    let result = call_tool(&client, &v1, "t1", "list_sequences", json!({})).await;
+    let listed = tool_json(&result);
+    let items = listed["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["name"], "round-trip-seq");
+
+    // Launch by id, then by name — both paths must resolve.
+    let inst_id = mcp_create_instance(
+        &client,
+        &v1,
+        "t1",
+        json!({ "sequence_id": seq_id, "metadata": { "source": "mcp" } }),
+    )
+    .await;
+    let by_name = mcp_create_instance(
+        &client,
+        &v1,
+        "t1",
+        json!({ "sequence_name": "round-trip-seq" }),
+    )
+    .await;
+    assert_ne!(inst_id, by_name);
+
+    // Status of the first instance via MCP.
+    let result = call_tool(
+        &client,
+        &v1,
+        "t1",
+        "get_instance_status",
+        json!({ "instance_id": inst_id }),
+    )
+    .await;
+    let status = tool_json(&result);
+    assert_eq!(status["id"], inst_id.to_string());
+    assert_eq!(status["state"], "scheduled");
+    assert_eq!(status["sequence_id"], seq_id.to_string());
+    assert_eq!(status["metadata"]["source"], "mcp");
+    assert!(status["created_at"].is_string());
+    assert!(status["updated_at"].is_string());
+
+    // Outputs exist (empty — nothing has executed) and don't error.
+    let result = call_tool(
+        &client,
+        &v1,
+        "t1",
+        "get_instance_outputs",
+        json!({ "instance_id": inst_id }),
+    )
+    .await;
+    let outputs = tool_json(&result);
+    assert_eq!(outputs, json!([]));
+}
+
+#[tokio::test]
+async fn send_signal_and_retry_instance_happy_paths() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+    let v1 = srv.v1_url();
+    create_sequence(&client, &v1, "t1", "signal-seq").await;
+    let inst_id =
+        mcp_create_instance(&client, &v1, "t1", json!({ "sequence_name": "signal-seq" })).await;
+
+    // send_signal: pause the scheduled instance.
+    let result = call_tool(
+        &client,
+        &v1,
+        "t1",
+        "send_signal",
+        json!({ "instance_id": inst_id, "signal": "pause", "payload": { "by": "test" } }),
+    )
+    .await;
+    let signal = tool_json(&result);
+    assert!(signal["signal_id"].is_string());
+
+    // retry_instance requires a Failed instance — force the state directly
+    // through the storage handle, like sibling tests do.
+    srv.storage
+        .update_instance_state(InstanceId::from_uuid(inst_id), InstanceState::Failed, None)
+        .await
+        .unwrap();
+
+    // The failed instance shows up in the DLQ via MCP.
+    let result = call_tool(&client, &v1, "t1", "list_dlq", json!({ "limit": 10 })).await;
+    let dlq = tool_json(&result);
+    let rows = dlq.as_array().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], inst_id.to_string());
+
+    // retry resets it to scheduled.
+    let result = call_tool(
+        &client,
+        &v1,
+        "t1",
+        "retry_instance",
+        json!({ "instance_id": inst_id }),
+    )
+    .await;
+    let retried = tool_json(&result);
+    assert_eq!(retried["state"], "scheduled");
+
+    let result = call_tool(
+        &client,
+        &v1,
+        "t1",
+        "get_instance_status",
+        json!({ "instance_id": inst_id }),
+    )
+    .await;
+    assert_eq!(tool_json(&result)["state"], "scheduled");
+}
+
+#[tokio::test]
+async fn retry_non_failed_instance_is_domain_error() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+    let v1 = srv.v1_url();
+    create_sequence(&client, &v1, "t1", "retry-seq").await;
+    let inst_id =
+        mcp_create_instance(&client, &v1, "t1", json!({ "sequence_name": "retry-seq" })).await;
+
+    // Scheduled (not Failed) → invalid-state domain error, isError: true.
+    let result = call_tool(
+        &client,
+        &v1,
+        "t1",
+        "retry_instance",
+        json!({ "instance_id": inst_id }),
+    )
+    .await;
+    assert_eq!(result["isError"], true);
+    let text = result["content"][0]["text"].as_str().unwrap();
+    assert!(text.contains("can only retry failed instances"), "{text}");
+}
+
+#[tokio::test]
+async fn get_usage_via_mcp() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+
+    let result = call_tool(
+        &client,
+        &srv.v1_url(),
+        "t1",
+        "get_usage",
+        json!({ "start": "2026-01-01T00:00:00Z", "end": "2026-02-01T00:00:00Z" }),
+    )
+    .await;
+    let usage = tool_json(&result);
+    assert_eq!(usage["tenant"], "t1");
+    assert!(usage["usage"].as_array().unwrap().is_empty());
+    assert_eq!(usage["start"], "2026-01-01T00:00:00Z");
+}
+
+#[tokio::test]
+async fn domain_error_unknown_instance_is_is_error_true() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+
+    let result = call_tool(
+        &client,
+        &srv.v1_url(),
+        "t1",
+        "get_instance_status",
+        json!({ "instance_id": Uuid::now_v7() }),
+    )
+    .await;
+    assert_eq!(result["isError"], true);
+    let text = result["content"][0]["text"].as_str().unwrap();
+    assert!(text.contains("not found"), "{text}");
+}
+
+#[tokio::test]
+async fn unknown_method_returns_32601() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+
+    let (status, body) = rpc(
+        &client,
+        &srv.v1_url(),
+        "t1",
+        &json!({ "jsonrpc": "2.0", "id": 3, "method": "resources/list" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["error"]["code"], -32601);
+    assert_eq!(body["id"], 3);
+}
+
+#[tokio::test]
+async fn malformed_json_returns_32700() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{}/mcp", srv.v1_url()))
+        .header("Content-Type", "application/json")
+        .header("X-Tenant-Id", "t1")
+        .body("{ not json")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["error"]["code"], -32700);
+    assert_eq!(body["id"], Value::Null);
+}
+
+#[tokio::test]
+async fn invalid_jsonrpc_envelope_returns_32600() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+
+    // Batch arrays are not supported in v1.
+    let (_, body) = rpc(&client, &srv.v1_url(), "t1", &json!([])).await;
+    assert_eq!(body["error"]["code"], -32600);
+
+    // Wrong jsonrpc version marker.
+    let (_, body) = rpc(
+        &client,
+        &srv.v1_url(),
+        "t1",
+        &json!({ "jsonrpc": "1.0", "id": 1, "method": "tools/list" }),
+    )
+    .await;
+    assert_eq!(body["error"]["code"], -32600);
+}
+
+#[tokio::test]
+async fn unknown_tool_returns_32602() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+
+    // Documented choice: an unknown tool name is a protocol error (-32602),
+    // not an isError result — the catalog is static.
+    let (status, body) = rpc(
+        &client,
+        &srv.v1_url(),
+        "t1",
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": { "name": "explode_workflow", "arguments": {} },
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["error"]["code"], -32602);
+    assert!(body["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("unknown tool"));
+}
+
+#[tokio::test]
+async fn tenant_isolation_hides_foreign_instances() {
+    let srv = spawn_test_server().await;
+    let client = reqwest::Client::new();
+    let v1 = srv.v1_url();
+    create_sequence(&client, &v1, "t1", "isolated-seq").await;
+    let inst_id = mcp_create_instance(
+        &client,
+        &v1,
+        "t1",
+        json!({ "sequence_name": "isolated-seq" }),
+    )
+    .await;
+
+    // Another tenant cannot see t1's instance (404 → domain error).
+    let result = call_tool(
+        &client,
+        &v1,
+        "t2",
+        "get_instance_status",
+        json!({ "instance_id": inst_id }),
+    )
+    .await;
+    assert_eq!(result["isError"], true);
+    assert!(result["content"][0]["text"]
+        .as_str()
+        .unwrap()
+        .contains("not found"));
+
+    // Nor signal it.
+    let result = call_tool(
+        &client,
+        &v1,
+        "t2",
+        "send_signal",
+        json!({ "instance_id": inst_id, "signal": "cancel" }),
+    )
+    .await;
+    assert_eq!(result["isError"], true);
+
+    // list_sequences for t2 is empty — sequences are tenant-scoped too.
+    let result = call_tool(&client, &v1, "t2", "list_sequences", json!({})).await;
+    let listed = tool_json(&result);
+    assert!(listed["items"].as_array().unwrap().is_empty());
+}


### PR DESCRIPTION
## Summary
Orch8 already speaks MCP as a client; this makes it an MCP **server**. `POST /api/v1/mcp` implements streamable-HTTP JSON-RPC 2.0 (hand-rolled, zero new deps, mirroring the engine's own MCP client vocabulary), inheriting auth + tenant middleware like every sibling route. Claude Code / Cursor / any MCP client can now launch and supervise durable workflows conversationally.

- Protocol: `initialize` (echoes known protocol versions, defaults `2025-06-18`), notifications → 202, `ping`, `tools/list`, `tools/call`. JSON-RPC protocol errors (-32700/-32600/-32601/-32602) over HTTP 200 so clients parse the error object; domain failures (unknown instance, bad UUID) → `isError: true` tool results.
- 8 tools, each with JSON Schema `inputSchema`: `list_sequences`, `create_instance` (by id or name), `get_instance_status`, `get_instance_outputs`, `send_signal`, `retry_instance`, `list_dlq`, `get_usage`.
- Tools invoke the REST handler fns directly and decode their responses — tenant enforcement, validation, and status semantics cannot drift between the REST and MCP surfaces.
- v1 scope: stateless single-message POSTs; SSE streaming responses and `Mcp-Session-Id` sessions deliberately deferred.

## Tests
12 integration tests via `spawn_test_server` (handshake, catalog, create+status round-trips by id and name, signal/retry happy paths, DLQ, usage, all protocol-error codes, tenant isolation) + 6 unit tests. `cargo test -p orch8-api`: 287 passed. fmt/clippy/doc gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)