### PR TITLE
feat(llm): multimodal image content via artifacts + gen_ai.* telemetry fields

### DIFF
--- a/orch8-engine/src/handlers/blob.rs
+++ b/orch8-engine/src/handlers/blob.rs
@@ -48,7 +48,8 @@ const DEFAULT_MAX_BYTES: u64 = 25 * 1024 * 1024;
 /// Map an artifact-backend storage error to a step error. A `Unsupported`
 /// backend (not configured) is a permanent misconfiguration — retrying would
 /// only burn the budget. Transient backend failures stay retryable.
-fn artifact_step_err(context: &str, e: &orch8_types::error::StorageError) -> StepError {
+/// Shared with `llm_call`'s multimodal image resolution.
+pub(crate) fn artifact_step_err(context: &str, e: &orch8_types::error::StorageError) -> StepError {
     match e {
         orch8_types::error::StorageError::Unsupported(_) => StepError::Permanent {
             message: format!("{context}: {e}"),
@@ -64,8 +65,9 @@ fn artifact_step_err(context: &str, e: &orch8_types::error::StorageError) -> Ste
 /// Resolve an artifact key from a `ref` param. Accepts a bare key string, a
 /// `{ "key": "…" }` object, or the canonical `{ "artifact": { "key": "…" } }`
 /// shape that `blob_put` (and `tool_call`) emit — so callers can wire
-/// `{{outputs.put.artifact}}` straight through.
-fn extract_key(refval: &Value) -> Option<String> {
+/// `{{outputs.put.artifact}}` straight through. Shared with `llm_call`'s
+/// multimodal image blocks, which accept the same `artifact` ref shapes.
+pub(crate) fn extract_key(refval: &Value) -> Option<String> {
     match refval {
         Value::String(s) => Some(s.clone()),
         Value::Object(_) => {

--- a/orch8-engine/src/handlers/llm/anthropic.rs
+++ b/orch8-engine/src/handlers/llm/anthropic.rs
@@ -23,6 +23,16 @@ pub(super) async fn call_anthropic(
 
     let messages_raw = params.get("messages").cloned().unwrap_or(json!([]));
     let (system_from_msgs, messages) = extract_system_message(&messages_raw);
+    // Plain-string content is cloned unchanged; normalized image blocks
+    // become Anthropic base64 `source` blocks at request-build time.
+    let messages = match messages.as_array() {
+        Some(arr) => Value::Array(
+            arr.iter()
+                .map(super::multimodal::to_anthropic_message)
+                .collect(),
+        ),
+        None => messages,
+    };
 
     let max_tokens = params
         .get("max_tokens")

--- a/orch8-engine/src/handlers/llm/mod.rs
+++ b/orch8-engine/src/handlers/llm/mod.rs
@@ -14,7 +14,7 @@
 //! | `api_key` | string | — | API key (direct) |
 //! | `api_key_env` | string | — | Env var name containing API key |
 //! | `model` | string | per-provider | Model identifier (see env var overrides below) |
-//! | `messages` | array | `[]` | Chat messages (`{role, content}`) |
+//! | `messages` | array | `[]` | Chat messages (`{role, content}`); `content` is a string or an array of content blocks (see Multimodal content) |
 //! | `system` | string | — | System prompt (Anthropic shorthand) |
 //! | `temperature` | number | — | Sampling temperature |
 //! | `max_tokens` | number | `4096` | Max output tokens |
@@ -24,6 +24,33 @@
 //! | `per_provider_timeout_secs` | number | `60` | Per-provider timeout in failover mode |
 //! | `response_schema` | object | — | JSON Schema the response must satisfy (validated, auto-repaired) |
 //! | `max_repair_attempts` | number | `2` | Schema-repair re-calls per provider attempt (hard cap 5) |
+//! | `max_image_bytes` | number | 20 MiB | Per-image size cap, pre-encoding (can only lower the default) |
+//!
+//! ## Multimodal content
+//!
+//! A message's `content` may be a plain string (unchanged behavior) or an
+//! array of content blocks:
+//!
+//! - `{"type": "text", "text": "…"}`
+//! - `{"type": "image", "artifact": "<key>", "media_type": "image/png"}` —
+//!   image bytes fetched from the artifact store before provider dispatch.
+//!   `artifact` accepts the same shapes as `blob_get`'s `ref` (bare key,
+//!   `{"key"}`, `{"artifact": {"key"}}`). `media_type` defaults to `image/png`.
+//! - `{"type": "image", "data": "<base64>", "media_type": "image/png"}` —
+//!   inline base64 passthrough.
+//!
+//! Images are resolved once (before failover, so every provider attempt
+//! reuses the fetched bytes); each provider adapter converts to its wire
+//! shape — OpenAI-compatible `image_url` data URLs, Anthropic base64
+//! `source` blocks. See the `multimodal` submodule.
+//!
+//! ## Telemetry
+//!
+//! Each successful call emits a `gen_ai.client.inference` `tracing` event
+//! carrying `OTel` `GenAI` semantic-convention fields (`gen_ai.operation.name`,
+//! `gen_ai.system`, `gen_ai.request.model`, `gen_ai.response.model`,
+//! `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`) — structured
+//! telemetry consumable by any subscriber, no OTLP exporter required.
 //!
 //! ## Providers
 //!
@@ -52,6 +79,7 @@
 
 mod anthropic;
 pub(crate) mod common;
+mod multimodal;
 mod openai;
 mod schema;
 
@@ -121,7 +149,7 @@ pub(crate) fn http_client() -> &'static reqwest::Client {
 /// If the params contain a `providers` array, iterates through each provider
 /// in order, attempting the call. On failure, tries the next provider.
 /// The output includes a `tried` array listing providers attempted in order.
-pub async fn handle_llm_call(ctx: StepContext) -> Result<Value, StepError> {
+pub async fn handle_llm_call(mut ctx: StepContext) -> Result<Value, StepError> {
     let dry = ctx.is_dry_run();
 
     // Compile `response_schema` once per step, BEFORE any provider call (and
@@ -138,41 +166,89 @@ pub async fn handle_llm_call(ctx: StepContext) -> Result<Value, StepError> {
             }
             return Ok(llm_dry_run_stub(&ctx.params));
         }
-        return handle_llm_call_failover(&ctx.params, providers, response_schema.as_ref()).await;
+        let providers = providers.clone();
+        // Resolve artifact-backed image blocks ONCE, before the failover loop
+        // and schema paths, so every provider attempt reuses the fetched bytes.
+        multimodal::resolve_message_images(&ctx.storage, ctx.instance_id, &mut ctx.params).await?;
+        return handle_llm_call_failover(&ctx.params, &providers, response_schema.as_ref()).await;
     }
 
     let provider = ctx
         .params
         .get("provider")
         .and_then(Value::as_str)
-        .unwrap_or("openai");
+        .unwrap_or("openai")
+        .to_string();
 
     // Resolve + validate (api key present, base URL allowed) BEFORE the
     // dry-run skip, so a dry-run still catches missing keys / blocked URLs.
-    let api_key = resolve_api_key(&ctx.params, provider)?;
-    let base = resolve_base_url(&ctx.params, provider);
+    let api_key = resolve_api_key(&ctx.params, &provider)?;
+    let base = resolve_base_url(&ctx.params, &provider);
 
     if !super::builtin::is_url_safe(&base).await {
         return Err(permanent(format!("base_url is not allowed: {base}")));
     }
 
     // Dry-run: validation passed; skip only the model call. Mirror the output
-    // shape (empty assistant message) so downstream templates resolve.
+    // shape (empty assistant message) so downstream templates resolve. Image
+    // resolution stays AFTER this skip — a dry-run never reads artifacts.
     if dry {
         return Ok(llm_dry_run_stub(&ctx.params));
     }
 
+    multimodal::resolve_message_images(&ctx.storage, ctx.instance_id, &mut ctx.params).await?;
+
     let out = match response_schema.as_ref() {
         Some(compiled) => {
-            call_provider_with_schema(&ctx.params, &api_key, &base, provider, compiled)
+            call_provider_with_schema(&ctx.params, &api_key, &base, &provider, compiled)
                 .await
                 .map_err(SchemaCallFailure::into_permanent)?
         }
-        None => dispatch_provider(&ctx.params, &api_key, &base, provider).await?,
+        None => dispatch_provider(&ctx.params, &api_key, &base, &provider).await?,
     };
+    emit_gen_ai_telemetry(&ctx.params, &provider, &out);
     // Capture token usage for cost aggregation (best-effort — never fails the call).
     record_llm_usage(&ctx, &out).await;
     Ok(out)
+}
+
+/// Emit `OTel` `GenAI` semantic-convention telemetry for a completed LLM call.
+///
+/// A single structured `tracing::info!` event with the message
+/// `gen_ai.client.inference`, consumable by any subscriber — convention-named
+/// structured telemetry only, no OTLP exporter involved. Fields (greppable):
+///
+/// - `gen_ai.operation.name` — always `"chat"`.
+/// - `gen_ai.system` — provider name (`"openai"`, `"anthropic"`, …).
+/// - `gen_ai.request.model` — model requested in params (or the provider default).
+/// - `gen_ai.response.model` — model reported by the provider response, when present.
+/// - `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` — token usage
+///   as reported by the provider (0 when absent).
+fn emit_gen_ai_telemetry(params: &Value, provider: &str, out: &Value) {
+    let request_model = params
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| {
+            if provider == "anthropic" {
+                anthropic_default_model()
+            } else {
+                openai_default_model()
+            }
+        });
+    let response_model = out
+        .get("model")
+        .and_then(Value::as_str)
+        .filter(|m| !m.is_empty());
+    let (input_tokens, output_tokens) = usage_tokens(out);
+    tracing::info!(
+        gen_ai.operation.name = "chat",
+        gen_ai.system = provider,
+        gen_ai.request.model = request_model,
+        gen_ai.response.model = response_model,
+        gen_ai.usage.input_tokens = input_tokens,
+        gen_ai.usage.output_tokens = output_tokens,
+        "gen_ai.client.inference"
+    );
 }
 
 /// Route a single call to the correct provider API.
@@ -464,6 +540,7 @@ async fn failover_inner(
 
         match result {
             Ok(mut output) => {
+                emit_gen_ai_telemetry(&merged, provider_name, &output);
                 if let Some(obj) = output.as_object_mut() {
                     obj.insert("tried".into(), json!(tried));
                 }
@@ -976,6 +1053,310 @@ mod tests {
         assert!(matches!(err, StepError::Permanent { .. }), "{err}");
         assert!(err.to_string().contains("not a valid JSON Schema"), "{err}");
         assert_eq!(requests.lock().await.len(), 0, "no provider call made");
+    }
+
+    // --- multimodal image content (artifact store → provider wire shape) ---
+
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine as _;
+    use orch8_storage::artifacts::ObjectArtifactStore;
+
+    /// Storage with an in-memory artifact backend, for image-resolution tests.
+    async fn storage_with_artifacts() -> Arc<dyn orch8_storage::StorageBackend> {
+        Arc::new(
+            orch8_storage::sqlite::SqliteStorage::in_memory()
+                .await
+                .unwrap()
+                .with_artifact_store(Arc::new(ObjectArtifactStore::memory())),
+        )
+    }
+
+    fn ctx_with(
+        storage: &Arc<dyn orch8_storage::StorageBackend>,
+        instance_id: orch8_types::ids::InstanceId,
+        params: Value,
+    ) -> StepContext {
+        StepContext {
+            instance_id,
+            tenant_id: orch8_types::ids::TenantId::unchecked("t"),
+            block_id: orch8_types::ids::BlockId::new("b"),
+            params,
+            context: orch8_types::context::ExecutionContext::default(),
+            attempt: 0,
+            storage: Arc::clone(storage),
+            wait_for_input: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn openai_artifact_image_sent_as_data_url() {
+        let (base, requests) = start_openai_mock(vec![openai_resp("a red square", 5, 3)]).await;
+        let storage = storage_with_artifacts().await;
+        let id = orch8_types::ids::InstanceId::new();
+        let raw: &[u8] = b"\x89PNG\r\n fake image";
+        let aref = storage
+            .put_artifact(id, "image/png", bytes::Bytes::from_static(raw))
+            .await
+            .unwrap();
+
+        let ctx = ctx_with(
+            &storage,
+            id,
+            json!({
+                "provider": "openai",
+                "model": "gpt-test",
+                "api_key": "k",
+                "base_url": base,
+                "messages": [{"role": "user", "content": [
+                    {"type": "text", "text": "what is this?"},
+                    {"type": "image", "artifact": {"artifact": {"key": aref.key}}},
+                ]}],
+            }),
+        );
+        let out = handle_llm_call(ctx).await.unwrap();
+        assert_eq!(out["message"]["content"], "a red square");
+
+        let reqs = requests.lock().await;
+        assert_eq!(reqs.len(), 1);
+        let blocks = reqs[0]["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(blocks[0], json!({"type": "text", "text": "what is this?"}));
+        assert_eq!(blocks[1]["type"], "image_url");
+        let url = blocks[1]["image_url"]["url"].as_str().unwrap();
+        assert_eq!(
+            url,
+            format!("data:image/png;base64,{}", STANDARD.encode(raw)),
+            "outgoing OpenAI body carries the artifact bytes as a data URL"
+        );
+    }
+
+    #[tokio::test]
+    async fn anthropic_artifact_image_sent_as_base64_source_block() {
+        // The mock answers any path, so it serves /messages too; queue an
+        // Anthropic-shaped response body.
+        let (base, requests) = start_openai_mock(vec![json!({
+            "content": [{"type": "text", "text": "a cat"}],
+            "model": "claude-test",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 4, "output_tokens": 2},
+        })])
+        .await;
+        let storage = storage_with_artifacts().await;
+        let id = orch8_types::ids::InstanceId::new();
+        let raw: &[u8] = b"\xff\xd8\xff fake jpeg";
+        let aref = storage
+            .put_artifact(id, "image/jpeg", bytes::Bytes::from_static(raw))
+            .await
+            .unwrap();
+
+        let ctx = ctx_with(
+            &storage,
+            id,
+            json!({
+                "provider": "anthropic",
+                "model": "claude-test",
+                "api_key": "k",
+                "base_url": base,
+                "messages": [{"role": "user", "content": [
+                    {"type": "text", "text": "describe"},
+                    {"type": "image", "artifact": aref.key, "media_type": "image/jpeg"},
+                ]}],
+            }),
+        );
+        let out = handle_llm_call(ctx).await.unwrap();
+        assert_eq!(out["message"]["content"], "a cat");
+
+        let reqs = requests.lock().await;
+        assert_eq!(reqs.len(), 1);
+        let blocks = reqs[0]["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(blocks[0], json!({"type": "text", "text": "describe"}));
+        assert_eq!(
+            blocks[1],
+            json!({
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/jpeg",
+                    "data": STANDARD.encode(raw),
+                },
+            }),
+            "outgoing Anthropic body carries the base64 source block"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_image_artifact_is_permanent_without_provider_call() {
+        let (base, requests) = start_openai_mock(vec![]).await;
+        let storage = storage_with_artifacts().await;
+        let id = orch8_types::ids::InstanceId::new();
+        // Owned by this instance (passes the ownership guard) but nonexistent.
+        let missing = format!("{}/nonexistent", id.into_uuid());
+
+        let ctx = ctx_with(
+            &storage,
+            id,
+            json!({
+                "provider": "openai",
+                "model": "gpt-test",
+                "api_key": "k",
+                "base_url": base,
+                "messages": [{"role": "user", "content": [
+                    {"type": "image", "artifact": missing},
+                ]}],
+            }),
+        );
+        let err = handle_llm_call(ctx)
+            .await
+            .expect_err("missing artifact must fail the step");
+        let StepError::Permanent { message, .. } = err else {
+            panic!("expected Permanent");
+        };
+        assert!(message.contains("not found"), "{message}");
+        assert_eq!(requests.lock().await.len(), 0, "no provider call made");
+    }
+
+    #[tokio::test]
+    async fn failover_resolves_images_once_and_reuses_them() {
+        // Provider A fails key resolution (unset env var), so the loop moves
+        // on; provider B must still receive the already-resolved data URL —
+        // resolution happened once, before the failover loop.
+        let (base_b, requests_b) = start_openai_mock(vec![openai_resp("ok", 1, 1)]).await;
+        let storage = storage_with_artifacts().await;
+        let id = orch8_types::ids::InstanceId::new();
+        let raw: &[u8] = b"png-bytes";
+        let aref = storage
+            .put_artifact(id, "image/png", bytes::Bytes::from_static(raw))
+            .await
+            .unwrap();
+
+        let ctx = ctx_with(
+            &storage,
+            id,
+            json!({
+                "messages": [{"role": "user", "content": [
+                    {"type": "image", "artifact": aref.key},
+                ]}],
+                "providers": [
+                    {"provider": "openai", "api_key_env": "LLM_TEST_UNSET_KEY_VAR", "model": "m", "base_url": base_b},
+                    {"provider": "openai", "api_key": "k", "model": "m", "base_url": base_b},
+                ],
+            }),
+        );
+        let out = handle_llm_call(ctx).await.unwrap();
+        assert_eq!(out["tried"], json!(["openai", "openai"]));
+
+        let reqs = requests_b.lock().await;
+        assert_eq!(reqs.len(), 1, "only the second provider was called");
+        let url = reqs[0]["messages"][0]["content"][0]["image_url"]["url"]
+            .as_str()
+            .unwrap();
+        assert_eq!(
+            url,
+            format!("data:image/png;base64,{}", STANDARD.encode(raw))
+        );
+    }
+
+    // --- gen_ai.* telemetry (OTel GenAI semantic conventions) --------------
+    //
+    // Same Layer-based capture pattern as the warning-capture tests in
+    // expression.rs / template.rs: a subscriber layer collects events whose
+    // message is `gen_ai.client.inference` into a map of field → rendered value.
+
+    #[derive(Default)]
+    struct FieldCollector {
+        fields: std::collections::HashMap<String, String>,
+    }
+
+    impl tracing::field::Visit for FieldCollector {
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            self.fields
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+        fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+    }
+
+    struct GenAiCapture {
+        events: Arc<std::sync::Mutex<Vec<std::collections::HashMap<String, String>>>>,
+    }
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for GenAiCapture {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let mut collector = FieldCollector::default();
+            event.record(&mut collector);
+            if collector.fields.get("message").map(String::as_str)
+                == Some("gen_ai.client.inference")
+            {
+                self.events.lock().unwrap().push(collector.fields);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn gen_ai_telemetry_event_emitted_on_success() {
+        use tracing_subscriber::layer::SubscriberExt;
+        let (base, _requests) = start_openai_mock(vec![openai_resp("hi", 11, 4)]).await;
+        let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(GenAiCapture {
+            events: Arc::clone(&events),
+        });
+        // Thread-local default: the #[tokio::test] current-thread runtime runs
+        // the whole call on this thread, so every event is captured.
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let ctx = test_ctx(json!({
+            "provider": "openai",
+            "model": "gpt-test",
+            "api_key": "k",
+            "base_url": base,
+            "messages": [{"role": "user", "content": "hello"}],
+        }))
+        .await;
+        handle_llm_call(ctx).await.unwrap();
+
+        let events = events.lock().unwrap();
+        assert_eq!(events.len(), 1, "exactly one gen_ai.client.inference event");
+        let e = &events[0];
+        assert_eq!(e["gen_ai.operation.name"], "chat");
+        assert_eq!(e["gen_ai.system"], "openai");
+        assert_eq!(e["gen_ai.request.model"], "gpt-test");
+        assert_eq!(e["gen_ai.response.model"], "gpt-test");
+        assert_eq!(e["gen_ai.usage.input_tokens"], "11");
+        assert_eq!(e["gen_ai.usage.output_tokens"], "4");
+    }
+
+    #[tokio::test]
+    async fn gen_ai_telemetry_emitted_from_failover_path() {
+        use tracing_subscriber::layer::SubscriberExt;
+        let (base, _requests) = start_openai_mock(vec![openai_resp("hi", 2, 1)]).await;
+        let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(GenAiCapture {
+            events: Arc::clone(&events),
+        });
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let ctx = test_ctx(json!({
+            "messages": [{"role": "user", "content": "hello"}],
+            "providers": [
+                {"provider": "openai", "api_key": "k", "model": "m-failover", "base_url": base},
+            ],
+        }))
+        .await;
+        handle_llm_call(ctx).await.unwrap();
+
+        let events = events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0]["gen_ai.request.model"], "m-failover");
+        assert_eq!(events[0]["gen_ai.system"], "openai");
     }
 
     #[tokio::test]

--- a/orch8-engine/src/handlers/llm/multimodal.rs
+++ b/orch8-engine/src/handlers/llm/multimodal.rs
@@ -1,0 +1,467 @@
+//! Multimodal message content for `llm_call` — images via the artifact store.
+//!
+//! A message's `content` may be a plain string (unchanged behavior) or an
+//! array of content blocks. Supported block shapes:
+//!
+//! - `{"type": "text", "text": "…"}` — plain text, passed through.
+//! - `{"type": "image", "artifact": "<key>", "media_type": "image/png"}` —
+//!   image bytes fetched from the artifact store. The `artifact` value accepts
+//!   the same shapes as `blob_get`'s `ref`: a bare key string, `{"key": "…"}`,
+//!   or `{"artifact": {"key": "…"}}`.
+//! - `{"type": "image", "data": "<base64>", "media_type": "image/png"}` —
+//!   inline base64 image, passed through.
+//!
+//! [`resolve_message_images`] runs ONCE in `handle_llm_call` — after the
+//! dry-run skip (no storage reads in dry-run) but before the failover loop and
+//! schema paths — rewriting every image block into the normalized internal
+//! form `{"type": "image", "media_type": "…", "data": "<b64>"}` so each
+//! provider attempt reuses the already-fetched bytes. The provider adapters
+//! then convert the normalized form to their wire shape at request-build time
+//! ([`to_openai_message`] / [`to_anthropic_message`]). Plain-string `content`
+//! passes through every stage byte-for-byte unchanged.
+
+use std::sync::Arc;
+
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine as _;
+use serde_json::{json, Value};
+
+use orch8_storage::StorageBackend;
+use orch8_types::error::StepError;
+use orch8_types::ids::InstanceId;
+
+use super::common::permanent;
+use crate::handlers::blob::{artifact_step_err, extract_key};
+use crate::handlers::tool_call::artifact_key_owned_by;
+
+/// Default per-image size cap in bytes, pre-encoding (20 MiB). The
+/// `max_image_bytes` param can lower this, never raise it.
+pub(super) const DEFAULT_MAX_IMAGE_BYTES: u64 = 20 * 1024 * 1024;
+
+/// Media type assumed when an image block doesn't specify one. The storage
+/// layer's `get_artifact` returns raw bytes without a content type, so the
+/// block-level `media_type` (or this default) is authoritative.
+const DEFAULT_MEDIA_TYPE: &str = "image/png";
+
+/// Resolve artifact-backed image blocks in `params.messages` into the
+/// normalized internal form, in place.
+///
+/// - String `content` (and messages without array content) is untouched.
+/// - `{"type": "image", "artifact": …}` blocks are fetched from the artifact
+///   store — with the same key-shape tolerance and per-instance ownership
+///   guard as `blob_get` — and rewritten to
+///   `{"type": "image", "media_type": …, "data": "<b64>"}`.
+/// - `{"type": "image", "data": …}` inline blocks only get a `media_type`
+///   default applied.
+/// - A missing artifact, a foreign-instance key, or an image exceeding the
+///   size cap is a [`StepError::Permanent`].
+pub(super) async fn resolve_message_images(
+    storage: &Arc<dyn StorageBackend>,
+    instance_id: InstanceId,
+    params: &mut Value,
+) -> Result<(), StepError> {
+    let max_bytes = params
+        .get("max_image_bytes")
+        .and_then(Value::as_u64)
+        .map_or(DEFAULT_MAX_IMAGE_BYTES, |v| v.min(DEFAULT_MAX_IMAGE_BYTES));
+
+    let Some(messages) = params.get_mut("messages").and_then(Value::as_array_mut) else {
+        return Ok(());
+    };
+    for msg in messages.iter_mut() {
+        let Some(blocks) = msg.get_mut("content").and_then(Value::as_array_mut) else {
+            continue; // plain-string (or absent) content: untouched
+        };
+        for block in blocks.iter_mut() {
+            if block.get("type").and_then(Value::as_str) == Some("image") {
+                normalize_image_block(storage, instance_id, max_bytes, block).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Normalize one `{"type": "image", …}` block in place (see
+/// [`resolve_message_images`] for the rules).
+async fn normalize_image_block(
+    storage: &Arc<dyn StorageBackend>,
+    instance_id: InstanceId,
+    max_bytes: u64,
+    block: &mut Value,
+) -> Result<(), StepError> {
+    let Some(obj) = block.as_object_mut() else {
+        return Ok(()); // malformed block: leave for the provider to reject
+    };
+
+    // Inline base64 passthrough: already in normalized form. Default the media
+    // type and enforce the (approximate, pre-encoding) size cap.
+    if let Some(data) = obj.get("data").and_then(Value::as_str) {
+        let approx_raw = (data.len() as u64 / 4) * 3;
+        if approx_raw > max_bytes {
+            return Err(permanent(format!(
+                "llm_call: inline image (~{approx_raw} bytes decoded) exceeds max_image_bytes {max_bytes}"
+            )));
+        }
+        obj.remove("artifact");
+        obj.entry("media_type")
+            .or_insert_with(|| json!(DEFAULT_MEDIA_TYPE));
+        return Ok(());
+    }
+
+    let key = obj.get("artifact").and_then(extract_key).ok_or_else(|| {
+        permanent(
+            "llm_call: image block requires `artifact` (key string, {key}, or \
+             {artifact: {key}}) or `data` (base64)"
+                .to_string(),
+        )
+    })?;
+
+    // Same per-instance ownership guard as `blob_get` / `tool_call`: a crafted
+    // key must not read another instance's (or tenant's) artifacts.
+    if !artifact_key_owned_by(&key, instance_id) {
+        return Err(permanent(format!(
+            "llm_call: image artifact '{key}' does not belong to this instance"
+        )));
+    }
+
+    let bytes = storage
+        .get_artifact(&key)
+        .await
+        .map_err(|e| artifact_step_err("llm_call image artifact fetch error", &e))?
+        .ok_or_else(|| permanent(format!("llm_call: image artifact not found: {key}")))?;
+
+    if bytes.len() as u64 > max_bytes {
+        return Err(permanent(format!(
+            "llm_call: image artifact '{key}' is {} bytes, exceeds max_image_bytes {max_bytes}",
+            bytes.len()
+        )));
+    }
+
+    if !obj.contains_key("media_type") {
+        obj.insert("media_type".into(), json!(DEFAULT_MEDIA_TYPE));
+    }
+    obj.remove("artifact");
+    obj.insert("data".into(), json!(STANDARD.encode(&bytes)));
+    Ok(())
+}
+
+/// Convert one chat message to the OpenAI-compatible wire shape.
+///
+/// Plain-string `content` (and any non-array content) is returned unchanged —
+/// zero regression for existing string messages. In array content, normalized
+/// image blocks become
+/// `{"type": "image_url", "image_url": {"url": "data:<media_type>;base64,<data>"}}`;
+/// text and unknown blocks pass through as-is.
+pub(super) fn to_openai_message(msg: &Value) -> Value {
+    convert_message(msg, |media_type, data| {
+        json!({
+            "type": "image_url",
+            "image_url": { "url": format!("data:{media_type};base64,{data}") },
+        })
+    })
+}
+
+/// Convert one chat message to the Anthropic wire shape.
+///
+/// Plain-string `content` (and any non-array content) is returned unchanged.
+/// In array content, normalized image blocks become
+/// `{"type": "image", "source": {"type": "base64", "media_type": …, "data": …}}`;
+/// text and unknown blocks pass through as-is.
+pub(super) fn to_anthropic_message(msg: &Value) -> Value {
+    convert_message(msg, |media_type, data| {
+        json!({
+            "type": "image",
+            "source": { "type": "base64", "media_type": media_type, "data": data },
+        })
+    })
+}
+
+/// Apply `convert_image(media_type, b64_data)` to each normalized image block
+/// of an array-content message; everything else (string content, text blocks,
+/// unknown or unresolved blocks) is cloned unchanged.
+fn convert_message(msg: &Value, convert_image: impl Fn(&str, &str) -> Value) -> Value {
+    let Some(blocks) = msg.get("content").and_then(Value::as_array) else {
+        return msg.clone();
+    };
+    let converted: Vec<Value> = blocks
+        .iter()
+        .map(|b| match normalized_image_parts(b) {
+            Some((media_type, data)) => convert_image(media_type, data),
+            None => b.clone(),
+        })
+        .collect();
+    let mut out = msg.clone();
+    if let Some(obj) = out.as_object_mut() {
+        obj.insert("content".into(), Value::Array(converted));
+    }
+    out
+}
+
+/// `(media_type, data)` of a normalized image block; `None` for any other
+/// block (including an image block that was never resolved to `data`).
+fn normalized_image_parts(block: &Value) -> Option<(&str, &str)> {
+    if block.get("type").and_then(Value::as_str) != Some("image") {
+        return None;
+    }
+    let data = block.get("data").and_then(Value::as_str)?;
+    let media_type = block
+        .get("media_type")
+        .and_then(Value::as_str)
+        .unwrap_or(DEFAULT_MEDIA_TYPE);
+    Some((media_type, data))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use orch8_storage::artifacts::ObjectArtifactStore;
+    use orch8_storage::sqlite::SqliteStorage;
+
+    async fn storage_with_artifacts() -> Arc<dyn StorageBackend> {
+        Arc::new(
+            SqliteStorage::in_memory()
+                .await
+                .unwrap()
+                .with_artifact_store(Arc::new(ObjectArtifactStore::memory())),
+        )
+    }
+
+    #[tokio::test]
+    async fn string_content_untouched() {
+        let storage = storage_with_artifacts().await;
+        let mut params = json!({
+            "messages": [
+                {"role": "system", "content": "be brief"},
+                {"role": "user", "content": "hello"},
+            ],
+        });
+        let before = params.clone();
+        resolve_message_images(&storage, InstanceId::new(), &mut params)
+            .await
+            .unwrap();
+        assert_eq!(params, before, "plain-string messages must not change");
+    }
+
+    #[tokio::test]
+    async fn inline_base64_block_gets_media_type_default() {
+        let storage = storage_with_artifacts().await;
+        let b64 = STANDARD.encode(b"fake-jpeg");
+        let mut params = json!({
+            "messages": [{"role": "user", "content": [
+                {"type": "text", "text": "what is this?"},
+                {"type": "image", "data": b64},
+            ]}],
+        });
+        resolve_message_images(&storage, InstanceId::new(), &mut params)
+            .await
+            .unwrap();
+        let blocks = params["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(blocks[0], json!({"type": "text", "text": "what is this?"}));
+        assert_eq!(blocks[1]["media_type"], "image/png");
+        assert_eq!(blocks[1]["data"], json!(b64));
+    }
+
+    #[tokio::test]
+    async fn inline_base64_explicit_media_type_preserved() {
+        let storage = storage_with_artifacts().await;
+        let mut params = json!({
+            "messages": [{"role": "user", "content": [
+                {"type": "image", "data": "QUJD", "media_type": "image/webp"},
+            ]}],
+        });
+        resolve_message_images(&storage, InstanceId::new(), &mut params)
+            .await
+            .unwrap();
+        assert_eq!(
+            params["messages"][0]["content"][0]["media_type"],
+            "image/webp"
+        );
+    }
+
+    #[tokio::test]
+    async fn artifact_block_resolved_for_all_ref_shapes() {
+        let storage = storage_with_artifacts().await;
+        let id = InstanceId::new();
+        let raw = b"\x89PNG fake image bytes";
+        let aref = storage
+            .put_artifact(id, "image/png", Bytes::from_static(raw))
+            .await
+            .unwrap();
+        let expected_b64 = STANDARD.encode(raw);
+
+        // Same key-extraction tolerance as blob_get: bare string, {key},
+        // {artifact: {key}}.
+        for refval in [
+            json!(aref.key),
+            json!({"key": aref.key}),
+            json!({"artifact": {"key": aref.key}}),
+        ] {
+            let mut params = json!({
+                "messages": [{"role": "user", "content": [
+                    {"type": "image", "artifact": refval, "media_type": "image/png"},
+                ]}],
+            });
+            resolve_message_images(&storage, id, &mut params)
+                .await
+                .unwrap();
+            let block = &params["messages"][0]["content"][0];
+            assert_eq!(block["type"], "image");
+            assert_eq!(block["media_type"], "image/png");
+            assert_eq!(block["data"], json!(expected_b64));
+            assert!(block.get("artifact").is_none(), "artifact ref replaced");
+        }
+    }
+
+    #[tokio::test]
+    async fn artifact_exceeding_size_cap_is_permanent() {
+        let storage = storage_with_artifacts().await;
+        let id = InstanceId::new();
+        let aref = storage
+            .put_artifact(id, "image/png", Bytes::from(vec![0u8; 64]))
+            .await
+            .unwrap();
+        let mut params = json!({
+            "max_image_bytes": 16,
+            "messages": [{"role": "user", "content": [
+                {"type": "image", "artifact": aref.key},
+            ]}],
+        });
+        let err = resolve_message_images(&storage, id, &mut params)
+            .await
+            .expect_err("oversized image must be rejected");
+        let StepError::Permanent { message, .. } = err else {
+            panic!("expected Permanent");
+        };
+        assert!(message.contains("exceeds max_image_bytes"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn inline_data_exceeding_size_cap_is_permanent() {
+        let storage = storage_with_artifacts().await;
+        let mut params = json!({
+            "max_image_bytes": 16,
+            "messages": [{"role": "user", "content": [
+                {"type": "image", "data": STANDARD.encode(vec![0u8; 64])},
+            ]}],
+        });
+        let err = resolve_message_images(&storage, InstanceId::new(), &mut params)
+            .await
+            .expect_err("oversized inline image must be rejected");
+        assert!(matches!(err, StepError::Permanent { .. }));
+    }
+
+    #[tokio::test]
+    async fn missing_artifact_is_permanent() {
+        let storage = storage_with_artifacts().await;
+        let id = InstanceId::new();
+        // Owned by this instance (passes the ownership guard) but nonexistent.
+        let missing = format!("{}/nonexistent", id.into_uuid());
+        let mut params = json!({
+            "messages": [{"role": "user", "content": [
+                {"type": "image", "artifact": missing},
+            ]}],
+        });
+        let err = resolve_message_images(&storage, id, &mut params)
+            .await
+            .expect_err("missing artifact must be rejected");
+        let StepError::Permanent { message, .. } = err else {
+            panic!("expected Permanent");
+        };
+        assert!(message.contains("not found"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn cross_instance_artifact_key_is_rejected() {
+        let storage = storage_with_artifacts().await;
+        let victim = InstanceId::new();
+        let aref = storage
+            .put_artifact(victim, "image/png", Bytes::from_static(b"secret"))
+            .await
+            .unwrap();
+        let mut params = json!({
+            "messages": [{"role": "user", "content": [
+                {"type": "image", "artifact": aref.key},
+            ]}],
+        });
+        let err = resolve_message_images(&storage, InstanceId::new(), &mut params)
+            .await
+            .expect_err("foreign-instance artifact must be rejected");
+        let StepError::Permanent { message, .. } = err else {
+            panic!("expected Permanent");
+        };
+        assert!(
+            message.contains("does not belong to this instance"),
+            "{message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn image_block_without_artifact_or_data_is_permanent() {
+        let storage = storage_with_artifacts().await;
+        let mut params = json!({
+            "messages": [{"role": "user", "content": [{"type": "image"}]}],
+        });
+        let err = resolve_message_images(&storage, InstanceId::new(), &mut params)
+            .await
+            .expect_err("image block without a source must be rejected");
+        assert!(matches!(err, StepError::Permanent { .. }));
+    }
+
+    #[test]
+    fn to_openai_message_string_content_unchanged() {
+        let msg = json!({"role": "user", "content": "hello"});
+        assert_eq!(to_openai_message(&msg), msg);
+    }
+
+    #[test]
+    fn to_anthropic_message_string_content_unchanged() {
+        let msg = json!({"role": "user", "content": "hello"});
+        assert_eq!(to_anthropic_message(&msg), msg);
+    }
+
+    #[test]
+    fn to_openai_message_converts_normalized_image_to_data_url() {
+        let msg = json!({"role": "user", "content": [
+            {"type": "text", "text": "describe"},
+            {"type": "image", "media_type": "image/jpeg", "data": "QUJD"},
+        ]});
+        let out = to_openai_message(&msg);
+        let blocks = out["content"].as_array().unwrap();
+        assert_eq!(blocks[0], json!({"type": "text", "text": "describe"}));
+        assert_eq!(
+            blocks[1],
+            json!({
+                "type": "image_url",
+                "image_url": {"url": "data:image/jpeg;base64,QUJD"},
+            })
+        );
+    }
+
+    #[test]
+    fn to_anthropic_message_converts_normalized_image_to_source_block() {
+        let msg = json!({"role": "user", "content": [
+            {"type": "text", "text": "describe"},
+            {"type": "image", "media_type": "image/jpeg", "data": "QUJD"},
+        ]});
+        let out = to_anthropic_message(&msg);
+        let blocks = out["content"].as_array().unwrap();
+        assert_eq!(blocks[0], json!({"type": "text", "text": "describe"}));
+        assert_eq!(
+            blocks[1],
+            json!({
+                "type": "image",
+                "source": {"type": "base64", "media_type": "image/jpeg", "data": "QUJD"},
+            })
+        );
+    }
+
+    #[test]
+    fn unknown_blocks_pass_through_both_conversions() {
+        let msg = json!({"role": "user", "content": [
+            {"type": "tool_result", "id": "x"},
+        ]});
+        assert_eq!(to_openai_message(&msg), msg);
+        assert_eq!(to_anthropic_message(&msg), msg);
+    }
+}

--- a/orch8-engine/src/handlers/llm/openai.rs
+++ b/orch8-engine/src/handlers/llm/openai.rs
@@ -28,7 +28,9 @@ pub(super) async fn call_openai_compat(
             msgs.push(json!({"role": "system", "content": sys}));
         }
         if let Some(Value::Array(arr)) = params.get("messages") {
-            msgs.extend(arr.iter().cloned());
+            // Plain-string content is cloned unchanged; normalized image
+            // blocks become `image_url` data URLs at request-build time.
+            msgs.extend(arr.iter().map(super::multimodal::to_openai_message));
         }
         Value::Array(msgs)
     };


### PR DESCRIPTION
## Summary
**Multimodal `llm_call`.** Message `content` arrays now support `{"type":"text"}`, `{"type":"image","artifact":"<key>"}` (same ref tolerance as `blob_get`), and inline base64 image blocks. Images are resolved once per step — after the dry-run skip (no storage reads in dry-run), before the failover/schema paths so every provider attempt reuses fetched bytes — then converted at request-build time to OpenAI `image_url` data URLs or Anthropic base64 `source` blocks. Plain-string content behaves exactly as before. Missing artifact or oversized image (20 MiB cap, lowerable via `max_image_bytes`) → `Permanent`, with zero provider calls.

Security: image artifact resolution enforces the same per-instance ownership guard (`artifact_key_owned_by`) as `blob_get`/`tool_call` — without it this would have been a cross-tenant read hole.

**gen_ai telemetry.** A structured `tracing::info!` event `gen_ai.client.inference` (OTel GenAI semantic-convention field names: `gen_ai.operation.name`, `gen_ai.system`, `gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.usage.input_tokens/output_tokens`) is emitted on both single-provider and failover success paths. No new deps, no exporter — consumable by any subscriber; OTLP export can layer on later.

## Tests
14 multimodal unit tests, 4 mock-HTTP integration tests (OpenAI body shape, Anthropic body shape, missing artifact → no provider call, failover reuse), 2 telemetry capture tests. `cargo test -p orch8-engine`: 2078 passed. fmt/clippy/doc gates clean.

## Known edge (documented)
A `providers[]` entry overriding `messages` in per-provider config bypasses image resolution (resolution runs on base params); standard usage unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)