### PR TITLE
⚡ Bolt: Replace HashSet allocation with zero-allocation binary search in scheduler limits

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -42,3 +42,6 @@
 ## 2025-10-28 - [Zero-Allocation Reference Tuples in Hot Path Iterators]
 **Learning:** In the fast path of the scheduler (scheduler.rs:1026), passing &BlockId by reference into get_block_outputs_batch avoids allocating and copying Strings for every step that requires a deadline check. Prior to this, BlockId was cloned on every iteration inside a loop processing active steps, introducing significant memory overhead across the cluster.
 **Action:** Always prefer accepting references within collections (&[(InstanceId, &BlockId)]) for database batch operations if the caller only holds references, preventing O(N) string clones on execution hot paths.
+## 2025-10-31 - [HashSet Allocation Overhead in Priority Queue Ordering]
+**Learning:** In `enforce_concurrency_limits` inside `orch8-engine/src/scheduler.rs`, the logic used a `HashSet` to filter out indices of instances that hit concurrency limits. This `HashSet` creation allocates memory and hashes every excluded index, creating significant overhead on the hot path for the execution engine loop simply to filter an array.
+**Action:** Replace `HashSet` with `Vec::sort_unstable()` and `Vec::binary_search()` to perform an O(log N) zero-allocation lookup when filtering deferred elements out of the batch in scheduler execution paths.

--- a/orch8-api/src/instances.rs
+++ b/orch8-api/src/instances.rs
@@ -31,12 +31,12 @@ pub(crate) use bulk::{
     __path_batch_action, __path_bulk_reschedule, __path_bulk_update_state, __path_list_dlq,
     batch_action, bulk_reschedule, bulk_update_state, list_dlq,
 };
+pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};
 pub(crate) use checkpoints::{
     __path_get_latest_checkpoint, __path_list_checkpoints, __path_prune_checkpoints,
     __path_save_checkpoint, get_latest_checkpoint, list_checkpoints, prune_checkpoints,
     save_checkpoint,
 };
-pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};
 pub use fork::ForkResponse;
 pub(crate) use fork::{__path_fork_instance, fork_instance};
 pub use inject::InjectBlocksRequest;
@@ -53,8 +53,8 @@ pub(crate) use outputs::{
     __path_get_execution_tree, __path_get_outputs, get_execution_tree, get_outputs,
 };
 pub(crate) use signals::{__path_send_signal, send_signal};
-pub(crate) use timeline::{__path_get_timeline, get_timeline};
 pub use timeline::{TimelineEntry, TimelineInstance, TimelineResponse, TimelineStateTransition};
+pub(crate) use timeline::{__path_get_timeline, get_timeline};
 pub use types::{
     BatchAction, BatchActionRequest, BatchActionResponse, BulkFilter, ForkRequest, InjectedSignal,
     ResumeFromRequest,

--- a/orch8-api/src/instances.rs
+++ b/orch8-api/src/instances.rs
@@ -32,6 +32,7 @@ pub(crate) use bulk::{
     batch_action, bulk_reschedule, bulk_update_state, list_dlq,
 };
 pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};
+
 pub(crate) use checkpoints::{
     __path_get_latest_checkpoint, __path_list_checkpoints, __path_prune_checkpoints,
     __path_save_checkpoint, get_latest_checkpoint, list_checkpoints, prune_checkpoints,
@@ -54,6 +55,7 @@ pub(crate) use outputs::{
 };
 pub(crate) use signals::{__path_send_signal, send_signal};
 pub use timeline::{TimelineEntry, TimelineInstance, TimelineResponse, TimelineStateTransition};
+
 pub(crate) use timeline::{__path_get_timeline, get_timeline};
 pub use types::{
     BatchAction, BatchActionRequest, BatchActionResponse, BulkFilter, ForkRequest, InjectedSignal,

--- a/orch8-engine/src/scheduler.rs
+++ b/orch8-engine/src/scheduler.rs
@@ -619,11 +619,13 @@ async fn enforce_concurrency_limits(
     // the holes, scrambling the priority order established by
     // claim_due_instances (e.g. deferring indices [1,3] from [A,B,C,D,E]
     // would yield [A,E,C] instead of [A,C,E]).
-    let deferred_set: std::collections::HashSet<usize> = deferred_indices.into_iter().collect();
+    // ⚡ Bolt: Use zero-allocation sort and binary search to avoid massive HashSet allocation overhead
+    // on the hot execution path.
+    deferred_indices.sort_unstable();
     let kept = instances
         .into_iter()
         .enumerate()
-        .filter(|(i, _)| !deferred_set.contains(i))
+        .filter(|(i, _)| deferred_indices.binary_search(i).is_err())
         .map(|(_, inst)| inst)
         .collect();
 


### PR DESCRIPTION
💡 **What**: Replaced a `HashSet` allocation in `orch8-engine/src/scheduler.rs` `enforce_concurrency_limits` with a zero-allocation `Vec::sort_unstable()` and `Vec::binary_search()` approach.
🎯 **Why**: Creating a `HashSet` from `deferred_indices` allocates memory on the heap and hashes every element. In a hot loop processing task executions, this adds significant memory and CPU overhead. Using `sort_unstable` and `binary_search` allows an O(log N) lookup directly on the existing `Vec<usize>` without any allocations.
📊 **Impact**: Reduces heap allocations and latency on the engine's scheduler hot path. The impact scales with the number of instances deferred due to concurrency limits.
🔬 **Measurement**: Verified via existing unit tests in `scheduler::tests`. The change preserves the exact same logic (filtering out indices that are present in the `deferred_indices` list) without regressions.

---
*PR created automatically by Jules for task [13146997047013780785](https://jules.google.com/task/13146997047013780785) started by @ovasylenko*