### PR TITLE
⚡ Bolt: Remove Vec allocation overhead from evaluator checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -67,3 +67,6 @@
 ## 2025-10-31 - [Zero-Allocation In-Place Vector Filtering]
 **Learning:** In the `enforce_concurrency_limits` hot path within `orch8-engine/src/scheduler.rs`, filtering elements from a `Vec` into a new `Vec` via `into_iter().enumerate().filter(...).collect()` forces unnecessary reallocation of the underlying buffer. Using `retain` avoids this reallocation by filtering the `Vec` in-place, keeping memory consumption stable during heavy scheduling loads.
 **Action:** When filtering a vector that you already own on a hot path, always use `.retain()` instead of collecting into a new vector to avoid unnecessary memory allocations.
+## 2025-10-31 - [Single-Pass Iterator Optimization]
+**Learning:** In the `check_termination` function within `orch8-engine/src/evaluator.rs`, the original code collected `.iter().filter(|n| n.parent_id.is_none())` into a `Vec` and then iterated over it three times with `.all()` and `.any()` checks. Allocating a `Vec` inside a hot evaluation loop is unnecessary and negatively impacts performance.
+**Action:** When performing aggregate checks on filtered elements in a hot path, prefer single-pass evaluation loops using boolean accumulators over collecting elements into an intermediate `Vec`. Ensure edge-case handling (like `.all()` returning `true` on an empty iterator) is strictly replicated in the rewritten logic.

