### PR TITLE
⚡ Bolt: [performance improvement] Eliminate Vector Reallocation in Scheduler Fast Path

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -56,3 +56,7 @@
 ## 2025-10-30 - [Avoid HashMap Allocation in Tree Indexing]
 **Learning:** In the `cancel_subtree` function within `orch8-engine/src/evaluator.rs`, allocating a `HashMap<ParentId, Vec<ChildId>>` to index the tree for a BFS traversal introduces massive hashing and memory allocation overhead on the cancellation hot path, resulting in O(N²) overall cost for deep trees when combining the allocation and iteration per node.
 **Action:** Replace dynamic parent-to-children index maps (`HashMap<ParentId, Vec<ChildId>>`) with a flat `Vec<(ParentId, ChildId)>` sorted by parent ID. This allows using `.partition_point()` to perform O(log N) zero-allocation lookups for children on every visited node.
+
+## 2025-10-31 - [Zero-Allocation In-Place Vector Filtering]
+**Learning:** In the `enforce_concurrency_limits` hot path within `orch8-engine/src/scheduler.rs`, filtering elements from a `Vec` into a new `Vec` via `into_iter().enumerate().filter(...).collect()` forces unnecessary reallocation of the underlying buffer. Using `retain` avoids this reallocation by filtering the `Vec` in-place, keeping memory consumption stable during heavy scheduling loads.
+**Action:** When filtering a vector that you already own on a hot path, always use `.retain()` instead of collecting into a new vector to avoid unnecessary memory allocations.

--- a/orch8-api/src/instances.rs
+++ b/orch8-api/src/instances.rs
@@ -31,12 +31,12 @@ pub(crate) use bulk::{
     __path_batch_action, __path_bulk_reschedule, __path_bulk_update_state, __path_list_dlq,
     batch_action, bulk_reschedule, bulk_update_state, list_dlq,
 };
+pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};
 pub(crate) use checkpoints::{
     __path_get_latest_checkpoint, __path_list_checkpoints, __path_prune_checkpoints,
     __path_save_checkpoint, get_latest_checkpoint, list_checkpoints, prune_checkpoints,
     save_checkpoint,
 };
-pub use checkpoints::{PruneCheckpointsRequest, SaveCheckpointRequest};
 pub use fork::ForkResponse;
 pub(crate) use fork::{__path_fork_instance, fork_instance};
 pub use inject::InjectBlocksRequest;
@@ -53,8 +53,8 @@ pub(crate) use outputs::{
     __path_get_execution_tree, __path_get_outputs, get_execution_tree, get_outputs,
 };
 pub(crate) use signals::{__path_send_signal, send_signal};
-pub(crate) use timeline::{__path_get_timeline, get_timeline};
 pub use timeline::{TimelineEntry, TimelineInstance, TimelineResponse, TimelineStateTransition};
+pub(crate) use timeline::{__path_get_timeline, get_timeline};
 pub use types::{
     BatchAction, BatchActionRequest, BatchActionResponse, BulkFilter, ForkRequest, InjectedSignal,
     ResumeFromRequest,

--- a/orch8-engine/src/scheduler.rs
+++ b/orch8-engine/src/scheduler.rs
@@ -639,14 +639,17 @@ async fn enforce_concurrency_limits(
     // the allocation and hashing overhead of building a HashSet for
     // exclusion checking on the execution hot path.
     deferred_indices.sort_unstable();
-    let kept = instances
-        .into_iter()
-        .enumerate()
-        .filter(|(i, _)| deferred_indices.binary_search(i).is_err())
-        .map(|(_, inst)| inst)
-        .collect();
+    deferred_indices.dedup();
 
-    Ok(kept)
+    let mut i = 0;
+    let mut instances = instances;
+    instances.retain(|_| {
+        let keep = deferred_indices.binary_search(&i).is_err();
+        i += 1;
+        keep
+    });
+
+    Ok(instances)
 }
 
 /// Process signals for instances in paused/waiting state.


### PR DESCRIPTION
💡 What: Replaced `into_iter().enumerate().filter(...).collect()` with `.retain(...)` in `enforce_concurrency_limits`, and added `.dedup()` after `.sort_unstable()`.
🎯 Why: `collect()` forces an unnecessary memory allocation of a new `Vec`, consuming resources under heavy load on the scheduler fast path.
📊 Impact: Eliminates a memory allocation per batch when concurrency limits are enforced, reducing GC pressure and execution time.
🔬 Measurement: Validated correctness with `cargo test -p orch8-engine --lib scheduler::tests`, ran format and clippy.

---
*PR created automatically by Jules for task [9903002544254924122](https://jules.google.com/task/9903002544254924122) started by @ovasylenko*