### PR TITLE
⚡ Bolt: Replace HashSet allocation with binary search in scheduler

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -42,3 +42,6 @@
 ## 2025-10-28 - [Zero-Allocation Reference Tuples in Hot Path Iterators]
 **Learning:** In the fast path of the scheduler (scheduler.rs:1026), passing &BlockId by reference into get_block_outputs_batch avoids allocating and copying Strings for every step that requires a deadline check. Prior to this, BlockId was cloned on every iteration inside a loop processing active steps, introducing significant memory overhead across the cluster.
 **Action:** Always prefer accepting references within collections (&[(InstanceId, &BlockId)]) for database batch operations if the caller only holds references, preventing O(N) string clones on execution hot paths.
+## 2025-10-29 - [Avoid HashSet Allocation in Array Filtering on Hot Paths]
+**Learning:** In the `enforce_concurrency_limits` hot path within `orch8-engine/src/scheduler.rs`, building a `HashSet` simply to test indices for exclusion incurs unnecessary memory allocation and hashing overhead. When checking small numbers of exclusion indices against elements in a loop, sorting the array and using binary search provides a much faster and zero-allocation alternative.
+**Action:** When filtering out items by index or ID on hot execution paths, avoid allocating a `HashSet`. Instead, sort the indices (`.sort_unstable()`) and use `.binary_search().is_err()` to identify elements to keep.

--- a/orch8-engine/src/scheduler.rs
+++ b/orch8-engine/src/scheduler.rs
@@ -619,11 +619,15 @@ async fn enforce_concurrency_limits(
     // the holes, scrambling the priority order established by
     // claim_due_instances (e.g. deferring indices [1,3] from [A,B,C,D,E]
     // would yield [A,E,C] instead of [A,C,E]).
-    let deferred_set: std::collections::HashSet<usize> = deferred_indices.into_iter().collect();
+    //
+    // Performance: Sorting `deferred_indices` and using binary search avoids
+    // the allocation and hashing overhead of building a HashSet for
+    // exclusion checking on the execution hot path.
+    deferred_indices.sort_unstable();
     let kept = instances
         .into_iter()
         .enumerate()
-        .filter(|(i, _)| !deferred_set.contains(i))
+        .filter(|(i, _)| deferred_indices.binary_search(i).is_err())
         .map(|(_, inst)| inst)
         .collect();
 


### PR DESCRIPTION
💡 **What**: Replaced the `HashSet` allocation in `enforce_concurrency_limits` with an in-place sort of the `deferred_indices` array and a `binary_search` lookup.
🎯 **Why**: In the execution hot path of the scheduler, building a `HashSet` specifically to perform exclusion checks against small sets of elements incurs unnecessary memory allocation and hashing overhead. 
📊 **Impact**: Eliminates `HashSet` allocation for deferred indices entirely on the concurrency limits fast path, yielding zero-allocation O(log N) lookup instead of a heap-allocated O(1) hashed lookup.
🔬 **Measurement**: Verified by running `cargo test -p orch8-engine --lib scheduler::tests`, `cargo clippy`, and `cargo fmt`. Benchmarking typical batch scheduler processing would show a reduction in heap allocations and CPU time spent hashing integer indices.

---
*PR created automatically by Jules for task [14583748674299856171](https://jules.google.com/task/14583748674299856171) started by @ovasylenko*