--- a/orch8-engine/src/evaluator.rs
+++ b/orch8-engine/src/evaluator.rs
@@ -582,25 +582,34 @@ pub async fn evaluate(
 /// Check if root nodes indicate the instance is done (all completed/skipped,
 /// or any failed/cancelled).
 fn check_termination(tree: &[ExecutionNode]) -> Option<EvalOutcome> {
-    let root_nodes: Vec<&ExecutionNode> = tree.iter().filter(|n| n.parent_id.is_none()).collect();
+    let mut any_failed = false;
+    let mut any_cancelled = false;
+    let mut all_completed_or_skipped = true;
 
-    // Termination: all root nodes done.
-    if root_nodes
-        .iter()
-        .all(|n| matches!(n.state, NodeState::Completed | NodeState::Skipped))
-    {
+    for n in tree.iter().filter(|n| n.parent_id.is_none()) {
+        match n.state {
+            NodeState::Completed | NodeState::Skipped => {}
+            NodeState::Failed => {
+                any_failed = true;
+                all_completed_or_skipped = false;
+            }
+            NodeState::Cancelled => {
+                any_cancelled = true;
+                all_completed_or_skipped = false;
+            }
+            _ => {
+                all_completed_or_skipped = false;
+            }
+        }
+    }
+
+    if all_completed_or_skipped {
         return Some(EvalOutcome::Done {
             any_failed: false,
             any_cancelled: false,
         });
     }
-    // Termination: any root node failed/cancelled.
-    if root_nodes
-        .iter()
-        .any(|n| matches!(n.state, NodeState::Failed | NodeState::Cancelled))
-    {
-        let any_failed = root_nodes.iter().any(|n| n.state == NodeState::Failed);
-        let any_cancelled = root_nodes.iter().any(|n| n.state == NodeState::Cancelled);
+    if any_failed || any_cancelled {
         return Some(EvalOutcome::Done {
             any_failed,
             any_cancelled,
@@ -622,26 +631,24 @@ async fn phase_root_activation(
     sequence: &SequenceDefinition,
     outputs_snapshot: &OutputsSnapshot,
 ) -> Result<IterAction, EngineError> {
-    let root_nodes: Vec<&ExecutionNode> =
-        ctx.tree.iter().filter(|n| n.parent_id.is_none()).collect();
-
-    let first_pending_idx = root_nodes
-        .iter()
-        .position(|n| n.state == NodeState::Pending);
-    let Some(idx) = first_pending_idx else {
-        return Ok(IterAction::FallThrough);
-    };
-
-    // Only activate if all prior roots are done.
-    let all_prior_done = root_nodes[..idx].iter().all(|n| {
-        matches!(
+    let mut pending_node = None;
+    for n in ctx.tree.iter().filter(|n| n.parent_id.is_none()) {
+        if n.state == NodeState::Pending {
+            pending_node = Some(n);
+            break;
+        }
+        if !matches!(
             n.state,
             NodeState::Completed | NodeState::Failed | NodeState::Cancelled | NodeState::Skipped
-        )
-    });
-    if !all_prior_done {
-        return Ok(IterAction::FallThrough);
+        ) {
+            // A prior root is not done yet, so we cannot activate any pending root.
+            return Ok(IterAction::FallThrough);
+        }
     }
+
+    let Some(node) = pending_node else {
+        return Ok(IterAction::FallThrough);
+    };
 
     // Before activating new work, check if a cancel/pause signal arrived
     // mid-tick. Process it now to avoid dispatching already-cancelled or
@@ -679,7 +686,6 @@ async fn phase_root_activation(
         return Ok(IterAction::Continue);
     }
 
-    let node = root_nodes[idx];
     if let Some(block) = block_map.get(&node.block_id).copied() {
         dispatch_block(
             storage,

--- a/orch8-engine/src/template.rs
+++ b/orch8-engine/src/template.rs
@@ -1841,7 +1841,7 @@ mod tests {
             &json!({}),
         )
         .unwrap();
-        assert!(result.as_str().unwrap().len() == 64);
+        assert_eq!(result.as_str().unwrap().len(), 64);
     }
 
     // --- round filter ---
@@ -2069,7 +2069,7 @@ mod tests {
         let seq = mk_seq(vec![lp]);
         let warnings = validate_sequence_templates(&seq);
         assert_eq!(warnings.len(), 1);
-        assert!(warnings[0].field == "condition");
+        assert_eq!(warnings[0].field, "condition");
     }
 
     // --- state.* template resolution tests ---

--- a/orch8-storage/src/postgres/misc.rs
+++ b/orch8-storage/src/postgres/misc.rs
@@ -250,9 +250,7 @@ pub(super) async fn get_injected_blocks(
             .bind(instance_id.into_uuid())
             .fetch_optional(&store.pool)
             .await?;
-    Ok(row
-        .and_then(|(v,)| v)
-        .and_then(|v| if v.is_null() { None } else { Some(v) }))
+    Ok(row.and_then(|(v,)| v).filter(|v| !v.is_null()))
 }
 
 pub(super) async fn inject_blocks_at_position(
@@ -274,9 +272,7 @@ pub(super) async fn inject_blocks_at_position(
         .fetch_optional(&mut *tx)
         .await?;
 
-        let existing = row
-            .and_then(|(v,)| v)
-            .and_then(|v| if v.is_null() { None } else { Some(v) });
+        let existing = row.and_then(|(v,)| v).filter(|v| !v.is_null());
 
         let mut arr = existing
             .and_then(|v| v.as_array().cloned())


### PR DESCRIPTION
💡 What: Replaced a sequence of `.collect::<Vec<_>>()` and `.iter()` calls in `check_termination` and `phase_root_activation` inside `orch8-engine/src/evaluator.rs` with single-pass iterator traversals avoiding allocation.
🎯 Why: In a hot evaluation loop, repeatedly allocating a `Vec` just to store references for three simple boolean checks (`.all()` / `.any()`) or to find the first pending element introduces significant, unnecessary heap memory allocation. 
📊 Impact: Eliminates `Vec` allocation overhead on every evaluation loop tick for both termination checking and root node activation logic, improving CPU and memory efficiency.
🔬 Measurement: Verify correctness through `cargo test -p orch8-engine --lib evaluator`. Memory profiling would show zero allocations during the termination loop pass.

---
*PR created automatically by Jules for task [7567445089162289647](https://jules.google.com/task/7567445089162289647) started by @ovasylenko*