### PR TITLE
⚡ Bolt: [Zero-Allocation HashMap lookup in scheduler]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -45,3 +45,6 @@
 ## 2025-10-29 - [Avoid HashSet Allocation in Array Filtering on Hot Paths]
 **Learning:** In the `enforce_concurrency_limits` hot path within `orch8-engine/src/scheduler.rs`, building a `HashSet` simply to test indices for exclusion incurs unnecessary memory allocation and hashing overhead. When checking small numbers of exclusion indices against elements in a loop, sorting the array and using binary search provides a much faster and zero-allocation alternative.
 **Action:** When filtering out items by index or ID on hot execution paths, avoid allocating a `HashSet`. Instead, sort the indices (`.sort_unstable()`) and use `.binary_search().is_err()` to identify elements to keep.
+## 2025-10-28 - [Zero-Allocation Compound HashMap Lookups]
+**Learning:** In hot loops where a compound key (like `(InstanceId, BlockId)`) is used to query a `HashMap`, using `.contains_key(&(id1, id2.clone()))` allocates a new `String` for the second part of the tuple on every iteration.
+**Action:** When working with `HashMap`s with compound keys built from batch queries, construct a local `HashSet` or `HashMap` of references (e.g. `(&InstanceId, &BlockId)`) outside the loop, allowing zero-allocation lookups inside the hot loop.

--- a/orch8-api/src/instances.rs
+++ b/orch8-api/src/instances.rs
@@ -31,12 +31,12 @@ pub(crate) use bulk::{
     __path_batch_action, __path_bulk_reschedule, __path_bulk_update_state, __path_list_dlq,
     batch_action, bulk_reschedule, bulk_update_state, list_dlq,
 };
-pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};
 pub(crate) use checkpoints::{
     __path_get_latest_checkpoint, __path_list_checkpoints, __path_prune_checkpoints,
     __path_save_checkpoint, get_latest_checkpoint, list_checkpoints, prune_checkpoints,
     save_checkpoint,
 };
+pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};
 pub use fork::ForkResponse;
 pub(crate) use fork::{__path_fork_instance, fork_instance};
 pub use inject::InjectBlocksRequest;
@@ -53,8 +53,8 @@ pub(crate) use outputs::{
     __path_get_execution_tree, __path_get_outputs, get_execution_tree, get_outputs,
 };
 pub(crate) use signals::{__path_send_signal, send_signal};
-pub use timeline::{TimelineEntry, TimelineInstance, TimelineResponse, TimelineStateTransition};
 pub(crate) use timeline::{__path_get_timeline, get_timeline};
+pub use timeline::{TimelineEntry, TimelineInstance, TimelineResponse, TimelineStateTransition};
 pub use types::{
     BatchAction, BatchActionRequest, BatchActionResponse, BulkFilter, ForkRequest, InjectedSignal,
     ResumeFromRequest,

--- a/orch8-api/src/instances.rs
+++ b/orch8-api/src/instances.rs
@@ -31,12 +31,12 @@ pub(crate) use bulk::{
     __path_batch_action, __path_bulk_reschedule, __path_bulk_update_state, __path_list_dlq,
     batch_action, bulk_reschedule, bulk_update_state, list_dlq,
 };
+pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};
 pub(crate) use checkpoints::{
     __path_get_latest_checkpoint, __path_list_checkpoints, __path_prune_checkpoints,
     __path_save_checkpoint, get_latest_checkpoint, list_checkpoints, prune_checkpoints,
     save_checkpoint,
 };
-pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};
 pub use fork::ForkResponse;
 pub(crate) use fork::{__path_fork_instance, fork_instance};
 pub use inject::InjectBlocksRequest;
@@ -53,8 +53,8 @@ pub(crate) use outputs::{
     __path_get_execution_tree, __path_get_outputs, get_execution_tree, get_outputs,
 };
 pub(crate) use signals::{__path_send_signal, send_signal};
-pub(crate) use timeline::{__path_get_timeline, get_timeline};
 pub use timeline::{TimelineEntry, TimelineInstance, TimelineResponse, TimelineStateTransition};
+pub(crate) use timeline::{__path_get_timeline, get_timeline};
 pub use types::{
     BatchAction, BatchActionRequest, BatchActionResponse, BulkFilter, ForkRequest, InjectedSignal,
     ResumeFromRequest,

--- a/orch8-engine/src/scheduler.rs
+++ b/orch8-engine/src/scheduler.rs
@@ -1061,10 +1061,14 @@ async fn process_sla_breaches(
         .map(|c| (active[c.idx].id, &c.block_id))
         .collect();
     let existing = storage.get_block_outputs_batch(&keys).await?;
+    let mut existing_ref = std::collections::HashSet::with_capacity(existing.len());
+    for k in existing.keys() {
+        existing_ref.insert((&k.0, &k.1));
+    }
 
     for c in &candidates {
         let instance = &active[c.idx];
-        if existing.contains_key(&(instance.id, c.block_id.clone())) {
+        if existing_ref.contains(&(&instance.id, &c.block_id)) {
             continue;
         }
         // Persist the sentinel BEFORE emitting so a crash mid-emit cannot


### PR DESCRIPTION
💡 What: Replaced a `HashMap` lookup that forced a `BlockId.clone()` with a `HashSet` of borrowed reference tuples.
🎯 Why: `HashMap::contains_key` with a compound key like `(InstanceId, BlockId)` requires an owned `BlockId` on the query side if the first type is owned/borrowed differently. This caused unnecessary `String` heap allocations inside a fast loop handling SLA sentinel checks in the scheduler.
📊 Impact: Removes O(N) `String` allocations inside the scheduler's `process_sla_breaches` hot loop for instances with deadlines.
🔬 Measurement: Verify zero allocations by reviewing the reference-based `HashSet` construction outside the loop and the usage of `(&instance.id, &c.block_id)` during iteration. Tests and linters pass (`cargo clippy`, `cargo test -p orch8-engine --lib scheduler::tests`).

---
*PR created automatically by Jules for task [17251556225346661298](https://jules.google.com/task/17251556225346661298) started by @ovasylenko*