### PR TITLE
⚡ Bolt: Remove unnecessary String clone in scheduler hot path

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -70,3 +70,7 @@
 ## 2025-10-31 - [Single-Pass Iterator Optimization]
 **Learning:** In the `check_termination` function within `orch8-engine/src/evaluator.rs`, the original code collected `.iter().filter(|n| n.parent_id.is_none())` into a `Vec` and then iterated over it three times with `.all()` and `.any()` checks. Allocating a `Vec` inside a hot evaluation loop is unnecessary and negatively impacts performance.
 **Action:** When performing aggregate checks on filtered elements in a hot path, prefer single-pass evaluation loops using boolean accumulators over collecting elements into an intermediate `Vec`. Ensure edge-case handling (like `.all()` returning `true` on an empty iterator) is strictly replicated in the rewritten logic.
+
+## 2025-11-01 - [Avoid Cloning Strings for Reference Passing]
+**Learning:** In the activepieces integration of the scheduler hot loop (`orch8-engine/src/scheduler.rs`), a `String` field (`step.handler`) was being cloned into a new local variable merely to pass its reference (`&handler_name`) to a downstream handler function. This caused an unnecessary heap allocation on an execution hot path.
+**Action:** When calling functions that require string references (`&str`), always pass a reference directly from the source struct (`&step.handler`) rather than cloning the `String` first.

--- a/orch8-engine/src/handlers/step.rs
+++ b/orch8-engine/src/handlers/step.rs
@@ -127,8 +127,7 @@ pub async fn execute_step_dry(
         // clamping — a clamp would make every retry past 32 767 collide
         // against the same row and silently replay a stale output.
         let matches_memoized = u16::try_from(exec.attempt)
-            .ok()
-            .is_some_and(|a| existing.attempt == a);
+            .is_ok_and(|a| existing.attempt == a);
         if matches_memoized {
             info!(
                 instance_id = %exec.instance_id,
@@ -328,8 +327,7 @@ pub async fn execute_step(
         // clamping — a clamp would make every retry past 32 767 collide
         // against the same row and silently replay a stale output.
         let matches_memoized = u16::try_from(exec.attempt)
-            .ok()
-            .is_some_and(|a| existing.attempt == a);
+            .is_ok_and(|a| existing.attempt == a);
         if matches_memoized {
             info!(
                 instance_id = %exec.instance_id,

--- a/orch8-engine/src/handlers/step.rs
+++ b/orch8-engine/src/handlers/step.rs
@@ -126,8 +126,7 @@ pub async fn execute_step_dry(
         // the block_outputs.attempt column. Refuse to memoize rather than
         // clamping — a clamp would make every retry past 32 767 collide
         // against the same row and silently replay a stale output.
-        let matches_memoized = u16::try_from(exec.attempt)
-            .is_ok_and(|a| existing.attempt == a);
+        let matches_memoized = u16::try_from(exec.attempt).is_ok_and(|a| existing.attempt == a);
         if matches_memoized {
             info!(
                 instance_id = %exec.instance_id,
@@ -326,8 +325,7 @@ pub async fn execute_step(
         // the block_outputs.attempt column. Refuse to memoize rather than
         // clamping — a clamp would make every retry past 32 767 collide
         // against the same row and silently replay a stale output.
-        let matches_memoized = u16::try_from(exec.attempt)
-            .is_ok_and(|a| existing.attempt == a);
+        let matches_memoized = u16::try_from(exec.attempt).is_ok_and(|a| existing.attempt == a);
         if matches_memoized {
             info!(
                 instance_id = %exec.instance_id,

--- a/orch8-engine/src/scheduler.rs
+++ b/orch8-engine/src/scheduler.rs
@@ -1073,8 +1073,8 @@ async fn run_cleanup_hooks(
         let result = if let Some(handler) = handlers.get(&step.handler) {
             dispatch_hook_bounded(handler(ctx)).await
         } else if crate::handlers::activepieces::is_ap_handler(&step.handler) {
-            let handler_name = step.handler.clone();
-            dispatch_hook_bounded(crate::handlers::activepieces::handle_ap(ctx, &handler_name))
+            // ⚡ Bolt: Avoid cloning `step.handler` String just to pass a reference.
+            dispatch_hook_bounded(crate::handlers::activepieces::handle_ap(ctx, &step.handler))
                 .await
         } else if crate::handlers::grpc_plugin::is_grpc_handler(&step.handler) {
             let Some(endpoint) = crate::handlers::step_dispatch::resolve_plugin_source(


### PR DESCRIPTION
💡 What: Removed a `.clone()` call on `step.handler` inside the `scheduler.rs` loop when dispatching to `activepieces`.
🎯 Why: `handle_ap` expects a `&str`. The code was cloning the `String` into a new `handler_name` local variable simply to pass its reference, which creates an entirely unnecessary heap allocation on every evaluation of this hook within the scheduler tick.
📊 Impact: Eliminates a redundant `String` heap allocation on the hot path for activepieces step evaluation.
🔬 Measurement: Verify via `cargo test -p orch8-engine --lib scheduler::tests`, ensuring all test cases pass without regressions.

---
*PR created automatically by Jules for task [14677780503107139046](https://jules.google.com/task/14677780503107139046) started by @ovasylenko*