### PR TITLE
⚡ Bolt: Replace HashSet with Vec for block IDs tracking during output compaction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -56,3 +56,7 @@
 ## 2025-10-30 - [Avoid HashMap Allocation in Tree Indexing]
 **Learning:** In the `cancel_subtree` function within `orch8-engine/src/evaluator.rs`, allocating a `HashMap<ParentId, Vec<ChildId>>` to index the tree for a BFS traversal introduces massive hashing and memory allocation overhead on the cancellation hot path, resulting in O(N²) overall cost for deep trees when combining the allocation and iteration per node.
 **Action:** Replace dynamic parent-to-children index maps (`HashMap<ParentId, Vec<ChildId>>`) with a flat `Vec<(ParentId, ChildId)>` sorted by parent ID. This allows using `.partition_point()` to perform O(log N) zero-allocation lookups for children on every visited node.
+
+## 2024-06-28 - Avoid Deep String Allocation Overhead on Output Compaction
+**Learning:** `collect_body_block_ids` in `orch8-engine/src/evaluator.rs` was accepting a mutable `std::collections::HashSet<BlockId>`, resulting in deep heap allocation clones for every `BlockId` on the hot output compaction execution path.
+**Action:** Replaced `HashSet` with `Vec<&'a BlockId>`, utilizing borrowed references combined with `.sort_unstable()` and `.dedup()` to perform zero-allocation tracking. Search changed to `vec.binary_search()`.

--- a/orch8-engine/src/evaluator.rs
+++ b/orch8-engine/src/evaluator.rs
@@ -282,12 +282,12 @@ fn build_nodes(
 /// Collect every block id reachable inside `blocks` (the block itself plus all
 /// descendants), mirroring `build_nodes`' recursion. Used to scope output
 /// compaction to a loop/foreach body.
-fn collect_body_block_ids(
-    blocks: &[BlockDefinition],
-    out: &mut std::collections::HashSet<BlockId>,
+fn collect_body_block_ids<'a>(
+    blocks: &'a [BlockDefinition],
+    out: &mut Vec<&'a BlockId>,
 ) {
     for block in blocks {
-        out.insert(block_meta(block).0.clone());
+        out.push(block_meta(block).0);
         match block {
             BlockDefinition::Step(_) | BlockDefinition::SubSequence(_) => {}
             BlockDefinition::Parallel(p) => {
@@ -341,16 +341,18 @@ pub(crate) async fn compact_iteration_outputs(
     if retain == 0 {
         return Ok(0);
     }
-    let mut block_ids: std::collections::HashSet<BlockId> = std::collections::HashSet::new();
+    let mut block_ids: Vec<&BlockId> = Vec::new();
     collect_body_block_ids(body, &mut block_ids);
     if block_ids.is_empty() {
         return Ok(0);
     }
+    block_ids.sort_unstable();
+    block_ids.dedup();
 
     let all = storage.get_all_outputs(instance_id).await?;
     let mut by_block: HashMap<&BlockId, Vec<&orch8_types::output::BlockOutput>> = HashMap::new();
     for o in &all {
-        if block_ids.contains(&o.block_id) {
+        if block_ids.binary_search(&&o.block_id).is_ok() {
             by_block.entry(&o.block_id).or_default().push(o);
         }
     }

--- a/orch8-engine/src/evaluator.rs
+++ b/orch8-engine/src/evaluator.rs
@@ -282,10 +282,7 @@ fn build_nodes(
 /// Collect every block id reachable inside `blocks` (the block itself plus all
 /// descendants), mirroring `build_nodes`' recursion. Used to scope output
 /// compaction to a loop/foreach body.
-fn collect_body_block_ids<'a>(
-    blocks: &'a [BlockDefinition],
-    out: &mut Vec<&'a BlockId>,
-) {
+fn collect_body_block_ids<'a>(blocks: &'a [BlockDefinition], out: &mut Vec<&'a BlockId>) {
     for block in blocks {
         out.push(block_meta(block).0);
         match block {


### PR DESCRIPTION
💡 **What:** 
The `collect_body_block_ids` function in `orch8-engine/src/evaluator.rs` was allocating and cloning Strings (`BlockId`) into a `HashSet` on the hot execution path when compacting iteration outputs. I replaced `HashSet` with `Vec<&BlockId>` and adjusted the iteration to use `.sort_unstable()`, `.dedup()`, and `.binary_search()`.

🎯 **Why:** 
String allocation and hashing have a measurable overhead in hot loops. During loop iterations where we do output compactions, cloning large numbers of identifiers hurts throughput. Replacing the map with a zero-allocation vector reference lookup bypasses this constraint and mirrors performance principles observed in `orch8-engine` where similar optimizations exist.

📊 **Impact:** 
Eliminates O(N) heap allocations for block ID collection entirely on loop body traversal. Based on comparable operations in rust, avoiding String cloning combined with `.binary_search` is markedly faster for smaller block tracking limits than a clone-heavy Hashset map.

🔬 **Measurement:** 
Testing confirms exact behavioral compatibility passing `cargo test -p orch8-engine --lib evaluator::tests`.

---
*PR created automatically by Jules for task [14973451970852441863](https://jules.google.com/task/14973451970852441863) started by @ovasylenko*