### PR TITLE
⚡ Bolt: Zero-allocation vector filtering in concurrency hot path

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -71,6 +71,10 @@
 **Learning:** In the `check_termination` function within `orch8-engine/src/evaluator.rs`, the original code collected `.iter().filter(|n| n.parent_id.is_none())` into a `Vec` and then iterated over it three times with `.all()` and `.any()` checks. Allocating a `Vec` inside a hot evaluation loop is unnecessary and negatively impacts performance.
 **Action:** When performing aggregate checks on filtered elements in a hot path, prefer single-pass evaluation loops using boolean accumulators over collecting elements into an intermediate `Vec`. Ensure edge-case handling (like `.all()` returning `true` on an empty iterator) is strictly replicated in the rewritten logic.
 
+## 2025-10-31 - [Zero-Allocation In-Place Vector Filtering with Original Indices]
+**Learning:** In hot paths (like `filter_by_concurrency_pg`), filtering elements from a `Vec` into a new `Vec` via `into_iter().enumerate().filter(...).collect()` forces unnecessary reallocation of the underlying buffer.
+**Action:** When filtering a vector that you already own on a hot path and need the original index, always use `.retain()` with an external mutable counter variable instead of collecting into a new vector to avoid unnecessary memory allocations.
+
 ## 2025-11-01 - [Avoid Cloning Strings for Reference Passing]
 **Learning:** In the activepieces integration of the scheduler hot loop (`orch8-engine/src/scheduler.rs`), a `String` field (`step.handler`) was being cloned into a new local variable merely to pass its reference (`&handler_name`) to a downstream handler function. This caused an unnecessary heap allocation on an execution hot path.
 **Action:** When calling functions that require string references (`&str`), always pass a reference directly from the source struct (`&step.handler`) rather than cloning the `String` first.

--- a/orch8-storage/src/postgres/instances.rs
+++ b/orch8-storage/src/postgres/instances.rs
@@ -343,12 +343,15 @@ async fn filter_by_concurrency_pg(
     // during the `binary_search` filtering phase, improving hot path performance.
     excluded.dedup();
 
-    Ok(candidates
-        .into_iter()
-        .enumerate()
-        .filter(|(idx, _)| excluded.binary_search(idx).is_err())
-        .map(|(_, inst)| inst)
-        .collect())
+    let mut idx = 0;
+    let mut candidates = candidates;
+    candidates.retain(|_| {
+        let keep = excluded.binary_search(&idx).is_err();
+        idx += 1;
+        keep
+    });
+
+    Ok(candidates)
 }
 
 pub(super) async fn update_state(

--- a/orch8-storage/src/sqlite/instances.rs
+++ b/orch8-storage/src/sqlite/instances.rs
@@ -281,12 +281,15 @@ async fn filter_by_concurrency(
     // during the `binary_search` filtering phase, improving hot path performance.
     excluded.dedup();
 
-    Ok(candidates
-        .into_iter()
-        .enumerate()
-        .filter(|(idx, _)| excluded.binary_search(idx).is_err())
-        .map(|(_, inst)| inst)
-        .collect())
+    let mut idx = 0;
+    let mut candidates = candidates;
+    candidates.retain(|_| {
+        let keep = excluded.binary_search(&idx).is_err();
+        idx += 1;
+        keep
+    });
+
+    Ok(candidates)
 }
 
 pub(super) async fn update_state(


### PR DESCRIPTION
💡 What: Replaced out-of-place vector filtering (`into_iter().enumerate().filter().collect()`) with in-place mutation (`retain()`) in `filter_by_concurrency` and `filter_by_concurrency_pg`.
🎯 Why: `filter_by_concurrency` operates directly on a vector passed by value in the scheduler execution hot path. Re-collecting elements forces a new buffer allocation and moves memory unnecessarily.
📊 Impact: Eliminates a `Vec` memory allocation and buffer copy per batch in the `claim_due_instances` path, improving memory stability during heavy scheduling load.
🔬 Measurement: Verify with `cargo test -p orch8-storage`. Code operates exactly as before but with zero reallocation overhead.

---
*PR created automatically by Jules for task [14725430113395233040](https://jules.google.com/task/14725430113395233040) started by @ovasylenko*