### PR TITLE
refactor(storage): build mobile-command ack IN-lists with sqlx QueryBuilder

### DIFF
--- a/orch8-storage/src/postgres/mobile_sync.rs
+++ b/orch8-storage/src/postgres/mobile_sync.rs
@@ -571,20 +571,18 @@ impl crate::MobileSyncStore for PostgresStorage {
         if command_ids.is_empty() {
             return Ok(0);
         }
-        let placeholders: Vec<String> = command_ids
-            .iter()
-            .enumerate()
-            .map(|(i, _)| format!("${}", i + 2))
-            .collect();
-        let sql = format!(
-            "UPDATE mobile_commands SET acked_at = now() WHERE device_id = $1 AND id IN ({})",
-            placeholders.join(",")
+        let mut qb = sqlx::QueryBuilder::new(
+            "UPDATE mobile_commands SET acked_at = now() WHERE device_id = ",
         );
-        let mut query = sqlx::query(&sql).bind(device_id);
+        qb.push_bind(device_id);
+        qb.push(" AND id IN (");
+        let mut separated = qb.separated(", ");
         for id in command_ids {
-            query = query.bind(id);
+            separated.push_bind(id);
         }
-        let result = query
+        separated.push_unseparated(")");
+        let result = qb
+            .build()
             .execute(&self.pool)
             .await
             .map_err(|e| StorageError::Query(e.to_string()))?;

--- a/orch8-storage/src/sqlite/mod.rs
+++ b/orch8-storage/src/sqlite/mod.rs
@@ -2673,16 +2673,18 @@ impl crate::MobileSyncStore for SqliteStorage {
         if command_ids.is_empty() {
             return Ok(0);
         }
-        let placeholders: Vec<&str> = command_ids.iter().map(|_| "?").collect();
-        let sql = format!(
-            "UPDATE mobile_commands SET acked_at = datetime('now') WHERE device_id = ? AND id IN ({})",
-            placeholders.join(",")
+        let mut qb: sqlx::QueryBuilder<'_, sqlx::Sqlite> = sqlx::QueryBuilder::new(
+            "UPDATE mobile_commands SET acked_at = datetime('now') WHERE device_id = ",
         );
-        let mut query = sqlx::query(&sql).bind(device_id);
+        qb.push_bind(device_id);
+        qb.push(" AND id IN (");
+        let mut separated = qb.separated(", ");
         for id in command_ids {
-            query = query.bind(id);
+            separated.push_bind(id);
         }
-        let result = query
+        separated.push_unseparated(")");
+        let result = qb
+            .build()
             .execute(&self.pool)
             .await
             .map_err(|e| StorageError::Query(e.to_string()))?;


### PR DESCRIPTION
Replaces format!-assembled placeholder SQL with `sqlx::QueryBuilder` + `push_bind` in both backends' mobile-command ack paths. Values were already bound in the old code, so this is hardening and consistency, not a live injection fix.

Validated against current main: full workspace suite 3648 passed; `cargo clippy -p orch8-storage -D warnings` clean. Supersedes the stale Sentinel PR #52 (same fix, plus #52 only adds an import reshuffle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)