### PR TITLE
🛡️ Sentinel: [security improvement] Remove dynamic SQL formatting in instance deletion queries

### DIFF
--- a/migrations/down/072_resumable_worker_activities.sql
+++ b/migrations/down/072_resumable_worker_activities.sql
@@ -1,2 +1,3 @@
+-- Reverses 072_resumable_worker_activities
 ALTER TABLE worker_tasks DROP COLUMN IF EXISTS checkpoint_seq;
 ALTER TABLE worker_tasks DROP COLUMN IF EXISTS resume_checkpoint;

--- a/migrations/down/073_shared_agent_knowledge.sql
+++ b/migrations/down/073_shared_agent_knowledge.sql
@@ -1,1 +1,2 @@
+-- Reverses 073_shared_agent_knowledge
 DROP TABLE IF EXISTS shared_agent_knowledge;

--- a/migrations/down/074_partition_high_volume_tables.sql
+++ b/migrations/down/074_partition_high_volume_tables.sql
@@ -1,3 +1,4 @@
+-- Reverses 074_partition_high_volume_tables
 ALTER TABLE block_outputs RENAME TO block_outputs_partitioned_074;
 ALTER TABLE block_outputs_partitioned_074
     DROP CONSTRAINT IF EXISTS block_outputs_pkey;

--- a/orch8-storage/src/postgres/instances.rs
+++ b/orch8-storage/src/postgres/instances.rs
@@ -1109,8 +1109,12 @@ pub(super) async fn delete_terminal_instances(
     // externalized_state / audit_log (all cascade -- see migrations 016 and
     // 034).
     for table in ["step_logs", "usage_events"] {
-        let sql = format!("DELETE FROM {table} WHERE instance_id = ANY($1)");
-        sqlx::query(&sql).bind(&ids).execute(&mut *tx).await?;
+        let sql = match table {
+            "step_logs" => "DELETE FROM step_logs WHERE instance_id = ANY($1)",
+            "usage_events" => "DELETE FROM usage_events WHERE instance_id = ANY($1)",
+            _ => unreachable!(),
+        };
+        sqlx::query(sql).bind(&ids).execute(&mut *tx).await?;
     }
 
     let result = sqlx::query("DELETE FROM task_instances WHERE id = ANY($1)")

--- a/orch8-storage/src/sqlite/instances.rs
+++ b/orch8-storage/src/sqlite/instances.rs
@@ -985,7 +985,12 @@ pub(super) async fn delete_terminal_instances(
     // doesn't. All three are deleted explicitly here so the divergence
     // doesn't leave orphans on this backend.
     for table in ["step_logs", "audit_log", "usage_events"] {
-        let sql = format!("DELETE FROM {table} WHERE instance_id IN (");
+        let sql = match table {
+            "step_logs" => "DELETE FROM step_logs WHERE instance_id IN (",
+            "audit_log" => "DELETE FROM audit_log WHERE instance_id IN (",
+            "usage_events" => "DELETE FROM usage_events WHERE instance_id IN (",
+            _ => unreachable!(),
+        };
         let mut qb: sqlx::QueryBuilder<'_, sqlx::Sqlite> = sqlx::QueryBuilder::new(sql);
         let mut separated = qb.separated(",");
         for id in &ids {


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: Dynamic string formatting (`format!`) was used to construct SQL queries by interpolating table names (`step_logs`, `usage_events`, `audit_log`) during instance garbage collection/deletion.
🎯 Impact: While not directly exploitable (as the table names were hardcoded in static arrays within the function), using `format!` for SQL structural components is an unsafe pattern that bypasses static SQL verification. If the list of tables were ever refactored to accept external input, it could result in SQL injection.
🔧 Fix: Replaced the dynamic formatting with exhaustive `match` statements that map table names to hardcoded SQL query strings. Also added missing comment headers to rollback migrations to ensure the test suite (`migration_rollback`) passes.
✅ Verification: Ran `cargo +nightly test -p orch8-storage` and `cargo +nightly clippy -p orch8-storage`. Code review approved the changes.

---
*PR created automatically by Jules for task [1788426567162971381](https://jules.google.com/task/1788426567162971381) started by @ovasylenko*