### PR TITLE
test(engine): expand boundary and dataflow coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
         run: ./scripts/check-destructive-migrations.sh
       - name: Review-fix guard regression tests
         run: ./scripts/test-review-fix-guards.sh
+      - name: Expanded test counts
+        run: bash ./scripts/check-expanded-test-counts.sh
       - name: Check
         run: cargo check --workspace
       - name: Generated client contract

--- a/orch8-api/src/client_contract.rs
+++ b/orch8-api/src/client_contract.rs
@@ -76,3 +76,7 @@ mod tests {
         assert!(generate_javascript_client().contains("/releases/{id}/validate"));
     }
 }
+
+#[cfg(test)]
+#[path = "client_contract_boundary_tests.rs"]
+mod boundary_tests;

--- a/orch8-api/src/client_contract_boundary_tests.rs
+++ b/orch8-api/src/client_contract_boundary_tests.rs
@@ -1,0 +1,103 @@
+//! Generated-client contract edge cases.
+//!
+//! Count contract: 20 independently named unit tests.
+
+use super::*;
+
+macro_rules! escape_case {
+    ($name:ident, $input:expr, $expected:expr) => {
+        #[test]
+        fn $name() {
+            let actual = escape($input);
+            assert_eq!(actual, $expected);
+        }
+    };
+}
+
+escape_case!(coverage_client_contract_001_empty_pointer_segment, "", "");
+escape_case!(coverage_client_contract_002_root_slash, "/", "~1");
+escape_case!(
+    coverage_client_contract_003_instances_path,
+    "/instances",
+    "~1instances"
+);
+escape_case!(
+    coverage_client_contract_004_nested_path,
+    "/instances/{id}",
+    "~1instances~1{id}"
+);
+escape_case!(
+    coverage_client_contract_005_tilde_is_escaped_first,
+    "~",
+    "~0"
+);
+escape_case!(coverage_client_contract_006_tilde_then_slash, "~/", "~0~1");
+escape_case!(coverage_client_contract_007_slash_then_tilde, "/~", "~1~0");
+escape_case!(coverage_client_contract_008_double_tilde, "~~", "~0~0");
+escape_case!(coverage_client_contract_009_double_slash, "//", "~1~1");
+escape_case!(
+    coverage_client_contract_010_literal_escape_text,
+    "~1",
+    "~01"
+);
+escape_case!(
+    coverage_client_contract_011_unicode_path,
+    "/sequências/ação",
+    "~1sequências~1ação"
+);
+escape_case!(
+    coverage_client_contract_012_query_like_text,
+    "/items?x=1",
+    "~1items?x=1"
+);
+
+macro_rules! generated_contains_case {
+    ($name:ident, $generator:expr, $needle:expr) => {
+        #[test]
+        fn $name() {
+            let generated = ($generator)();
+            assert!(generated.contains($needle));
+        }
+    };
+}
+
+generated_contains_case!(
+    coverage_client_contract_013_rust_has_instances_create,
+    generate_rust_client,
+    "(\"post\", \"/instances\")"
+);
+generated_contains_case!(
+    coverage_client_contract_014_rust_has_instance_get,
+    generate_rust_client,
+    "(\"get\", \"/instances/{id}\")"
+);
+generated_contains_case!(
+    coverage_client_contract_015_rust_has_release_validate,
+    generate_rust_client,
+    "(\"post\", \"/releases/{id}/validate\")"
+);
+generated_contains_case!(
+    coverage_client_contract_016_rust_has_timeline_get,
+    generate_rust_client,
+    "(\"get\", \"/instances/{id}/timeline\")"
+);
+generated_contains_case!(
+    coverage_client_contract_017_javascript_has_instances_create,
+    generate_javascript_client,
+    "method: \"post\", path: \"/instances\""
+);
+generated_contains_case!(
+    coverage_client_contract_018_javascript_has_instance_get,
+    generate_javascript_client,
+    "method: \"get\", path: \"/instances/{id}\""
+);
+generated_contains_case!(
+    coverage_client_contract_019_javascript_has_release_validate,
+    generate_javascript_client,
+    "method: \"post\", path: \"/releases/{id}/validate\""
+);
+generated_contains_case!(
+    coverage_client_contract_020_javascript_has_timeline_get,
+    generate_javascript_client,
+    "method: \"get\", path: \"/instances/{id}/timeline\""
+);

--- a/orch8-api/src/entitlements.rs
+++ b/orch8-api/src/entitlements.rs
@@ -165,3 +165,7 @@ mod tests {
         assert!(plan.validate().is_err());
     }
 }
+
+#[cfg(test)]
+#[path = "entitlements_boundary_tests.rs"]
+mod boundary_tests;

--- a/orch8-api/src/entitlements_boundary_tests.rs
+++ b/orch8-api/src/entitlements_boundary_tests.rs
@@ -1,0 +1,276 @@
+//! Additional boundary coverage for provider-neutral plan admission.
+//!
+//! Count contract: 40 independently named unit tests.
+
+use super::*;
+
+fn valid_plan() -> PlanEntitlements {
+    PlanEntitlements {
+        plan_id: "team".into(),
+        max_active_instances: 10,
+        max_batch_instances: 100,
+        max_context_bytes: 4096,
+        allowed_namespaces: BTreeSet::new(),
+        features: BTreeSet::new(),
+    }
+}
+
+macro_rules! validation_case {
+    ($name:ident, $mutate:expr, $valid:expr) => {
+        #[test]
+        fn $name() {
+            let mut plan = valid_plan();
+            ($mutate)(&mut plan);
+            let result = plan.validate();
+            assert_eq!(result.is_ok(), $valid);
+        }
+    };
+}
+
+validation_case!(
+    coverage_entitlement_001_empty_plan_id_is_invalid,
+    |p: &mut PlanEntitlements| p.plan_id.clear(),
+    false
+);
+validation_case!(
+    coverage_entitlement_002_single_character_plan_id_is_valid,
+    |p: &mut PlanEntitlements| p.plan_id = "x".into(),
+    true
+);
+validation_case!(
+    coverage_entitlement_003_whitespace_plan_id_is_preserved,
+    |p: &mut PlanEntitlements| p.plan_id = " ".into(),
+    true
+);
+validation_case!(
+    coverage_entitlement_004_unicode_plan_id_is_valid,
+    |p: &mut PlanEntitlements| p.plan_id = "plano-pró".into(),
+    true
+);
+validation_case!(
+    coverage_entitlement_005_hyphenated_plan_id_is_valid,
+    |p: &mut PlanEntitlements| p.plan_id = "team-pro".into(),
+    true
+);
+validation_case!(
+    coverage_entitlement_006_long_plan_id_does_not_change_limits,
+    |p: &mut PlanEntitlements| p.plan_id = "x".repeat(512),
+    true
+);
+validation_case!(
+    coverage_entitlement_007_zero_active_instances_is_invalid,
+    |p: &mut PlanEntitlements| p.max_active_instances = 0,
+    false
+);
+validation_case!(
+    coverage_entitlement_008_one_active_instance_is_valid,
+    |p: &mut PlanEntitlements| p.max_active_instances = 1,
+    true
+);
+validation_case!(
+    coverage_entitlement_009_large_active_instance_limit_is_valid,
+    |p: &mut PlanEntitlements| p.max_active_instances = 1_000_000,
+    true
+);
+validation_case!(
+    coverage_entitlement_010_unlimited_active_instances_is_valid,
+    |p: &mut PlanEntitlements| p.max_active_instances = u64::MAX,
+    true
+);
+validation_case!(
+    coverage_entitlement_011_zero_batch_limit_is_invalid,
+    |p: &mut PlanEntitlements| p.max_batch_instances = 0,
+    false
+);
+validation_case!(
+    coverage_entitlement_012_one_batch_item_is_valid,
+    |p: &mut PlanEntitlements| p.max_batch_instances = 1,
+    true
+);
+validation_case!(
+    coverage_entitlement_013_batch_limit_99_is_valid,
+    |p: &mut PlanEntitlements| p.max_batch_instances = 99,
+    true
+);
+validation_case!(
+    coverage_entitlement_014_batch_limit_100_is_valid,
+    |p: &mut PlanEntitlements| p.max_batch_instances = 100,
+    true
+);
+validation_case!(
+    coverage_entitlement_015_batch_limit_9999_is_valid,
+    |p: &mut PlanEntitlements| p.max_batch_instances = 9_999,
+    true
+);
+validation_case!(
+    coverage_entitlement_016_batch_limit_10000_is_valid,
+    |p: &mut PlanEntitlements| p.max_batch_instances = 10_000,
+    true
+);
+validation_case!(
+    coverage_entitlement_017_batch_limit_10001_is_invalid,
+    |p: &mut PlanEntitlements| p.max_batch_instances = 10_001,
+    false
+);
+validation_case!(
+    coverage_entitlement_018_maximum_u32_batch_is_invalid,
+    |p: &mut PlanEntitlements| p.max_batch_instances = u32::MAX,
+    false
+);
+validation_case!(
+    coverage_entitlement_019_zero_context_bytes_is_invalid,
+    |p: &mut PlanEntitlements| p.max_context_bytes = 0,
+    false
+);
+validation_case!(
+    coverage_entitlement_020_one_context_byte_is_valid,
+    |p: &mut PlanEntitlements| p.max_context_bytes = 1,
+    true
+);
+validation_case!(
+    coverage_entitlement_021_context_limit_1024_is_valid,
+    |p: &mut PlanEntitlements| p.max_context_bytes = 1024,
+    true
+);
+validation_case!(
+    coverage_entitlement_022_context_limit_one_megabyte_is_valid,
+    |p: &mut PlanEntitlements| p.max_context_bytes = 1_048_576,
+    true
+);
+validation_case!(
+    coverage_entitlement_023_maximum_context_limit_is_valid,
+    |p: &mut PlanEntitlements| p.max_context_bytes = u32::MAX,
+    true
+);
+validation_case!(
+    coverage_entitlement_024_empty_namespace_set_is_valid,
+    |p: &mut PlanEntitlements| p.allowed_namespaces.clear(),
+    true
+);
+validation_case!(
+    coverage_entitlement_025_single_namespace_is_valid,
+    |p: &mut PlanEntitlements| p.allowed_namespaces.insert("prod".into()),
+    true
+);
+validation_case!(
+    coverage_entitlement_026_unicode_namespace_policy_is_valid,
+    |p: &mut PlanEntitlements| p.allowed_namespaces.insert("produção".into()),
+    true
+);
+validation_case!(
+    coverage_entitlement_027_empty_feature_set_is_valid,
+    |p: &mut PlanEntitlements| p.features.clear(),
+    true
+);
+validation_case!(
+    coverage_entitlement_028_named_feature_is_valid,
+    |p: &mut PlanEntitlements| p.features.insert("continuity".into()),
+    true
+);
+validation_case!(
+    coverage_entitlement_029_multiple_features_are_valid,
+    |p: &mut PlanEntitlements| {
+        p.features.insert("continuity".into());
+        p.features.insert("mobile".into());
+    },
+    true
+);
+validation_case!(
+    coverage_entitlement_030_unlimited_plan_validates,
+    |p: &mut PlanEntitlements| *p = PlanEntitlements::unlimited(),
+    true
+);
+
+macro_rules! catalog_case {
+    ($name:ident, $configured_tenant:expr, $lookup_tenant:expr, $expected_plan:expr) => {
+        #[test]
+        fn $name() {
+            let configured = TenantId::new($configured_tenant).unwrap();
+            let mut plan = valid_plan();
+            plan.plan_id = $expected_plan.into();
+            let catalog = StaticEntitlementCatalog::new(
+                HashMap::from([(configured, plan)]),
+                PlanEntitlements::unlimited(),
+            )
+            .unwrap();
+            let actual = catalog
+                .entitlements_for(&TenantId::new($lookup_tenant).unwrap())
+                .plan_id;
+            assert_eq!(actual, $expected_plan);
+        }
+    };
+}
+
+catalog_case!(
+    coverage_entitlement_031_catalog_matches_simple_tenant,
+    "tenant-a",
+    "tenant-a",
+    "team-a"
+);
+catalog_case!(
+    coverage_entitlement_032_catalog_matches_numeric_tenant,
+    "tenant-42",
+    "tenant-42",
+    "team-42"
+);
+catalog_case!(
+    coverage_entitlement_033_catalog_matches_dotted_tenant,
+    "tenant.eu",
+    "tenant.eu",
+    "team-eu"
+);
+catalog_case!(
+    coverage_entitlement_034_catalog_matches_underscored_tenant,
+    "tenant_ops",
+    "tenant_ops",
+    "ops"
+);
+catalog_case!(
+    coverage_entitlement_035_catalog_matches_long_tenant,
+    "tenant-enterprise-production",
+    "tenant-enterprise-production",
+    "enterprise"
+);
+
+macro_rules! fallback_case {
+    ($name:ident, $configured_tenant:expr, $lookup_tenant:expr) => {
+        #[test]
+        fn $name() {
+            let catalog = StaticEntitlementCatalog::new(
+                HashMap::from([(TenantId::new($configured_tenant).unwrap(), valid_plan())]),
+                PlanEntitlements::unlimited(),
+            )
+            .unwrap();
+            let actual = catalog
+                .entitlements_for(&TenantId::new($lookup_tenant).unwrap())
+                .plan_id;
+            assert_eq!(actual, "self_managed");
+        }
+    };
+}
+
+fallback_case!(
+    coverage_entitlement_036_catalog_falls_back_for_other_tenant,
+    "tenant-a",
+    "tenant-b"
+);
+fallback_case!(
+    coverage_entitlement_037_catalog_falls_back_for_prefix_collision,
+    "tenant",
+    "tenant-child"
+);
+fallback_case!(
+    coverage_entitlement_038_catalog_falls_back_for_case_difference,
+    "tenant-a",
+    "Tenant-a"
+);
+fallback_case!(
+    coverage_entitlement_039_catalog_falls_back_for_suffix_difference,
+    "tenant-a",
+    "tenant-a-1"
+);
+fallback_case!(
+    coverage_entitlement_040_catalog_falls_back_for_numeric_difference,
+    "tenant-1",
+    "tenant-2"
+);

--- a/orch8-engine/src/memory_governance.rs
+++ b/orch8-engine/src/memory_governance.rs
@@ -188,3 +188,7 @@ mod tests {
         assert!(policy.validate().is_err());
     }
 }
+
+#[cfg(test)]
+#[path = "memory_governance_boundary_tests.rs"]
+mod boundary_tests;

--- a/orch8-engine/src/memory_governance_boundary_tests.rs
+++ b/orch8-engine/src/memory_governance_boundary_tests.rs
@@ -1,0 +1,434 @@
+//! Boundary tests for governed durable-memory policies.
+//!
+//! Count contract: 70 independently named unit tests.
+
+use super::*;
+
+fn valid_policy() -> MemoryNamespacePolicy {
+    MemoryNamespacePolicy {
+        policy_version: 1,
+        allowed_sequence_ids: vec![SequenceId::new()],
+        operations: vec![MemoryOperation::Store],
+        residency: "br-south-1".into(),
+        default_retention_secs: 60,
+        max_retention_secs: 3_600,
+    }
+}
+
+macro_rules! namespace_case {
+    ($name:ident, $value:expr, $valid:expr) => {
+        #[test]
+        fn $name() {
+            let actual = namespace_is_valid($value);
+            assert_eq!(actual, $valid);
+        }
+    };
+}
+
+fn namespace_is_valid(namespace: impl AsRef<str>) -> bool {
+    validate_target_namespace(namespace.as_ref()).is_ok()
+}
+
+namespace_case!(
+    coverage_memory_001_empty_namespace_is_rejected,
+    String::new(),
+    false
+);
+namespace_case!(
+    coverage_memory_002_single_letter_namespace_is_allowed,
+    "a",
+    true
+);
+namespace_case!(
+    coverage_memory_003_single_digit_namespace_is_allowed,
+    "7",
+    true
+);
+namespace_case!(
+    coverage_memory_004_hyphen_namespace_is_allowed,
+    "customer-support",
+    true
+);
+namespace_case!(
+    coverage_memory_005_underscore_namespace_is_allowed,
+    "customer_support",
+    true
+);
+namespace_case!(
+    coverage_memory_006_dot_namespace_is_allowed,
+    "customer.support",
+    true
+);
+namespace_case!(
+    coverage_memory_007_slash_namespace_is_allowed,
+    "customer/support",
+    true
+);
+namespace_case!(
+    coverage_memory_008_mixed_safe_namespace_is_allowed,
+    "A9-b_c.d/e",
+    true
+);
+namespace_case!(
+    coverage_memory_009_128_byte_namespace_is_allowed,
+    "a".repeat(128),
+    true
+);
+namespace_case!(
+    coverage_memory_010_129_byte_namespace_is_rejected,
+    "a".repeat(129),
+    false
+);
+namespace_case!(
+    coverage_memory_011_space_namespace_is_rejected,
+    "customer support",
+    false
+);
+namespace_case!(
+    coverage_memory_012_colon_namespace_is_rejected,
+    "customer:support",
+    false
+);
+namespace_case!(
+    coverage_memory_013_at_namespace_is_rejected,
+    "customer@support",
+    false
+);
+namespace_case!(
+    coverage_memory_014_backslash_namespace_is_rejected,
+    "customer\\support",
+    false
+);
+namespace_case!(
+    coverage_memory_015_unicode_namespace_is_rejected,
+    "memória",
+    false
+);
+namespace_case!(
+    coverage_memory_016_newline_namespace_is_rejected,
+    "customer\nsupport",
+    false
+);
+namespace_case!(
+    coverage_memory_017_tab_namespace_is_rejected,
+    "customer\tsupport",
+    false
+);
+namespace_case!(
+    coverage_memory_018_hash_namespace_is_rejected,
+    "customer#support",
+    false
+);
+namespace_case!(
+    coverage_memory_019_question_namespace_is_rejected,
+    "customer?support",
+    false
+);
+namespace_case!(
+    coverage_memory_020_percent_namespace_is_rejected,
+    "customer%support",
+    false
+);
+namespace_case!(
+    coverage_memory_021_policy_namespace_is_rejected,
+    POLICY_NAMESPACE,
+    false
+);
+namespace_case!(
+    coverage_memory_022_reserved_prefix_is_rejected,
+    "__orch8_custom",
+    false
+);
+namespace_case!(
+    coverage_memory_023_reserved_prefix_alone_is_rejected,
+    "__orch8_",
+    false
+);
+namespace_case!(
+    coverage_memory_024_similar_non_reserved_prefix_is_allowed,
+    "_orch8_custom",
+    true
+);
+namespace_case!(
+    coverage_memory_025_reserved_text_after_prefix_is_allowed,
+    "team/__orch8_custom",
+    true
+);
+
+macro_rules! residency_case {
+    ($name:ident, $value:expr, $valid:expr) => {
+        #[test]
+        fn $name() {
+            let actual = residency_is_valid($value);
+            assert_eq!(actual, $valid);
+        }
+    };
+}
+
+fn residency_is_valid(residency: impl AsRef<str>) -> bool {
+    validate_residency(residency.as_ref()).is_ok()
+}
+
+residency_case!(
+    coverage_memory_026_empty_residency_is_rejected,
+    String::new(),
+    false
+);
+residency_case!(
+    coverage_memory_027_single_letter_residency_is_allowed,
+    "a",
+    true
+);
+residency_case!(
+    coverage_memory_028_single_digit_residency_is_allowed,
+    "1",
+    true
+);
+residency_case!(
+    coverage_memory_029_hyphenated_residency_is_allowed,
+    "br-south-1",
+    true
+);
+residency_case!(
+    coverage_memory_030_underscored_residency_is_allowed,
+    "br_south_1",
+    true
+);
+residency_case!(
+    coverage_memory_031_dotted_residency_is_allowed,
+    "br.south.1",
+    true
+);
+residency_case!(
+    coverage_memory_032_uppercase_residency_is_allowed,
+    "BR-SOUTH-1",
+    true
+);
+residency_case!(
+    coverage_memory_033_64_byte_residency_is_allowed,
+    "r".repeat(64),
+    true
+);
+residency_case!(
+    coverage_memory_034_65_byte_residency_is_rejected,
+    "r".repeat(65),
+    false
+);
+residency_case!(
+    coverage_memory_035_slash_residency_is_rejected,
+    "br/south",
+    false
+);
+residency_case!(
+    coverage_memory_036_space_residency_is_rejected,
+    "br south",
+    false
+);
+residency_case!(
+    coverage_memory_037_colon_residency_is_rejected,
+    "br:south",
+    false
+);
+residency_case!(
+    coverage_memory_038_at_residency_is_rejected,
+    "br@south",
+    false
+);
+residency_case!(
+    coverage_memory_039_unicode_residency_is_rejected,
+    "são-paulo",
+    false
+);
+residency_case!(
+    coverage_memory_040_newline_residency_is_rejected,
+    "br\nsouth",
+    false
+);
+residency_case!(
+    coverage_memory_041_backslash_residency_is_rejected,
+    "br\\south",
+    false
+);
+residency_case!(
+    coverage_memory_042_plus_residency_is_rejected,
+    "br+south",
+    false
+);
+residency_case!(
+    coverage_memory_043_comma_residency_is_rejected,
+    "br,south",
+    false
+);
+residency_case!(
+    coverage_memory_044_semicolon_residency_is_rejected,
+    "br;south",
+    false
+);
+residency_case!(
+    coverage_memory_045_mixed_safe_residency_is_allowed,
+    "BR_2.south-prod",
+    true
+);
+
+macro_rules! policy_case {
+    ($name:ident, $mutate:expr, $valid:expr) => {
+        #[test]
+        fn $name() {
+            let mut policy = valid_policy();
+            ($mutate)(&mut policy);
+            let result = policy.validate();
+            assert_eq!(result.is_ok(), $valid);
+        }
+    };
+}
+
+policy_case!(
+    coverage_memory_046_zero_policy_version_is_rejected,
+    |p: &mut MemoryNamespacePolicy| p.policy_version = 0,
+    false
+);
+policy_case!(
+    coverage_memory_047_version_one_is_allowed,
+    |p: &mut MemoryNamespacePolicy| p.policy_version = 1,
+    true
+);
+policy_case!(
+    coverage_memory_048_maximum_policy_version_is_allowed,
+    |p: &mut MemoryNamespacePolicy| p.policy_version = u64::MAX,
+    true
+);
+policy_case!(
+    coverage_memory_049_empty_sequence_allowlist_is_rejected,
+    |p: &mut MemoryNamespacePolicy| p.allowed_sequence_ids.clear(),
+    false
+);
+policy_case!(
+    coverage_memory_050_two_unique_sequences_are_allowed,
+    |p: &mut MemoryNamespacePolicy| p.allowed_sequence_ids.push(SequenceId::new()),
+    true
+);
+policy_case!(
+    coverage_memory_051_duplicate_sequence_is_rejected,
+    |p: &mut MemoryNamespacePolicy| {
+        let id = p.allowed_sequence_ids[0];
+        p.allowed_sequence_ids.push(id);
+    },
+    false
+);
+policy_case!(
+    coverage_memory_052_1024_sequences_are_allowed,
+    |p: &mut MemoryNamespacePolicy| p.allowed_sequence_ids =
+        (0..1024).map(|_| SequenceId::new()).collect(),
+    true
+);
+policy_case!(
+    coverage_memory_053_1025_sequences_are_rejected,
+    |p: &mut MemoryNamespacePolicy| p.allowed_sequence_ids =
+        (0..1025).map(|_| SequenceId::new()).collect(),
+    false
+);
+policy_case!(
+    coverage_memory_054_empty_operations_are_rejected,
+    |p: &mut MemoryNamespacePolicy| p.operations.clear(),
+    false
+);
+policy_case!(
+    coverage_memory_055_store_operation_is_allowed,
+    |p: &mut MemoryNamespacePolicy| p.operations = vec![MemoryOperation::Store],
+    true
+);
+policy_case!(
+    coverage_memory_056_search_operation_is_allowed,
+    |p: &mut MemoryNamespacePolicy| p.operations = vec![MemoryOperation::Search],
+    true
+);
+policy_case!(
+    coverage_memory_057_delete_operation_is_allowed,
+    |p: &mut MemoryNamespacePolicy| p.operations = vec![MemoryOperation::Delete],
+    true
+);
+policy_case!(
+    coverage_memory_058_all_operations_are_allowed,
+    |p: &mut MemoryNamespacePolicy| p.operations = vec![
+        MemoryOperation::Store,
+        MemoryOperation::Search,
+        MemoryOperation::Delete
+    ],
+    true
+);
+policy_case!(
+    coverage_memory_059_duplicate_operation_is_rejected,
+    |p: &mut MemoryNamespacePolicy| p.operations =
+        vec![MemoryOperation::Store, MemoryOperation::Store],
+    false
+);
+policy_case!(
+    coverage_memory_060_invalid_residency_rejects_policy,
+    |p: &mut MemoryNamespacePolicy| p.residency = "br/south".into(),
+    false
+);
+policy_case!(
+    coverage_memory_061_zero_default_retention_is_rejected,
+    |p: &mut MemoryNamespacePolicy| p.default_retention_secs = 0,
+    false
+);
+policy_case!(
+    coverage_memory_062_zero_max_retention_is_rejected,
+    |p: &mut MemoryNamespacePolicy| p.max_retention_secs = 0,
+    false
+);
+policy_case!(
+    coverage_memory_063_default_equal_to_max_is_allowed,
+    |p: &mut MemoryNamespacePolicy| p.default_retention_secs = p.max_retention_secs,
+    true
+);
+policy_case!(
+    coverage_memory_064_default_above_max_is_rejected,
+    |p: &mut MemoryNamespacePolicy| p.default_retention_secs = p.max_retention_secs + 1,
+    false
+);
+policy_case!(
+    coverage_memory_065_one_second_retention_is_allowed,
+    |p: &mut MemoryNamespacePolicy| {
+        p.default_retention_secs = 1;
+        p.max_retention_secs = 1;
+    },
+    true
+);
+policy_case!(
+    coverage_memory_066_ten_year_retention_is_allowed,
+    |p: &mut MemoryNamespacePolicy| {
+        p.default_retention_secs = MAX_RETENTION_SECS;
+        p.max_retention_secs = MAX_RETENTION_SECS;
+    },
+    true
+);
+policy_case!(
+    coverage_memory_067_more_than_ten_years_is_rejected,
+    |p: &mut MemoryNamespacePolicy| p.max_retention_secs = MAX_RETENTION_SECS + 1,
+    false
+);
+policy_case!(
+    coverage_memory_068_default_cannot_exceed_ten_year_cap,
+    |p: &mut MemoryNamespacePolicy| {
+        p.default_retention_secs = MAX_RETENTION_SECS + 1;
+        p.max_retention_secs = MAX_RETENTION_SECS + 1;
+    },
+    false
+);
+policy_case!(
+    coverage_memory_069_safe_nested_residency_label_is_allowed,
+    |p: &mut MemoryNamespacePolicy| p.residency = "prod.br_south-1".into(),
+    true
+);
+policy_case!(
+    coverage_memory_070_combined_valid_policy_is_accepted,
+    |p: &mut MemoryNamespacePolicy| {
+        p.policy_version = 9;
+        p.allowed_sequence_ids.push(SequenceId::new());
+        p.operations = vec![MemoryOperation::Store, MemoryOperation::Search];
+        p.default_retention_secs = 86_400;
+        p.max_retention_secs = 604_800;
+    },
+    true
+);

--- a/orch8-engine/src/optimizer.rs
+++ b/orch8-engine/src/optimizer.rs
@@ -464,3 +464,7 @@ mod tests {
         assert_eq!(first.constant_pool, second.constant_pool);
     }
 }
+
+#[cfg(test)]
+#[path = "optimizer_boundary_tests.rs"]
+mod boundary_tests;

--- a/orch8-engine/src/optimizer_boundary_tests.rs
+++ b/orch8-engine/src/optimizer_boundary_tests.rs
@@ -1,0 +1,352 @@
+//! Unit coverage for guard folding and canonical workflow identity.
+//!
+//! Count contract: 60 independently named unit tests.
+
+use chrono::Utc;
+use orch8_types::ids::{BlockId, Namespace, SequenceId, TenantId};
+use orch8_types::sequence::{BlockDefinition, SequenceDefinition, SequenceStatus, StepDef};
+use serde_json::json;
+
+use super::*;
+
+fn sequence_named(name: &str) -> SequenceDefinition {
+    SequenceDefinition {
+        id: SequenceId::new(),
+        tenant_id: TenantId::unchecked("tenant"),
+        namespace: Namespace::new("default"),
+        name: name.into(),
+        version: 1,
+        deprecated: false,
+        status: SequenceStatus::Production,
+        blocks: vec![BlockDefinition::Step(Box::new(StepDef {
+            id: BlockId::new("step"),
+            handler: "noop".into(),
+            params: json!({"value": 1}),
+            delay: None,
+            retry: None,
+            timeout: None,
+            rate_limit_key: None,
+            send_window: None,
+            context_access: None,
+            cancellable: true,
+            wait_for_input: None,
+            queue_name: None,
+            deadline: None,
+            on_deadline_breach: None,
+            fallback_handler: None,
+            cache_key: None,
+            output_schema: None,
+            when: None,
+            compensation: None,
+        }))],
+        interceptors: None,
+        input_schema: None,
+        sla: None,
+        on_failure: None,
+        on_cancel: None,
+        created_at: Utc::now(),
+    }
+}
+
+macro_rules! guard_case {
+    ($name:ident, $guard:expr, $expected:expr) => {
+        #[test]
+        fn $name() {
+            let actual = classify_guard($guard);
+            assert_eq!(actual, $expected);
+        }
+    };
+}
+
+guard_case!(
+    coverage_optimizer_001_missing_guard_is_always,
+    None,
+    GuardPlan::Always
+);
+guard_case!(
+    coverage_optimizer_002_true_guard_is_always,
+    Some("true"),
+    GuardPlan::Always
+);
+guard_case!(
+    coverage_optimizer_003_true_with_leading_space_is_always,
+    Some(" true"),
+    GuardPlan::Always
+);
+guard_case!(
+    coverage_optimizer_004_true_with_trailing_space_is_always,
+    Some("true "),
+    GuardPlan::Always
+);
+guard_case!(
+    coverage_optimizer_005_true_with_tabs_is_always,
+    Some("\ttrue\t"),
+    GuardPlan::Always
+);
+guard_case!(
+    coverage_optimizer_006_true_with_newlines_is_always,
+    Some("\ntrue\n"),
+    GuardPlan::Always
+);
+guard_case!(
+    coverage_optimizer_007_false_guard_is_never,
+    Some("false"),
+    GuardPlan::Never
+);
+guard_case!(
+    coverage_optimizer_008_false_with_leading_space_is_never,
+    Some(" false"),
+    GuardPlan::Never
+);
+guard_case!(
+    coverage_optimizer_009_false_with_trailing_space_is_never,
+    Some("false "),
+    GuardPlan::Never
+);
+guard_case!(
+    coverage_optimizer_010_false_with_tabs_is_never,
+    Some("\tfalse\t"),
+    GuardPlan::Never
+);
+guard_case!(
+    coverage_optimizer_011_false_with_newlines_is_never,
+    Some("\nfalse\n"),
+    GuardPlan::Never
+);
+guard_case!(
+    coverage_optimizer_012_empty_guard_is_dynamic,
+    Some(""),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_013_spaces_only_guard_is_dynamic,
+    Some("   "),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_014_uppercase_true_is_dynamic,
+    Some("TRUE"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_015_titlecase_true_is_dynamic,
+    Some("True"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_016_uppercase_false_is_dynamic,
+    Some("FALSE"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_017_titlecase_false_is_dynamic,
+    Some("False"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_018_numeric_one_is_dynamic,
+    Some("1"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_019_numeric_zero_is_dynamic,
+    Some("0"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_020_null_text_is_dynamic,
+    Some("null"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_021_template_reference_is_dynamic,
+    Some("{{ data.ready }}"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_022_output_reference_is_dynamic,
+    Some("{{ outputs.check.ok }}"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_023_equality_expression_is_dynamic,
+    Some("data.value == 1"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_024_inequality_expression_is_dynamic,
+    Some("data.value != 1"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_025_greater_expression_is_dynamic,
+    Some("data.value > 1"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_026_less_expression_is_dynamic,
+    Some("data.value < 1"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_027_boolean_and_expression_is_dynamic,
+    Some("a && b"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_028_boolean_or_expression_is_dynamic,
+    Some("a || b"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_029_negated_expression_is_dynamic,
+    Some("!a"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_030_json_true_is_dynamic,
+    Some("{\"value\":true}"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_031_quoted_true_is_dynamic,
+    Some("\"true\""),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_032_true_with_comment_is_dynamic,
+    Some("true # comment"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_033_false_with_comment_is_dynamic,
+    Some("false # comment"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_034_true_prefix_is_dynamic,
+    Some("true_value"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_035_false_prefix_is_dynamic,
+    Some("false_value"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_036_unicode_expression_is_dynamic,
+    Some("pronto"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_037_path_expression_is_dynamic,
+    Some("$.ready"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_038_parenthesized_true_is_dynamic,
+    Some("(true)"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_039_double_negation_is_dynamic,
+    Some("!!ready"),
+    GuardPlan::Dynamic
+);
+guard_case!(
+    coverage_optimizer_040_multiline_expression_is_dynamic,
+    Some("a\n&& b"),
+    GuardPlan::Dynamic
+);
+
+macro_rules! identity_case {
+    ($name:ident, $changed_name:expr) => {
+        #[test]
+        fn $name() {
+            let baseline = sequence_named("baseline");
+            let changed = sequence_named($changed_name);
+            let baseline_hash = source_hash(&baseline).unwrap();
+            let changed_hash = source_hash(&changed).unwrap();
+            assert_ne!(baseline_hash, changed_hash);
+            assert_eq!(changed_hash.len(), 64);
+        }
+    };
+}
+
+identity_case!(
+    coverage_optimizer_041_name_change_updates_identity,
+    "changed"
+);
+identity_case!(
+    coverage_optimizer_042_single_letter_name_updates_identity,
+    "x"
+);
+identity_case!(coverage_optimizer_043_numeric_name_updates_identity, "123");
+identity_case!(
+    coverage_optimizer_044_hyphenated_name_updates_identity,
+    "base-line"
+);
+identity_case!(
+    coverage_optimizer_045_underscored_name_updates_identity,
+    "base_line"
+);
+identity_case!(
+    coverage_optimizer_046_dotted_name_updates_identity,
+    "base.line"
+);
+identity_case!(
+    coverage_optimizer_047_slashed_name_updates_identity,
+    "base/line"
+);
+identity_case!(
+    coverage_optimizer_048_spaced_name_updates_identity,
+    "base line"
+);
+identity_case!(
+    coverage_optimizer_049_uppercase_name_updates_identity,
+    "BASELINE"
+);
+identity_case!(
+    coverage_optimizer_050_mixed_case_name_updates_identity,
+    "BaseLine"
+);
+identity_case!(
+    coverage_optimizer_051_unicode_name_updates_identity,
+    "sequência"
+);
+identity_case!(
+    coverage_optimizer_052_emoji_name_updates_identity,
+    "baseline-🚀"
+);
+identity_case!(
+    coverage_optimizer_053_newline_name_updates_identity,
+    "base\nline"
+);
+identity_case!(
+    coverage_optimizer_054_tab_name_updates_identity,
+    "base\tline"
+);
+identity_case!(
+    coverage_optimizer_055_quote_name_updates_identity,
+    "base\"line"
+);
+identity_case!(
+    coverage_optimizer_056_backslash_name_updates_identity,
+    "base\\line"
+);
+identity_case!(
+    coverage_optimizer_057_tilde_name_updates_identity,
+    "base~line"
+);
+identity_case!(
+    coverage_optimizer_058_braced_name_updates_identity,
+    "base{line}"
+);
+identity_case!(
+    coverage_optimizer_059_long_name_updates_identity,
+    "x".repeat(512).as_str()
+);
+identity_case!(
+    coverage_optimizer_060_zero_width_name_updates_identity,
+    "base\u{200b}line"
+);

--- a/orch8-mobile/src/capabilities.rs
+++ b/orch8-mobile/src/capabilities.rs
@@ -235,3 +235,7 @@ mod tests {
         ));
     }
 }
+
+#[cfg(test)]
+#[path = "capabilities_boundary_tests.rs"]
+mod boundary_tests;

--- a/orch8-mobile/src/capabilities_boundary_tests.rs
+++ b/orch8-mobile/src/capabilities_boundary_tests.rs
@@ -1,0 +1,320 @@
+//! Device capability contract boundaries.
+//!
+//! Count contract: 45 independently named unit tests.
+
+use super::*;
+
+struct EchoHost;
+
+impl CapabilityHost for EchoHost {
+    fn invoke(
+        &self,
+        capability: DeviceCapability,
+        request: &CapabilityRequest,
+    ) -> Result<CapabilityResponse, HandlerError> {
+        Ok(CapabilityResponse {
+            value: serde_json::json!({
+                "handler": capability.handler_name(),
+                "operation": request.operation,
+                "arguments": request.arguments,
+            }),
+            protected_reference: Some(format!("protected://{}", request.operation)),
+        })
+    }
+}
+
+fn descriptor_for(capability: DeviceCapability) -> CapabilityDescriptor {
+    standard_capability_descriptors()
+        .into_iter()
+        .find(|item| item.capability == capability)
+        .unwrap()
+}
+
+macro_rules! handler_case {
+    ($name:ident, $capability:expr, $expected:expr) => {
+        #[test]
+        fn $name() {
+            let actual = $capability.handler_name();
+            assert_eq!(actual, $expected);
+        }
+    };
+}
+
+handler_case!(
+    coverage_capability_001_camera_handler_is_stable,
+    DeviceCapability::Camera,
+    "device.camera"
+);
+handler_case!(
+    coverage_capability_002_file_handler_is_stable,
+    DeviceCapability::File,
+    "device.file"
+);
+handler_case!(
+    coverage_capability_003_biometric_handler_is_stable,
+    DeviceCapability::Biometric,
+    "device.biometric"
+);
+handler_case!(
+    coverage_capability_004_secure_storage_handler_is_stable,
+    DeviceCapability::SecureStorage,
+    "device.secure_storage"
+);
+
+macro_rules! descriptor_case {
+    ($name:ident, $capability:expr, $assertion:expr) => {
+        #[test]
+        fn $name() {
+            let descriptor = descriptor_for($capability);
+            assert!(($assertion)(&descriptor));
+        }
+    };
+}
+
+descriptor_case!(
+    coverage_capability_005_camera_requires_foreground,
+    DeviceCapability::Camera,
+    |d: &CapabilityDescriptor| d.requires_foreground
+);
+descriptor_case!(
+    coverage_capability_006_file_requires_foreground,
+    DeviceCapability::File,
+    |d: &CapabilityDescriptor| d.requires_foreground
+);
+descriptor_case!(
+    coverage_capability_007_biometric_requires_foreground,
+    DeviceCapability::Biometric,
+    |d: &CapabilityDescriptor| d.requires_foreground
+);
+descriptor_case!(
+    coverage_capability_008_secure_storage_allows_background,
+    DeviceCapability::SecureStorage,
+    |d: &CapabilityDescriptor| !d.requires_foreground
+);
+descriptor_case!(
+    coverage_capability_009_camera_marks_protected_data,
+    DeviceCapability::Camera,
+    |d: &CapabilityDescriptor| d.handles_protected_data
+);
+descriptor_case!(
+    coverage_capability_010_file_marks_protected_data,
+    DeviceCapability::File,
+    |d: &CapabilityDescriptor| d.handles_protected_data
+);
+descriptor_case!(
+    coverage_capability_011_biometric_does_not_return_protected_data,
+    DeviceCapability::Biometric,
+    |d: &CapabilityDescriptor| !d.handles_protected_data
+);
+descriptor_case!(
+    coverage_capability_012_secure_storage_marks_protected_data,
+    DeviceCapability::SecureStorage,
+    |d: &CapabilityDescriptor| d.handles_protected_data
+);
+
+macro_rules! execute_case {
+    ($name:ident, $capability:expr, $request:expr, $needle:expr) => {
+        #[test]
+        fn $name() {
+            let bridge = DeviceToolBridge::new(EchoHost);
+            let output = bridge.execute($capability, $request).unwrap();
+            assert!(output.contains($needle));
+        }
+    };
+}
+
+execute_case!(
+    coverage_capability_013_camera_capture_executes,
+    DeviceCapability::Camera,
+    r#"{"operation":"capture","foreground":true}"#,
+    "device.camera"
+);
+execute_case!(
+    coverage_capability_014_camera_preserves_empty_arguments,
+    DeviceCapability::Camera,
+    r#"{"operation":"capture","arguments":{},"foreground":true}"#,
+    "arguments"
+);
+execute_case!(
+    coverage_capability_015_camera_preserves_quality_argument,
+    DeviceCapability::Camera,
+    r#"{"operation":"capture","arguments":{"quality":"high"},"foreground":true}"#,
+    "high"
+);
+execute_case!(
+    coverage_capability_016_file_pick_executes,
+    DeviceCapability::File,
+    r#"{"operation":"pick","foreground":true}"#,
+    "device.file"
+);
+execute_case!(
+    coverage_capability_017_file_pick_preserves_type_argument,
+    DeviceCapability::File,
+    r#"{"operation":"pick","arguments":{"type":"pdf"},"foreground":true}"#,
+    "pdf"
+);
+execute_case!(
+    coverage_capability_018_file_read_scoped_executes,
+    DeviceCapability::File,
+    r#"{"operation":"read_scoped","foreground":true}"#,
+    "read_scoped"
+);
+execute_case!(
+    coverage_capability_019_file_read_preserves_reference,
+    DeviceCapability::File,
+    r#"{"operation":"read_scoped","arguments":{"reference":"file-1"},"foreground":true}"#,
+    "file-1"
+);
+execute_case!(
+    coverage_capability_020_biometric_verify_executes,
+    DeviceCapability::Biometric,
+    r#"{"operation":"verify","foreground":true}"#,
+    "device.biometric"
+);
+execute_case!(
+    coverage_capability_021_biometric_preserves_reason,
+    DeviceCapability::Biometric,
+    r#"{"operation":"verify","arguments":{"reason":"approve"},"foreground":true}"#,
+    "approve"
+);
+execute_case!(
+    coverage_capability_022_secure_get_executes_in_foreground,
+    DeviceCapability::SecureStorage,
+    r#"{"operation":"get","foreground":true}"#,
+    "secure_storage"
+);
+execute_case!(
+    coverage_capability_023_secure_get_executes_in_background,
+    DeviceCapability::SecureStorage,
+    r#"{"operation":"get","foreground":false}"#,
+    "get"
+);
+execute_case!(
+    coverage_capability_024_secure_put_executes_in_foreground,
+    DeviceCapability::SecureStorage,
+    r#"{"operation":"put","foreground":true}"#,
+    "put"
+);
+execute_case!(
+    coverage_capability_025_secure_put_executes_in_background,
+    DeviceCapability::SecureStorage,
+    r#"{"operation":"put","foreground":false}"#,
+    "put"
+);
+execute_case!(
+    coverage_capability_026_secure_delete_executes_in_foreground,
+    DeviceCapability::SecureStorage,
+    r#"{"operation":"delete","foreground":true}"#,
+    "delete"
+);
+execute_case!(
+    coverage_capability_027_secure_delete_executes_in_background,
+    DeviceCapability::SecureStorage,
+    r#"{"operation":"delete","foreground":false}"#,
+    "delete"
+);
+execute_case!(
+    coverage_capability_028_unicode_argument_round_trips,
+    DeviceCapability::SecureStorage,
+    r#"{"operation":"put","arguments":{"value":"segredo-ç"},"foreground":false}"#,
+    "segredo-ç"
+);
+execute_case!(
+    coverage_capability_029_empty_string_argument_round_trips,
+    DeviceCapability::SecureStorage,
+    r#"{"operation":"put","arguments":{"value":""},"foreground":false}"#,
+    "value"
+);
+execute_case!(
+    coverage_capability_030_multiple_arguments_round_trip,
+    DeviceCapability::SecureStorage,
+    r#"{"operation":"put","arguments":{"key":"a","value":"b"},"foreground":false}"#,
+    "protected://put"
+);
+
+macro_rules! rejected_case {
+    ($name:ident, $capability:expr, $request:expr) => {
+        #[test]
+        fn $name() {
+            let bridge = DeviceToolBridge::new(EchoHost);
+            let result = bridge.execute($capability, $request);
+            assert!(result.is_err());
+        }
+    };
+}
+
+rejected_case!(
+    coverage_capability_031_empty_json_is_rejected,
+    DeviceCapability::Camera,
+    ""
+);
+rejected_case!(
+    coverage_capability_032_json_null_is_rejected,
+    DeviceCapability::Camera,
+    "null"
+);
+rejected_case!(
+    coverage_capability_033_json_array_is_rejected,
+    DeviceCapability::Camera,
+    "[]"
+);
+rejected_case!(
+    coverage_capability_034_missing_operation_is_rejected,
+    DeviceCapability::Camera,
+    r#"{"foreground":true}"#
+);
+rejected_case!(
+    coverage_capability_035_missing_foreground_is_rejected,
+    DeviceCapability::Camera,
+    r#"{"operation":"capture"}"#
+);
+rejected_case!(
+    coverage_capability_036_camera_background_is_rejected,
+    DeviceCapability::Camera,
+    r#"{"operation":"capture","foreground":false}"#
+);
+rejected_case!(
+    coverage_capability_037_file_background_is_rejected,
+    DeviceCapability::File,
+    r#"{"operation":"pick","foreground":false}"#
+);
+rejected_case!(
+    coverage_capability_038_biometric_background_is_rejected,
+    DeviceCapability::Biometric,
+    r#"{"operation":"verify","foreground":false}"#
+);
+rejected_case!(
+    coverage_capability_039_camera_unknown_operation_is_rejected,
+    DeviceCapability::Camera,
+    r#"{"operation":"pick","foreground":true}"#
+);
+rejected_case!(
+    coverage_capability_040_file_unknown_operation_is_rejected,
+    DeviceCapability::File,
+    r#"{"operation":"capture","foreground":true}"#
+);
+rejected_case!(
+    coverage_capability_041_biometric_unknown_operation_is_rejected,
+    DeviceCapability::Biometric,
+    r#"{"operation":"get","foreground":true}"#
+);
+rejected_case!(
+    coverage_capability_042_secure_unknown_operation_is_rejected,
+    DeviceCapability::SecureStorage,
+    r#"{"operation":"list","foreground":false}"#
+);
+rejected_case!(
+    coverage_capability_043_empty_operation_is_rejected,
+    DeviceCapability::SecureStorage,
+    r#"{"operation":"","foreground":false}"#
+);
+rejected_case!(
+    coverage_capability_044_case_changed_operation_is_rejected,
+    DeviceCapability::SecureStorage,
+    r#"{"operation":"GET","foreground":false}"#
+);
+rejected_case!(
+    coverage_capability_045_whitespace_operation_is_rejected,
+    DeviceCapability::SecureStorage,
+    r#"{"operation":" get ","foreground":false}"#
+);

--- a/orch8-mobile/src/privacy.rs
+++ b/orch8-mobile/src/privacy.rs
@@ -240,3 +240,7 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+#[path = "privacy_boundary_tests.rs"]
+mod boundary_tests;

--- a/orch8-mobile/src/privacy_boundary_tests.rs
+++ b/orch8-mobile/src/privacy_boundary_tests.rs
@@ -1,0 +1,229 @@
+//! Protected-field redaction and handoff boundaries.
+//!
+//! Count contract: 35 independently named unit tests.
+
+use super::*;
+
+fn protected() -> BTreeSet<String> {
+    ["ssn".to_string(), "secret".to_string(), "photo".to_string()]
+        .into_iter()
+        .collect()
+}
+
+fn boundary() -> ProtectedFieldBoundary {
+    ProtectedFieldBoundary::new(FieldEncryptor::from_bytes(&[11; 32]), protected()).unwrap()
+}
+
+macro_rules! sanitize_case {
+    ($name:ident, $input:expr, $expected:expr) => {
+        #[test]
+        fn $name() {
+            let actual = sanitize_value(&$input, &protected());
+            assert_eq!(actual, $expected);
+        }
+    };
+}
+
+sanitize_case!(
+    coverage_privacy_001_null_is_unchanged,
+    serde_json::Value::Null,
+    serde_json::Value::Null
+);
+sanitize_case!(
+    coverage_privacy_002_boolean_is_unchanged,
+    serde_json::json!(true),
+    serde_json::json!(true)
+);
+sanitize_case!(
+    coverage_privacy_003_number_is_unchanged,
+    serde_json::json!(42),
+    serde_json::json!(42)
+);
+sanitize_case!(
+    coverage_privacy_004_string_is_unchanged,
+    serde_json::json!("public"),
+    serde_json::json!("public")
+);
+sanitize_case!(
+    coverage_privacy_005_empty_array_is_unchanged,
+    serde_json::json!([]),
+    serde_json::json!([])
+);
+sanitize_case!(
+    coverage_privacy_006_empty_object_is_unchanged,
+    serde_json::json!({}),
+    serde_json::json!({})
+);
+sanitize_case!(
+    coverage_privacy_007_ssn_is_redacted,
+    serde_json::json!({"ssn":"123"}),
+    serde_json::json!({"ssn":"[PROTECTED]"})
+);
+sanitize_case!(
+    coverage_privacy_008_secret_is_redacted,
+    serde_json::json!({"secret":"value"}),
+    serde_json::json!({"secret":"[PROTECTED]"})
+);
+sanitize_case!(
+    coverage_privacy_009_photo_is_redacted,
+    serde_json::json!({"photo":"bytes"}),
+    serde_json::json!({"photo":"[PROTECTED]"})
+);
+sanitize_case!(
+    coverage_privacy_010_nested_ssn_is_redacted,
+    serde_json::json!({"user":{"ssn":"123"}}),
+    serde_json::json!({"user":{"ssn":"[PROTECTED]"}})
+);
+sanitize_case!(
+    coverage_privacy_011_deep_secret_is_redacted,
+    serde_json::json!({"a":{"b":{"secret":"x"}}}),
+    serde_json::json!({"a":{"b":{"secret":"[PROTECTED]"}}})
+);
+sanitize_case!(
+    coverage_privacy_012_array_object_secret_is_redacted,
+    serde_json::json!([{"secret":"x"}]),
+    serde_json::json!([{"secret":"[PROTECTED]"}])
+);
+sanitize_case!(
+    coverage_privacy_013_multiple_array_secrets_are_redacted,
+    serde_json::json!([{"secret":"x"},{"secret":"y"}]),
+    serde_json::json!([{"secret":"[PROTECTED]"},{"secret":"[PROTECTED]"}])
+);
+sanitize_case!(
+    coverage_privacy_014_nested_array_photo_is_redacted,
+    serde_json::json!({"items":[{"photo":"x"}]}),
+    serde_json::json!({"items":[{"photo":"[PROTECTED]"}]})
+);
+sanitize_case!(
+    coverage_privacy_015_protected_object_is_replaced_wholly,
+    serde_json::json!({"secret":{"nested":"x"}}),
+    serde_json::json!({"secret":"[PROTECTED]"})
+);
+sanitize_case!(
+    coverage_privacy_016_protected_array_is_replaced_wholly,
+    serde_json::json!({"photo":["x","y"]}),
+    serde_json::json!({"photo":"[PROTECTED]"})
+);
+sanitize_case!(
+    coverage_privacy_017_protected_null_is_replaced,
+    serde_json::json!({"ssn":null}),
+    serde_json::json!({"ssn":"[PROTECTED]"})
+);
+sanitize_case!(
+    coverage_privacy_018_public_sibling_is_preserved,
+    serde_json::json!({"ssn":"x","case":"A"}),
+    serde_json::json!({"ssn":"[PROTECTED]","case":"A"})
+);
+sanitize_case!(
+    coverage_privacy_019_each_protected_key_is_redacted,
+    serde_json::json!({"ssn":"x","secret":"y","photo":"z"}),
+    serde_json::json!({"ssn":"[PROTECTED]","secret":"[PROTECTED]","photo":"[PROTECTED]"})
+);
+sanitize_case!(
+    coverage_privacy_020_case_changed_key_is_not_redacted,
+    serde_json::json!({"SSN":"x"}),
+    serde_json::json!({"SSN":"x"})
+);
+sanitize_case!(
+    coverage_privacy_021_prefixed_key_is_not_redacted,
+    serde_json::json!({"user_ssn":"x"}),
+    serde_json::json!({"user_ssn":"x"})
+);
+sanitize_case!(
+    coverage_privacy_022_suffixed_key_is_not_redacted,
+    serde_json::json!({"secret_value":"x"}),
+    serde_json::json!({"secret_value":"x"})
+);
+sanitize_case!(
+    coverage_privacy_023_empty_key_is_preserved,
+    serde_json::json!({"":"x"}),
+    serde_json::json!({"":"x"})
+);
+sanitize_case!(
+    coverage_privacy_024_unicode_public_key_is_preserved,
+    serde_json::json!({"segredo":"x"}),
+    serde_json::json!({"segredo":"x"})
+);
+sanitize_case!(
+    coverage_privacy_025_array_primitives_are_preserved,
+    serde_json::json!([1, true, "x", null]),
+    serde_json::json!([1, true, "x", null])
+);
+
+#[test]
+fn coverage_privacy_026_empty_policy_is_rejected() {
+    let result = ProtectedFieldBoundary::new(FieldEncryptor::from_bytes(&[1; 32]), Vec::new());
+    assert!(matches!(result, Err(PrivacyError::InvalidPolicy)));
+}
+
+#[test]
+fn coverage_privacy_027_empty_protected_field_is_rejected() {
+    let result = ProtectedFieldBoundary::new(FieldEncryptor::from_bytes(&[1; 32]), [String::new()]);
+    assert!(matches!(result, Err(PrivacyError::InvalidPolicy)));
+}
+
+#[test]
+fn coverage_privacy_028_empty_tenant_cannot_seal() {
+    let result = boundary().seal_for_handoff("", "instance", &serde_json::json!({"ssn":"x"}));
+    assert!(matches!(result, Err(PrivacyError::InvalidPolicy)));
+}
+
+#[test]
+fn coverage_privacy_029_empty_instance_cannot_seal() {
+    let result = boundary().seal_for_handoff("tenant", "", &serde_json::json!({"ssn":"x"}));
+    assert!(matches!(result, Err(PrivacyError::InvalidPolicy)));
+}
+
+#[test]
+fn coverage_privacy_030_matching_aad_round_trips() {
+    let sealed = boundary()
+        .seal_for_handoff("tenant", "instance", &serde_json::json!({"ssn":"x"}))
+        .unwrap();
+    let opened = boundary()
+        .open_in_trusted_runtime("tenant", "instance", &sealed)
+        .unwrap();
+    assert_eq!(opened, serde_json::json!({"ssn":"x"}));
+}
+
+#[test]
+fn coverage_privacy_031_tenant_mismatch_fails_decryption() {
+    let sealed = boundary()
+        .seal_for_handoff("tenant-a", "instance", &serde_json::json!({"ssn":"x"}))
+        .unwrap();
+    let result = boundary().open_in_trusted_runtime("tenant-b", "instance", &sealed);
+    assert!(result.is_err());
+}
+
+#[test]
+fn coverage_privacy_032_instance_mismatch_fails_decryption() {
+    let sealed = boundary()
+        .seal_for_handoff("tenant", "instance-a", &serde_json::json!({"ssn":"x"}))
+        .unwrap();
+    let result = boundary().open_in_trusted_runtime("tenant", "instance-b", &sealed);
+    assert!(result.is_err());
+}
+
+#[test]
+fn coverage_privacy_033_empty_raw_leak_probe_is_rejected() {
+    let result = boundary().assert_no_raw_value("", &[("log", serde_json::json!({}))]);
+    assert!(matches!(result, Err(PrivacyError::InvalidPolicy)));
+}
+
+#[test]
+fn coverage_privacy_034_raw_value_in_nested_output_is_detected() {
+    let result = boundary().assert_no_raw_value(
+        "needle",
+        &[("trace", serde_json::json!({"nested":{"value":"needle"}}))],
+    );
+    assert!(matches!(result, Err(PrivacyError::Leak(surface)) if surface == "trace"));
+}
+
+#[test]
+fn coverage_privacy_035_sanitized_surfaces_pass_leak_assertion() {
+    let value = boundary().sanitize(
+        DisclosureSurface::Sync,
+        &serde_json::json!({"ssn":"needle","public":"ok"}),
+    );
+    let result = boundary().assert_no_raw_value("needle", &[("sync", value)]);
+    assert!(result.is_ok());
+}

--- a/orch8-publisher/src/distribution.rs
+++ b/orch8-publisher/src/distribution.rs
@@ -866,3 +866,7 @@ mod tests {
         assert_eq!(lock.verify(), Err(DistributionError::HashMismatch));
     }
 }
+
+#[cfg(test)]
+#[path = "distribution_boundary_tests.rs"]
+mod boundary_tests;

--- a/orch8-publisher/src/distribution_boundary_tests.rs
+++ b/orch8-publisher/src/distribution_boundary_tests.rs
@@ -1,0 +1,408 @@
+//! Distribution input-validation boundaries.
+//!
+//! Count contract: 70 independently named unit tests.
+
+use super::*;
+
+macro_rules! path_case {
+    ($name:ident, $path:expr, $valid:expr) => {
+        #[test]
+        fn $name() {
+            let result = validate_relative_path($path);
+            assert_eq!(result.is_ok(), $valid);
+        }
+    };
+}
+
+path_case!(
+    coverage_distribution_001_simple_file_is_valid,
+    "a.txt",
+    true
+);
+path_case!(
+    coverage_distribution_002_nested_file_is_valid,
+    "dir/a.txt",
+    true
+);
+path_case!(
+    coverage_distribution_003_deep_file_is_valid,
+    "a/b/c.txt",
+    true
+);
+path_case!(
+    coverage_distribution_004_dot_component_is_valid,
+    "./a.txt",
+    true
+);
+path_case!(
+    coverage_distribution_005_hidden_file_is_valid,
+    ".manifest",
+    true
+);
+path_case!(
+    coverage_distribution_006_hyphenated_file_is_valid,
+    "my-file.txt",
+    true
+);
+path_case!(
+    coverage_distribution_007_underscored_file_is_valid,
+    "my_file.txt",
+    true
+);
+path_case!(
+    coverage_distribution_008_spaced_file_is_valid,
+    "my file.txt",
+    true
+);
+path_case!(
+    coverage_distribution_009_unicode_file_is_valid,
+    "dados/ação.json",
+    true
+);
+path_case!(
+    coverage_distribution_010_colon_file_is_valid,
+    "schema:v1.json",
+    true
+);
+path_case!(
+    coverage_distribution_011_percent_file_is_valid,
+    "asset%20name",
+    true
+);
+path_case!(
+    coverage_distribution_012_tilde_file_is_valid,
+    "asset~backup",
+    true
+);
+path_case!(coverage_distribution_013_single_dot_is_valid, ".", true);
+path_case!(
+    coverage_distribution_014_parent_text_is_valid,
+    "..file",
+    true
+);
+path_case!(
+    coverage_distribution_015_long_relative_file_is_valid,
+    "a".repeat(1024).as_str(),
+    true
+);
+path_case!(coverage_distribution_016_empty_path_is_invalid, "", false);
+path_case!(coverage_distribution_017_root_path_is_invalid, "/", false);
+path_case!(
+    coverage_distribution_018_absolute_unix_path_is_invalid,
+    "/etc/passwd",
+    false
+);
+path_case!(
+    coverage_distribution_019_parent_component_is_invalid,
+    "../a.txt",
+    false
+);
+path_case!(
+    coverage_distribution_020_nested_parent_component_is_invalid,
+    "a/../b.txt",
+    false
+);
+path_case!(
+    coverage_distribution_021_trailing_parent_component_is_invalid,
+    "a/..",
+    false
+);
+path_case!(
+    coverage_distribution_022_double_slash_is_invalid,
+    "a//b",
+    false
+);
+path_case!(
+    coverage_distribution_023_trailing_slash_is_invalid,
+    "a/",
+    false
+);
+path_case!(
+    coverage_distribution_024_leading_double_slash_is_invalid,
+    "//server",
+    false
+);
+path_case!(
+    coverage_distribution_025_backslash_is_invalid,
+    "a\\b",
+    false
+);
+path_case!(
+    coverage_distribution_026_windows_drive_path_is_invalid,
+    "C:\\a",
+    false
+);
+path_case!(coverage_distribution_027_nul_is_invalid, "a\0b", false);
+path_case!(
+    coverage_distribution_028_parent_between_deep_parts_is_invalid,
+    "a/b/../c",
+    false
+);
+path_case!(
+    coverage_distribution_029_empty_component_after_dot_is_invalid,
+    ".//a",
+    false
+);
+path_case!(
+    coverage_distribution_030_only_parent_component_is_invalid,
+    "..",
+    false
+);
+
+macro_rules! hash_case {
+    ($name:ident, $hash:expr, $valid:expr) => {
+        #[test]
+        fn $name() {
+            let actual = hash_is_valid($hash);
+            assert_eq!(actual, $valid);
+        }
+    };
+}
+
+fn hash_is_valid(hash: impl AsRef<str>) -> bool {
+    validate_hash(hash.as_ref()).is_ok()
+}
+
+hash_case!(
+    coverage_distribution_031_lowercase_a_hash_is_valid,
+    "a".repeat(64),
+    true
+);
+hash_case!(
+    coverage_distribution_032_lowercase_f_hash_is_valid,
+    "f".repeat(64),
+    true
+);
+hash_case!(
+    coverage_distribution_033_uppercase_a_hash_is_valid,
+    "A".repeat(64),
+    true
+);
+hash_case!(
+    coverage_distribution_034_uppercase_f_hash_is_valid,
+    "F".repeat(64),
+    true
+);
+hash_case!(
+    coverage_distribution_035_zero_hash_is_valid,
+    "0".repeat(64),
+    true
+);
+hash_case!(
+    coverage_distribution_036_nine_hash_is_valid,
+    "9".repeat(64),
+    true
+);
+hash_case!(
+    coverage_distribution_037_mixed_case_hash_is_valid,
+    "aF".repeat(32),
+    true
+);
+hash_case!(
+    coverage_distribution_038_numeric_hash_is_valid,
+    "0123456789".repeat(6) + "0123",
+    true
+);
+hash_case!(
+    coverage_distribution_039_full_hex_pattern_is_valid,
+    "0123456789abcdef".repeat(4),
+    true
+);
+hash_case!(
+    coverage_distribution_040_upper_hex_pattern_is_valid,
+    "0123456789ABCDEF".repeat(4),
+    true
+);
+hash_case!(
+    coverage_distribution_041_empty_hash_is_invalid,
+    String::new(),
+    false
+);
+hash_case!(
+    coverage_distribution_042_one_character_hash_is_invalid,
+    "a",
+    false
+);
+hash_case!(
+    coverage_distribution_043_63_character_hash_is_invalid,
+    "a".repeat(63),
+    false
+);
+hash_case!(
+    coverage_distribution_044_65_character_hash_is_invalid,
+    "a".repeat(65),
+    false
+);
+hash_case!(
+    coverage_distribution_045_sha1_length_hash_is_invalid,
+    "a".repeat(40),
+    false
+);
+hash_case!(
+    coverage_distribution_046_g_character_hash_is_invalid,
+    "g".repeat(64),
+    false
+);
+hash_case!(
+    coverage_distribution_047_z_character_hash_is_invalid,
+    "z".repeat(64),
+    false
+);
+hash_case!(
+    coverage_distribution_048_hyphenated_hash_is_invalid,
+    format!("{}-{}", "a".repeat(31), "b".repeat(32)),
+    false
+);
+hash_case!(
+    coverage_distribution_049_spaced_hash_is_invalid,
+    format!("{} {}", "a".repeat(31), "b".repeat(32)),
+    false
+);
+hash_case!(
+    coverage_distribution_050_prefixed_hash_is_invalid,
+    format!("sha256:{}", "a".repeat(64)),
+    false
+);
+hash_case!(
+    coverage_distribution_051_newline_hash_is_invalid,
+    format!("{}\n", "a".repeat(63)),
+    false
+);
+hash_case!(
+    coverage_distribution_052_unicode_hash_is_invalid,
+    "é".repeat(32),
+    false
+);
+hash_case!(
+    coverage_distribution_053_slash_hash_is_invalid,
+    "/".repeat(64),
+    false
+);
+hash_case!(
+    coverage_distribution_054_nul_hash_is_invalid,
+    "\0".repeat(64),
+    false
+);
+hash_case!(
+    coverage_distribution_055_128_character_hash_is_invalid,
+    "a".repeat(128),
+    false
+);
+
+macro_rules! requirement_case {
+    ($name:ident, $kind:expr, $required:expr, $available:expr, $valid:expr) => {
+        #[test]
+        fn $name() {
+            let required: Vec<String> = $required.into_iter().map(str::to_string).collect();
+            let available: Vec<String> = $available.into_iter().map(str::to_string).collect();
+            let result = require_all($kind, &required, &available);
+            assert_eq!(result.is_ok(), $valid);
+        }
+    };
+}
+
+requirement_case!(
+    coverage_distribution_056_empty_requirements_are_satisfied,
+    "handler",
+    Vec::<&str>::new(),
+    Vec::<&str>::new(),
+    true
+);
+requirement_case!(
+    coverage_distribution_057_single_handler_is_satisfied,
+    "handler",
+    vec!["noop"],
+    vec!["noop"],
+    true
+);
+requirement_case!(
+    coverage_distribution_058_handler_can_be_among_extras,
+    "handler",
+    vec!["noop"],
+    vec!["log", "noop", "http"],
+    true
+);
+requirement_case!(
+    coverage_distribution_059_multiple_handlers_are_satisfied,
+    "handler",
+    vec!["noop", "log"],
+    vec!["log", "noop"],
+    true
+);
+requirement_case!(
+    coverage_distribution_060_plugin_requirement_is_satisfied,
+    "plugin",
+    vec!["ocr"],
+    vec!["ocr"],
+    true
+);
+requirement_case!(
+    coverage_distribution_061_region_requirement_is_satisfied,
+    "region",
+    vec!["br"],
+    vec!["us", "br"],
+    true
+);
+requirement_case!(
+    coverage_distribution_062_hardware_requirement_is_satisfied,
+    "hardware",
+    vec!["camera"],
+    vec!["camera", "gps"],
+    true
+);
+requirement_case!(
+    coverage_distribution_063_credential_requirement_is_satisfied,
+    "credential",
+    vec!["vault"],
+    vec!["vault"],
+    true
+);
+requirement_case!(
+    coverage_distribution_064_missing_handler_is_rejected,
+    "handler",
+    vec!["noop"],
+    Vec::<&str>::new(),
+    false
+);
+requirement_case!(
+    coverage_distribution_065_one_missing_of_two_is_rejected,
+    "handler",
+    vec!["noop", "log"],
+    vec!["noop"],
+    false
+);
+requirement_case!(
+    coverage_distribution_066_case_changed_handler_is_rejected,
+    "handler",
+    vec!["noop"],
+    vec!["NOOP"],
+    false
+);
+requirement_case!(
+    coverage_distribution_067_prefix_handler_is_rejected,
+    "handler",
+    vec!["noop"],
+    vec!["noop-v2"],
+    false
+);
+requirement_case!(
+    coverage_distribution_068_missing_plugin_is_rejected,
+    "plugin",
+    vec!["ocr"],
+    vec!["vision"],
+    false
+);
+requirement_case!(
+    coverage_distribution_069_missing_region_is_rejected,
+    "region",
+    vec!["br"],
+    vec!["us"],
+    false
+);
+requirement_case!(
+    coverage_distribution_070_missing_hardware_is_rejected,
+    "hardware",
+    vec!["gpu"],
+    vec!["cpu"],
+    false
+);

--- a/orch8-push/src/governance.rs
+++ b/orch8-push/src/governance.rs
@@ -479,3 +479,7 @@ mod tests {
         assert!(state.active && state.quarantine_reason.is_none());
     }
 }
+
+#[cfg(test)]
+#[path = "governance_boundary_tests.rs"]
+mod boundary_tests;

--- a/orch8-push/src/governance_boundary_tests.rs
+++ b/orch8-push/src/governance_boundary_tests.rs
@@ -1,0 +1,597 @@
+//! Push routing, signed wake, collapse, and token lifecycle boundaries.
+//!
+//! Count contract: 60 independently named unit tests.
+
+use chrono::TimeZone as _;
+
+use super::*;
+
+fn route(tenant: &str, application: &str, topic: &str, credential: &str) -> PushCredentialRoute {
+    PushCredentialRoute {
+        tenant_id: tenant.into(),
+        application_id: application.into(),
+        topic: topic.into(),
+        encrypted_credential_id: credential.into(),
+    }
+}
+
+macro_rules! route_hit_case {
+    ($name:ident, $tenant:expr, $application:expr, $topic:expr, $credential:expr) => {
+        #[test]
+        fn $name() {
+            let router =
+                CredentialRouter::new([route($tenant, $application, $topic, $credential)]).unwrap();
+            let actual = router.resolve($tenant, $application, $topic).unwrap();
+            assert_eq!(actual, $credential);
+        }
+    };
+}
+
+route_hit_case!(
+    coverage_push_001_simple_route_resolves,
+    "tenant-a",
+    "field",
+    "resume",
+    "cred-1"
+);
+route_hit_case!(
+    coverage_push_002_numeric_route_resolves,
+    "tenant-2",
+    "app-2",
+    "topic-2",
+    "cred-2"
+);
+route_hit_case!(
+    coverage_push_003_dotted_topic_route_resolves,
+    "tenant",
+    "app",
+    "com.acme.app",
+    "cred-3"
+);
+route_hit_case!(
+    coverage_push_004_underscored_application_resolves,
+    "tenant",
+    "field_app",
+    "resume",
+    "cred-4"
+);
+route_hit_case!(
+    coverage_push_005_slashed_credential_id_resolves,
+    "tenant",
+    "app",
+    "resume",
+    "vault/push/5"
+);
+route_hit_case!(
+    coverage_push_006_unicode_route_resolves_exactly,
+    "locatário",
+    "aplicativo",
+    "tópico",
+    "cred-6"
+);
+route_hit_case!(
+    coverage_push_007_whitespace_is_exact_route_data,
+    "tenant ",
+    " app",
+    "topic ",
+    "cred-7"
+);
+route_hit_case!(
+    coverage_push_008_long_route_fields_resolve,
+    "t",
+    "a",
+    "x",
+    "c"
+);
+route_hit_case!(
+    coverage_push_009_uppercase_route_resolves,
+    "TENANT",
+    "APP",
+    "TOPIC",
+    "CRED-9"
+);
+route_hit_case!(
+    coverage_push_010_mixed_case_route_resolves,
+    "Tenant",
+    "App",
+    "Topic",
+    "Cred-10"
+);
+
+macro_rules! route_miss_case {
+    ($name:ident, $stored:expr, $tenant:expr, $application:expr, $topic:expr) => {
+        #[test]
+        fn $name() {
+            let router = CredentialRouter::new([$stored]).unwrap();
+            let actual = router.resolve($tenant, $application, $topic);
+            assert_eq!(actual, Err(PushGovernanceError::MissingCredential));
+        }
+    };
+}
+
+route_miss_case!(
+    coverage_push_011_tenant_mismatch_is_missing,
+    route("tenant-a", "app", "topic", "cred"),
+    "tenant-b",
+    "app",
+    "topic"
+);
+route_miss_case!(
+    coverage_push_012_application_mismatch_is_missing,
+    route("tenant", "app-a", "topic", "cred"),
+    "tenant",
+    "app-b",
+    "topic"
+);
+route_miss_case!(
+    coverage_push_013_topic_mismatch_is_missing,
+    route("tenant", "app", "topic-a", "cred"),
+    "tenant",
+    "app",
+    "topic-b"
+);
+route_miss_case!(
+    coverage_push_014_tenant_case_mismatch_is_missing,
+    route("tenant", "app", "topic", "cred"),
+    "Tenant",
+    "app",
+    "topic"
+);
+route_miss_case!(
+    coverage_push_015_application_case_mismatch_is_missing,
+    route("tenant", "app", "topic", "cred"),
+    "tenant",
+    "App",
+    "topic"
+);
+route_miss_case!(
+    coverage_push_016_topic_case_mismatch_is_missing,
+    route("tenant", "app", "topic", "cred"),
+    "tenant",
+    "app",
+    "Topic"
+);
+route_miss_case!(
+    coverage_push_017_tenant_prefix_does_not_match,
+    route("tenant", "app", "topic", "cred"),
+    "tenant-child",
+    "app",
+    "topic"
+);
+route_miss_case!(
+    coverage_push_018_application_prefix_does_not_match,
+    route("tenant", "app", "topic", "cred"),
+    "tenant",
+    "app-child",
+    "topic"
+);
+route_miss_case!(
+    coverage_push_019_topic_prefix_does_not_match,
+    route("tenant", "app", "topic", "cred"),
+    "tenant",
+    "app",
+    "topic-child"
+);
+route_miss_case!(
+    coverage_push_020_empty_lookup_does_not_match,
+    route("tenant", "app", "topic", "cred"),
+    "",
+    "",
+    ""
+);
+
+macro_rules! invalid_route_case {
+    ($name:ident, $route:expr) => {
+        #[test]
+        fn $name() {
+            let result = CredentialRouter::new([$route]);
+            assert!(matches!(result, Err(PushGovernanceError::Invalid(_))));
+        }
+    };
+}
+
+invalid_route_case!(
+    coverage_push_021_empty_tenant_route_is_rejected,
+    route("", "app", "topic", "cred")
+);
+invalid_route_case!(
+    coverage_push_022_empty_application_route_is_rejected,
+    route("tenant", "", "topic", "cred")
+);
+invalid_route_case!(
+    coverage_push_023_empty_topic_route_is_rejected,
+    route("tenant", "app", "", "cred")
+);
+invalid_route_case!(
+    coverage_push_024_empty_credential_route_is_rejected,
+    route("tenant", "app", "topic", "")
+);
+#[test]
+fn coverage_push_025_duplicate_route_is_rejected() {
+    let result = CredentialRouter::new([
+        route("tenant", "app", "topic", "cred-a"),
+        route("tenant", "app", "topic", "cred-b"),
+    ]);
+    assert!(matches!(result, Err(PushGovernanceError::Invalid(_))));
+}
+
+fn issued_at() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 7, 25, 12, 0, 0).unwrap()
+}
+
+fn signed_wake() -> SignedWakeMetadata {
+    let key = SigningKey::from_bytes(&[7; 32]);
+    SignedWakeMetadata::sign(
+        "tenant",
+        "device",
+        "command",
+        "key-v1",
+        &key,
+        issued_at(),
+        issued_at() + Duration::minutes(5),
+    )
+    .unwrap()
+}
+
+macro_rules! wake_verify_case {
+    ($name:ident, $mutate:expr, $tenant:expr, $device:expr, $offset:expr, $key_byte:expr, $expected:expr) => {
+        #[test]
+        fn $name() {
+            let mut wake = signed_wake();
+            ($mutate)(&mut wake);
+            let key = SigningKey::from_bytes(&[$key_byte; 32]);
+            let mut cache = WakeNonceCache::new(8);
+            let result = wake.verify(
+                $tenant,
+                $device,
+                issued_at() + Duration::seconds($offset),
+                &key.verifying_key(),
+                &mut cache,
+            );
+            assert_eq!(result, $expected);
+        }
+    };
+}
+
+wake_verify_case!(
+    coverage_push_026_wake_valid_at_issue_time,
+    |_w: &mut SignedWakeMetadata| {},
+    "tenant",
+    "device",
+    0,
+    7,
+    Ok(())
+);
+wake_verify_case!(
+    coverage_push_027_wake_valid_one_second_after_issue,
+    |_w: &mut SignedWakeMetadata| {},
+    "tenant",
+    "device",
+    1,
+    7,
+    Ok(())
+);
+wake_verify_case!(
+    coverage_push_028_wake_valid_one_second_before_expiry,
+    |_w: &mut SignedWakeMetadata| {},
+    "tenant",
+    "device",
+    299,
+    7,
+    Ok(())
+);
+wake_verify_case!(
+    coverage_push_029_wake_rejected_before_issue,
+    |_w: &mut SignedWakeMetadata| {},
+    "tenant",
+    "device",
+    -1,
+    7,
+    Err(PushGovernanceError::InvalidExpiry)
+);
+wake_verify_case!(
+    coverage_push_030_wake_rejected_at_expiry,
+    |_w: &mut SignedWakeMetadata| {},
+    "tenant",
+    "device",
+    300,
+    7,
+    Err(PushGovernanceError::InvalidExpiry)
+);
+wake_verify_case!(
+    coverage_push_031_wake_rejected_after_expiry,
+    |_w: &mut SignedWakeMetadata| {},
+    "tenant",
+    "device",
+    301,
+    7,
+    Err(PushGovernanceError::InvalidExpiry)
+);
+wake_verify_case!(
+    coverage_push_032_wrong_expected_tenant_is_rejected,
+    |_w: &mut SignedWakeMetadata| {},
+    "other",
+    "device",
+    1,
+    7,
+    Err(PushGovernanceError::InvalidSignature)
+);
+wake_verify_case!(
+    coverage_push_033_wrong_expected_device_is_rejected,
+    |_w: &mut SignedWakeMetadata| {},
+    "tenant",
+    "other",
+    1,
+    7,
+    Err(PushGovernanceError::InvalidSignature)
+);
+wake_verify_case!(
+    coverage_push_034_wrong_verification_key_is_rejected,
+    |_w: &mut SignedWakeMetadata| {},
+    "tenant",
+    "device",
+    1,
+    8,
+    Err(PushGovernanceError::InvalidSignature)
+);
+wake_verify_case!(
+    coverage_push_035_tampered_tenant_is_rejected,
+    |w: &mut SignedWakeMetadata| w.tenant_id = "other".into(),
+    "other",
+    "device",
+    1,
+    7,
+    Err(PushGovernanceError::InvalidSignature)
+);
+wake_verify_case!(
+    coverage_push_036_tampered_device_is_rejected,
+    |w: &mut SignedWakeMetadata| w.device_id = "other".into(),
+    "tenant",
+    "other",
+    1,
+    7,
+    Err(PushGovernanceError::InvalidSignature)
+);
+wake_verify_case!(
+    coverage_push_037_tampered_command_is_rejected,
+    |w: &mut SignedWakeMetadata| w.command_id = "other".into(),
+    "tenant",
+    "device",
+    1,
+    7,
+    Err(PushGovernanceError::InvalidSignature)
+);
+wake_verify_case!(
+    coverage_push_038_tampered_key_id_is_rejected,
+    |w: &mut SignedWakeMetadata| w.key_id = "key-v2".into(),
+    "tenant",
+    "device",
+    1,
+    7,
+    Err(PushGovernanceError::InvalidSignature)
+);
+wake_verify_case!(
+    coverage_push_039_unknown_schema_is_rejected,
+    |w: &mut SignedWakeMetadata| w.schema_version = 2,
+    "tenant",
+    "device",
+    1,
+    7,
+    Err(PushGovernanceError::InvalidExpiry)
+);
+wake_verify_case!(
+    coverage_push_040_empty_tenant_shape_is_rejected,
+    |w: &mut SignedWakeMetadata| w.tenant_id.clear(),
+    "",
+    "device",
+    1,
+    7,
+    Err(PushGovernanceError::InvalidExpiry)
+);
+wake_verify_case!(
+    coverage_push_041_empty_device_shape_is_rejected,
+    |w: &mut SignedWakeMetadata| w.device_id.clear(),
+    "tenant",
+    "",
+    1,
+    7,
+    Err(PushGovernanceError::InvalidExpiry)
+);
+wake_verify_case!(
+    coverage_push_042_empty_command_shape_is_rejected,
+    |w: &mut SignedWakeMetadata| w.command_id.clear(),
+    "tenant",
+    "device",
+    1,
+    7,
+    Err(PushGovernanceError::InvalidExpiry)
+);
+wake_verify_case!(
+    coverage_push_043_empty_key_shape_is_rejected,
+    |w: &mut SignedWakeMetadata| w.key_id.clear(),
+    "tenant",
+    "device",
+    1,
+    7,
+    Err(PushGovernanceError::InvalidExpiry)
+);
+
+#[test]
+fn coverage_push_044_more_than_fifteen_minute_ttl_is_rejected() {
+    let key = SigningKey::from_bytes(&[7; 32]);
+    let result = SignedWakeMetadata::sign(
+        "tenant",
+        "device",
+        "command",
+        "key",
+        &key,
+        issued_at(),
+        issued_at() + Duration::minutes(16),
+    );
+    assert_eq!(result, Err(PushGovernanceError::InvalidExpiry));
+}
+
+#[test]
+fn coverage_push_045_non_positive_ttl_is_rejected() {
+    let key = SigningKey::from_bytes(&[7; 32]);
+    let result = SignedWakeMetadata::sign(
+        "tenant",
+        "device",
+        "command",
+        "key",
+        &key,
+        issued_at(),
+        issued_at(),
+    );
+    assert_eq!(result, Err(PushGovernanceError::InvalidExpiry));
+}
+
+fn wake(
+    tenant: &str,
+    device: &str,
+    execution: &str,
+    topic: &str,
+    command: &str,
+    second: i64,
+) -> CollapsibleWake {
+    CollapsibleWake {
+        tenant_id: tenant.into(),
+        device_id: device.into(),
+        execution_id: execution.into(),
+        topic: topic.into(),
+        command_id: command.into(),
+        created_at: issued_at() + Duration::seconds(second),
+    }
+}
+
+macro_rules! collapse_key_difference_case {
+    ($name:ident, $left:expr, $right:expr) => {
+        #[test]
+        fn $name() {
+            let left = $left.collapse_key();
+            let right = $right.collapse_key();
+            assert_ne!(left, right);
+        }
+    };
+}
+
+collapse_key_difference_case!(
+    coverage_push_046_tenant_changes_collapse_key,
+    wake("a", "d", "e", "t", "c", 0),
+    wake("b", "d", "e", "t", "c", 0)
+);
+collapse_key_difference_case!(
+    coverage_push_047_device_changes_collapse_key,
+    wake("a", "d1", "e", "t", "c", 0),
+    wake("a", "d2", "e", "t", "c", 0)
+);
+collapse_key_difference_case!(
+    coverage_push_048_execution_changes_collapse_key,
+    wake("a", "d", "e1", "t", "c", 0),
+    wake("a", "d", "e2", "t", "c", 0)
+);
+collapse_key_difference_case!(
+    coverage_push_049_topic_changes_collapse_key,
+    wake("a", "d", "e", "t1", "c", 0),
+    wake("a", "d", "e", "t2", "c", 0)
+);
+
+#[test]
+fn coverage_push_050_command_does_not_change_collapse_key() {
+    let left = wake("a", "d", "e", "t", "c1", 0).collapse_key();
+    let right = wake("a", "d", "e", "t", "c2", 0).collapse_key();
+    assert_eq!(left, right);
+}
+
+#[test]
+fn coverage_push_051_created_at_does_not_change_collapse_key() {
+    let left = wake("a", "d", "e", "t", "c", 0).collapse_key();
+    let right = wake("a", "d", "e", "t", "c", 1).collapse_key();
+    assert_eq!(left, right);
+}
+
+#[test]
+fn coverage_push_052_newer_wake_replaces_older_wake() {
+    let collapsed = collapse_wakes([
+        wake("a", "d", "e", "t", "old", 0),
+        wake("a", "d", "e", "t", "new", 1),
+    ]);
+    assert_eq!(collapsed[0].command_id, "new");
+}
+
+#[test]
+fn coverage_push_053_older_wake_does_not_replace_newer_wake() {
+    let collapsed = collapse_wakes([
+        wake("a", "d", "e", "t", "new", 1),
+        wake("a", "d", "e", "t", "old", 0),
+    ]);
+    assert_eq!(collapsed[0].command_id, "new");
+}
+
+#[test]
+fn coverage_push_054_command_id_breaks_equal_time_ties() {
+    let collapsed = collapse_wakes([
+        wake("a", "d", "e", "t", "a", 0),
+        wake("a", "d", "e", "t", "b", 0),
+    ]);
+    assert_eq!(collapsed[0].command_id, "b");
+}
+
+#[test]
+fn coverage_push_055_distinct_collapse_keys_are_preserved() {
+    let collapsed = collapse_wakes([
+        wake("a", "d", "e1", "t", "a", 0),
+        wake("a", "d", "e2", "t", "b", 0),
+    ]);
+    assert_eq!(collapsed.len(), 2);
+}
+
+fn active_token() -> TokenLifecycleState {
+    TokenLifecycleState {
+        tenant_id: "tenant".into(),
+        device_id: "device".into(),
+        active: true,
+        quarantined_at: None,
+        quarantine_reason: None,
+    }
+}
+
+#[test]
+fn coverage_push_056_quarantine_marks_token_inactive() {
+    let mut token = active_token();
+    token.quarantine_invalid_token(issued_at());
+    assert!(!token.active);
+}
+
+#[test]
+fn coverage_push_057_quarantine_records_timestamp() {
+    let mut token = active_token();
+    token.quarantine_invalid_token(issued_at());
+    assert_eq!(token.quarantined_at, Some(issued_at()));
+}
+
+#[test]
+fn coverage_push_058_quarantine_records_provider_reason() {
+    let mut token = active_token();
+    token.quarantine_invalid_token(issued_at());
+    assert_eq!(
+        token.quarantine_reason.as_deref(),
+        Some("provider_invalid_token")
+    );
+}
+
+#[test]
+fn coverage_push_059_reactivation_marks_token_active() {
+    let mut token = active_token();
+    token.quarantine_invalid_token(issued_at());
+    token.reactivate_with_new_token();
+    assert!(token.active);
+}
+
+#[test]
+fn coverage_push_060_reactivation_clears_quarantine_evidence() {
+    let mut token = active_token();
+    token.quarantine_invalid_token(issued_at());
+    token.reactivate_with_new_token();
+    assert!(token.quarantined_at.is_none() && token.quarantine_reason.is_none());
+}

--- a/scripts/check-expanded-test-counts.sh
+++ b/scripts/check-expanded-test-counts.sh
@@ -20,9 +20,9 @@ e2e_files=(
   tests/e2e/features/compiled_plan_unknown_roots.test.ts
 )
 
-unit_pattern='^\s*(validation_case|catalog_case|fallback_case|escape_case|generated_contains_case|namespace_case|residency_case|policy_case|guard_case|identity_case|handler_case|descriptor_case|execute_case|rejected_case|sanitize_case|route_hit_case|route_miss_case|invalid_route_case|wake_verify_case|collapse_key_difference_case|path_case|hash_case|requirement_case)!|^\s*(async )?fn coverage_'
-unit_count="$(rg --no-filename --count-matches "$unit_pattern" "${unit_files[@]}" | awk '{ total += $1 } END { print total + 0 }')"
-e2e_count="$(rg --no-filename --count-matches '^\s*it\(' "${e2e_files[@]}" | awk '{ total += $1 } END { print total + 0 }')"
+unit_pattern='^[[:space:]]*(validation_case|catalog_case|fallback_case|escape_case|generated_contains_case|namespace_case|residency_case|policy_case|guard_case|identity_case|handler_case|descriptor_case|execute_case|rejected_case|sanitize_case|route_hit_case|route_miss_case|invalid_route_case|wake_verify_case|collapse_key_difference_case|path_case|hash_case|requirement_case)!|^[[:space:]]*(async )?fn coverage_'
+unit_count="$(grep -hEc "$unit_pattern" "${unit_files[@]}" | awk '{ total += $1 } END { print total + 0 }')"
+e2e_count="$(grep -hEc '^[[:space:]]*it\(' "${e2e_files[@]}" | awk '{ total += $1 } END { print total + 0 }')"
 
 if [[ "$unit_count" -ne 400 ]]; then
   echo "expected exactly 400 added Rust unit tests, found $unit_count" >&2
@@ -35,4 +35,3 @@ if [[ "$e2e_count" -ne 150 ]]; then
 fi
 
 echo "expanded test counts verified: $unit_count Rust unit tests, $e2e_count Node E2E tests"
-

--- a/scripts/check-expanded-test-counts.sh
+++ b/scripts/check-expanded-test-counts.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+unit_files=(
+  orch8-api/src/client_contract_boundary_tests.rs
+  orch8-api/src/entitlements_boundary_tests.rs
+  orch8-engine/src/memory_governance_boundary_tests.rs
+  orch8-engine/src/optimizer_boundary_tests.rs
+  orch8-mobile/src/capabilities_boundary_tests.rs
+  orch8-mobile/src/privacy_boundary_tests.rs
+  orch8-publisher/src/distribution_boundary_tests.rs
+  orch8-push/src/governance_boundary_tests.rs
+)
+
+e2e_files=(
+  tests/e2e/features/compiled_plan_input_types.test.ts
+  tests/e2e/features/compiled_plan_input_failures.test.ts
+  tests/e2e/features/compiled_plan_producer_failures.test.ts
+  tests/e2e/features/compiled_plan_output_types.test.ts
+  tests/e2e/features/compiled_plan_unknown_roots.test.ts
+)
+
+unit_pattern='^\s*(validation_case|catalog_case|fallback_case|escape_case|generated_contains_case|namespace_case|residency_case|policy_case|guard_case|identity_case|handler_case|descriptor_case|execute_case|rejected_case|sanitize_case|route_hit_case|route_miss_case|invalid_route_case|wake_verify_case|collapse_key_difference_case|path_case|hash_case|requirement_case)!|^\s*(async )?fn coverage_'
+unit_count="$(rg --no-filename --count-matches "$unit_pattern" "${unit_files[@]}" | awk '{ total += $1 } END { print total + 0 }')"
+e2e_count="$(rg --no-filename --count-matches '^\s*it\(' "${e2e_files[@]}" | awk '{ total += $1 } END { print total + 0 }')"
+
+if [[ "$unit_count" -ne 400 ]]; then
+  echo "expected exactly 400 added Rust unit tests, found $unit_count" >&2
+  exit 1
+fi
+
+if [[ "$e2e_count" -ne 150 ]]; then
+  echo "expected exactly 150 added Node E2E tests, found $e2e_count" >&2
+  exit 1
+fi
+
+echo "expanded test counts verified: $unit_count Rust unit tests, $e2e_count Node E2E tests"
+

--- a/tests/e2e/compiled_plan_cases.ts
+++ b/tests/e2e/compiled_plan_cases.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+
+import { Orch8Client, step, testSequence } from "./client.ts";
+
+const client = new Orch8Client();
+
+interface DataflowFinding {
+  code: string;
+  reference: string;
+}
+
+interface DataflowResult {
+  report: {
+    references_checked: number;
+    findings: DataflowFinding[];
+  };
+}
+
+function findingByReference(
+  result: DataflowResult,
+  reference: string,
+): DataflowFinding {
+  const finding = result.report.findings.find(
+    (candidate) => candidate.reference === reference,
+  );
+  assert.ok(finding, `missing finding for ${reference}`);
+  return finding;
+}
+
+export async function expectDeclaredInput(
+  caseName: string,
+  field: string,
+  schemaType: string,
+): Promise<void> {
+  const reference = `data.${field}`;
+  const sequence = testSequence(caseName, [
+    step("consumer", "noop", { value: `{{ ${reference} }}` }),
+  ]);
+  sequence.input_schema = {
+    type: "object",
+    properties: { [field]: { type: schemaType } },
+    required: [field],
+    additionalProperties: false,
+  };
+
+  const result = (await client.compileSequenceDataflow(
+    sequence,
+  )) as DataflowResult;
+
+  assert.equal(result.report.references_checked, 1);
+  assert.deepEqual(result.report.findings, []);
+}
+
+export async function expectMissingInput(
+  caseName: string,
+  field: string,
+): Promise<void> {
+  const reference = `data.${field}`;
+  const sequence = testSequence(caseName, [
+    step("consumer", "noop", { value: `{{ ${reference} }}` }),
+  ]);
+  sequence.input_schema = {
+    type: "object",
+    properties: { declared: { type: "string" } },
+    required: ["declared"],
+    additionalProperties: false,
+  };
+
+  const result = (await client.compileSequenceDataflow(
+    sequence,
+  )) as DataflowResult;
+
+  assert.equal(result.report.references_checked, 1);
+  assert.equal(findingByReference(result, reference).code, "SCHEMA_PATH_MISSING");
+}
+
+export async function expectMissingProducer(
+  caseName: string,
+  producerId: string,
+): Promise<void> {
+  const reference = `outputs.${producerId}.value`;
+  const sequence = testSequence(caseName, [
+    step("consumer", "noop", { value: `{{ ${reference} }}` }),
+  ]);
+
+  const result = (await client.compileSequenceDataflow(
+    sequence,
+  )) as DataflowResult;
+
+  assert.equal(result.report.references_checked, 1);
+  assert.equal(findingByReference(result, reference).code, "MISSING_PRODUCER");
+}
+
+export async function expectDeclaredOutput(
+  caseName: string,
+  field: string,
+  schemaType: string,
+): Promise<void> {
+  const reference = `outputs.source.${field}`;
+  const sequence = testSequence(caseName, [
+    step(
+      "source",
+      "noop",
+      {},
+      {
+        output_schema: {
+          type: "object",
+          properties: { [field]: { type: schemaType } },
+          required: [field],
+          additionalProperties: false,
+        },
+      },
+    ),
+    step("consumer", "noop", { value: `{{ ${reference} }}` }),
+  ]);
+
+  const result = (await client.compileSequenceDataflow(
+    sequence,
+  )) as DataflowResult;
+
+  assert.equal(result.report.references_checked, 1);
+  assert.deepEqual(result.report.findings, []);
+}
+
+export async function expectUnknownRoot(
+  caseName: string,
+  root: "state" | "config",
+  field: string,
+): Promise<void> {
+  const reference = `${root}.${field}`;
+  const sequence = testSequence(caseName, [
+    step("consumer", "noop", { value: `{{ ${reference} }}` }),
+  ]);
+
+  const result = (await client.compileSequenceDataflow(
+    sequence,
+  )) as DataflowResult;
+
+  assert.equal(result.report.references_checked, 1);
+  assert.equal(findingByReference(result, reference).code, "TYPE_UNKNOWN");
+}

--- a/tests/e2e/features/compiled_plan_input_failures.test.ts
+++ b/tests/e2e/features/compiled_plan_input_failures.test.ts
@@ -1,0 +1,137 @@
+import { after, before, describe, it } from "node:test";
+import { startServer, stopServer } from "../harness.ts";
+import type { ServerHandle } from "../harness.ts";
+import { expectMissingInput } from "../compiled_plan_cases.ts";
+
+describe("Compiled plan closed-schema diagnostics", () => {
+  let server: ServerHandle | undefined;
+
+  before(async () => {
+    server = await startServer();
+  });
+
+  after(async () => {
+    await stopServer(server);
+  });
+
+  it("reports closed-schema input path missing_customer", async () => {
+    await expectMissingInput("compiled-input-error-001", "missing_customer");
+  });
+
+  it("reports closed-schema input path missing_order", async () => {
+    await expectMissingInput("compiled-input-error-002", "missing_order");
+  });
+
+  it("reports closed-schema input path missing_account", async () => {
+    await expectMissingInput("compiled-input-error-003", "missing_account");
+  });
+
+  it("reports closed-schema input path missing_region", async () => {
+    await expectMissingInput("compiled-input-error-004", "missing_region");
+  });
+
+  it("reports closed-schema input path missing_token", async () => {
+    await expectMissingInput("compiled-input-error-005", "missing_token");
+  });
+
+  it("reports closed-schema input path missing_attempt", async () => {
+    await expectMissingInput("compiled-input-error-006", "missing_attempt");
+  });
+
+  it("reports closed-schema input path missing_retry", async () => {
+    await expectMissingInput("compiled-input-error-007", "missing_retry");
+  });
+
+  it("reports closed-schema input path missing_items", async () => {
+    await expectMissingInput("compiled-input-error-008", "missing_items");
+  });
+
+  it("reports closed-schema input path missing_priority", async () => {
+    await expectMissingInput("compiled-input-error-009", "missing_priority");
+  });
+
+  it("reports closed-schema input path missing_page", async () => {
+    await expectMissingInput("compiled-input-error-010", "missing_page");
+  });
+
+  it("reports closed-schema input path missing_total", async () => {
+    await expectMissingInput("compiled-input-error-011", "missing_total");
+  });
+
+  it("reports closed-schema input path missing_tax", async () => {
+    await expectMissingInput("compiled-input-error-012", "missing_tax");
+  });
+
+  it("reports closed-schema input path missing_score", async () => {
+    await expectMissingInput("compiled-input-error-013", "missing_score");
+  });
+
+  it("reports closed-schema input path missing_latitude", async () => {
+    await expectMissingInput("compiled-input-error-014", "missing_latitude");
+  });
+
+  it("reports closed-schema input path missing_longitude", async () => {
+    await expectMissingInput("compiled-input-error-015", "missing_longitude");
+  });
+
+  it("reports closed-schema input path missing_active", async () => {
+    await expectMissingInput("compiled-input-error-016", "missing_active");
+  });
+
+  it("reports closed-schema input path missing_verified", async () => {
+    await expectMissingInput("compiled-input-error-017", "missing_verified");
+  });
+
+  it("reports closed-schema input path missing_review", async () => {
+    await expectMissingInput("compiled-input-error-018", "missing_review");
+  });
+
+  it("reports closed-schema input path missing_consent", async () => {
+    await expectMissingInput("compiled-input-error-019", "missing_consent");
+  });
+
+  it("reports closed-schema input path missing_flag", async () => {
+    await expectMissingInput("compiled-input-error-020", "missing_flag");
+  });
+
+  it("reports closed-schema input path missing_profile", async () => {
+    await expectMissingInput("compiled-input-error-021", "missing_profile");
+  });
+
+  it("reports closed-schema input path missing_metadata", async () => {
+    await expectMissingInput("compiled-input-error-022", "missing_metadata");
+  });
+
+  it("reports closed-schema input path missing_address", async () => {
+    await expectMissingInput("compiled-input-error-023", "missing_address");
+  });
+
+  it("reports closed-schema input path missing_policy", async () => {
+    await expectMissingInput("compiled-input-error-024", "missing_policy");
+  });
+
+  it("reports closed-schema input path missing_attributes", async () => {
+    await expectMissingInput("compiled-input-error-025", "missing_attributes");
+  });
+
+  it("reports closed-schema input path missing_lines", async () => {
+    await expectMissingInput("compiled-input-error-026", "missing_lines");
+  });
+
+  it("reports closed-schema input path missing_tags", async () => {
+    await expectMissingInput("compiled-input-error-027", "missing_tags");
+  });
+
+  it("reports closed-schema input path missing_regions", async () => {
+    await expectMissingInput("compiled-input-error-028", "missing_regions");
+  });
+
+  it("reports closed-schema input path missing_files", async () => {
+    await expectMissingInput("compiled-input-error-029", "missing_files");
+  });
+
+  it("reports closed-schema input path missing_approvers", async () => {
+    await expectMissingInput("compiled-input-error-030", "missing_approvers");
+  });
+});
+

--- a/tests/e2e/features/compiled_plan_input_types.test.ts
+++ b/tests/e2e/features/compiled_plan_input_types.test.ts
@@ -1,0 +1,137 @@
+import { after, before, describe, it } from "node:test";
+import { startServer, stopServer } from "../harness.ts";
+import type { ServerHandle } from "../harness.ts";
+import { expectDeclaredInput } from "../compiled_plan_cases.ts";
+
+describe("Compiled plan input contracts", () => {
+  let server: ServerHandle | undefined;
+
+  before(async () => {
+    server = await startServer();
+  });
+
+  after(async () => {
+    await stopServer(server);
+  });
+
+  it("accepts declared string input field customer_id", async () => {
+    await expectDeclaredInput("compiled-input-001", "customer_id", "string");
+  });
+
+  it("accepts declared string input field order_id", async () => {
+    await expectDeclaredInput("compiled-input-002", "order_id", "string");
+  });
+
+  it("accepts declared string input field account_name", async () => {
+    await expectDeclaredInput("compiled-input-003", "account_name", "string");
+  });
+
+  it("accepts declared string input field region_code", async () => {
+    await expectDeclaredInput("compiled-input-004", "region_code", "string");
+  });
+
+  it("accepts declared string input field request_token", async () => {
+    await expectDeclaredInput("compiled-input-005", "request_token", "string");
+  });
+
+  it("accepts declared integer input field attempt_count", async () => {
+    await expectDeclaredInput("compiled-input-006", "attempt_count", "integer");
+  });
+
+  it("accepts declared integer input field retry_count", async () => {
+    await expectDeclaredInput("compiled-input-007", "retry_count", "integer");
+  });
+
+  it("accepts declared integer input field item_count", async () => {
+    await expectDeclaredInput("compiled-input-008", "item_count", "integer");
+  });
+
+  it("accepts declared integer input field priority_level", async () => {
+    await expectDeclaredInput("compiled-input-009", "priority_level", "integer");
+  });
+
+  it("accepts declared integer input field page_number", async () => {
+    await expectDeclaredInput("compiled-input-010", "page_number", "integer");
+  });
+
+  it("accepts declared number input field total_amount", async () => {
+    await expectDeclaredInput("compiled-input-011", "total_amount", "number");
+  });
+
+  it("accepts declared number input field tax_rate", async () => {
+    await expectDeclaredInput("compiled-input-012", "tax_rate", "number");
+  });
+
+  it("accepts declared number input field confidence_score", async () => {
+    await expectDeclaredInput("compiled-input-013", "confidence_score", "number");
+  });
+
+  it("accepts declared number input field latitude", async () => {
+    await expectDeclaredInput("compiled-input-014", "latitude", "number");
+  });
+
+  it("accepts declared number input field longitude", async () => {
+    await expectDeclaredInput("compiled-input-015", "longitude", "number");
+  });
+
+  it("accepts declared boolean input field is_active", async () => {
+    await expectDeclaredInput("compiled-input-016", "is_active", "boolean");
+  });
+
+  it("accepts declared boolean input field is_verified", async () => {
+    await expectDeclaredInput("compiled-input-017", "is_verified", "boolean");
+  });
+
+  it("accepts declared boolean input field requires_review", async () => {
+    await expectDeclaredInput("compiled-input-018", "requires_review", "boolean");
+  });
+
+  it("accepts declared boolean input field has_consent", async () => {
+    await expectDeclaredInput("compiled-input-019", "has_consent", "boolean");
+  });
+
+  it("accepts declared boolean input field is_priority", async () => {
+    await expectDeclaredInput("compiled-input-020", "is_priority", "boolean");
+  });
+
+  it("accepts declared object input field customer", async () => {
+    await expectDeclaredInput("compiled-input-021", "customer", "object");
+  });
+
+  it("accepts declared object input field metadata", async () => {
+    await expectDeclaredInput("compiled-input-022", "metadata", "object");
+  });
+
+  it("accepts declared object input field shipping_address", async () => {
+    await expectDeclaredInput("compiled-input-023", "shipping_address", "object");
+  });
+
+  it("accepts declared object input field policy", async () => {
+    await expectDeclaredInput("compiled-input-024", "policy", "object");
+  });
+
+  it("accepts declared object input field attributes", async () => {
+    await expectDeclaredInput("compiled-input-025", "attributes", "object");
+  });
+
+  it("accepts declared array input field items", async () => {
+    await expectDeclaredInput("compiled-input-026", "items", "array");
+  });
+
+  it("accepts declared array input field tags", async () => {
+    await expectDeclaredInput("compiled-input-027", "tags", "array");
+  });
+
+  it("accepts declared array input field regions", async () => {
+    await expectDeclaredInput("compiled-input-028", "regions", "array");
+  });
+
+  it("accepts declared array input field attachments", async () => {
+    await expectDeclaredInput("compiled-input-029", "attachments", "array");
+  });
+
+  it("accepts declared array input field approvers", async () => {
+    await expectDeclaredInput("compiled-input-030", "approvers", "array");
+  });
+});
+

--- a/tests/e2e/features/compiled_plan_output_types.test.ts
+++ b/tests/e2e/features/compiled_plan_output_types.test.ts
@@ -1,0 +1,137 @@
+import { after, before, describe, it } from "node:test";
+import { startServer, stopServer } from "../harness.ts";
+import type { ServerHandle } from "../harness.ts";
+import { expectDeclaredOutput } from "../compiled_plan_cases.ts";
+
+describe("Compiled plan output contracts", () => {
+  let server: ServerHandle | undefined;
+
+  before(async () => {
+    server = await startServer();
+  });
+
+  after(async () => {
+    await stopServer(server);
+  });
+
+  it("accepts declared string producer field customer_id", async () => {
+    await expectDeclaredOutput("compiled-output-001", "customer_id", "string");
+  });
+
+  it("accepts declared string producer field order_id", async () => {
+    await expectDeclaredOutput("compiled-output-002", "order_id", "string");
+  });
+
+  it("accepts declared string producer field account_name", async () => {
+    await expectDeclaredOutput("compiled-output-003", "account_name", "string");
+  });
+
+  it("accepts declared string producer field region_code", async () => {
+    await expectDeclaredOutput("compiled-output-004", "region_code", "string");
+  });
+
+  it("accepts declared string producer field request_token", async () => {
+    await expectDeclaredOutput("compiled-output-005", "request_token", "string");
+  });
+
+  it("accepts declared integer producer field attempt_count", async () => {
+    await expectDeclaredOutput("compiled-output-006", "attempt_count", "integer");
+  });
+
+  it("accepts declared integer producer field retry_count", async () => {
+    await expectDeclaredOutput("compiled-output-007", "retry_count", "integer");
+  });
+
+  it("accepts declared integer producer field item_count", async () => {
+    await expectDeclaredOutput("compiled-output-008", "item_count", "integer");
+  });
+
+  it("accepts declared integer producer field priority_level", async () => {
+    await expectDeclaredOutput("compiled-output-009", "priority_level", "integer");
+  });
+
+  it("accepts declared integer producer field page_number", async () => {
+    await expectDeclaredOutput("compiled-output-010", "page_number", "integer");
+  });
+
+  it("accepts declared number producer field total_amount", async () => {
+    await expectDeclaredOutput("compiled-output-011", "total_amount", "number");
+  });
+
+  it("accepts declared number producer field tax_rate", async () => {
+    await expectDeclaredOutput("compiled-output-012", "tax_rate", "number");
+  });
+
+  it("accepts declared number producer field confidence_score", async () => {
+    await expectDeclaredOutput("compiled-output-013", "confidence_score", "number");
+  });
+
+  it("accepts declared number producer field latitude", async () => {
+    await expectDeclaredOutput("compiled-output-014", "latitude", "number");
+  });
+
+  it("accepts declared number producer field longitude", async () => {
+    await expectDeclaredOutput("compiled-output-015", "longitude", "number");
+  });
+
+  it("accepts declared boolean producer field is_active", async () => {
+    await expectDeclaredOutput("compiled-output-016", "is_active", "boolean");
+  });
+
+  it("accepts declared boolean producer field is_verified", async () => {
+    await expectDeclaredOutput("compiled-output-017", "is_verified", "boolean");
+  });
+
+  it("accepts declared boolean producer field requires_review", async () => {
+    await expectDeclaredOutput("compiled-output-018", "requires_review", "boolean");
+  });
+
+  it("accepts declared boolean producer field has_consent", async () => {
+    await expectDeclaredOutput("compiled-output-019", "has_consent", "boolean");
+  });
+
+  it("accepts declared boolean producer field is_priority", async () => {
+    await expectDeclaredOutput("compiled-output-020", "is_priority", "boolean");
+  });
+
+  it("accepts declared object producer field customer", async () => {
+    await expectDeclaredOutput("compiled-output-021", "customer", "object");
+  });
+
+  it("accepts declared object producer field metadata", async () => {
+    await expectDeclaredOutput("compiled-output-022", "metadata", "object");
+  });
+
+  it("accepts declared object producer field shipping_address", async () => {
+    await expectDeclaredOutput("compiled-output-023", "shipping_address", "object");
+  });
+
+  it("accepts declared object producer field policy", async () => {
+    await expectDeclaredOutput("compiled-output-024", "policy", "object");
+  });
+
+  it("accepts declared object producer field attributes", async () => {
+    await expectDeclaredOutput("compiled-output-025", "attributes", "object");
+  });
+
+  it("accepts declared array producer field items", async () => {
+    await expectDeclaredOutput("compiled-output-026", "items", "array");
+  });
+
+  it("accepts declared array producer field tags", async () => {
+    await expectDeclaredOutput("compiled-output-027", "tags", "array");
+  });
+
+  it("accepts declared array producer field regions", async () => {
+    await expectDeclaredOutput("compiled-output-028", "regions", "array");
+  });
+
+  it("accepts declared array producer field attachments", async () => {
+    await expectDeclaredOutput("compiled-output-029", "attachments", "array");
+  });
+
+  it("accepts declared array producer field approvers", async () => {
+    await expectDeclaredOutput("compiled-output-030", "approvers", "array");
+  });
+});
+

--- a/tests/e2e/features/compiled_plan_producer_failures.test.ts
+++ b/tests/e2e/features/compiled_plan_producer_failures.test.ts
@@ -1,0 +1,136 @@
+import { after, before, describe, it } from "node:test";
+import { startServer, stopServer } from "../harness.ts";
+import type { ServerHandle } from "../harness.ts";
+import { expectMissingProducer } from "../compiled_plan_cases.ts";
+
+describe("Compiled plan producer diagnostics", () => {
+  let server: ServerHandle | undefined;
+
+  before(async () => {
+    server = await startServer();
+  });
+
+  after(async () => {
+    await stopServer(server);
+  });
+
+  it("reports missing producer ghost", async () => {
+    await expectMissingProducer("compiled-producer-error-001", "ghost");
+  });
+
+  it("reports missing producer unknown", async () => {
+    await expectMissingProducer("compiled-producer-error-002", "unknown");
+  });
+
+  it("reports missing producer absent", async () => {
+    await expectMissingProducer("compiled-producer-error-003", "absent");
+  });
+
+  it("reports missing producer upstream", async () => {
+    await expectMissingProducer("compiled-producer-error-004", "upstream");
+  });
+
+  it("reports missing producer source_a", async () => {
+    await expectMissingProducer("compiled-producer-error-005", "source_a");
+  });
+
+  it("reports missing producer source_b", async () => {
+    await expectMissingProducer("compiled-producer-error-006", "source_b");
+  });
+
+  it("reports missing producer producer_1", async () => {
+    await expectMissingProducer("compiled-producer-error-007", "producer_1");
+  });
+
+  it("reports missing producer producer_2", async () => {
+    await expectMissingProducer("compiled-producer-error-008", "producer_2");
+  });
+
+  it("reports missing producer fetch_customer", async () => {
+    await expectMissingProducer("compiled-producer-error-009", "fetch_customer");
+  });
+
+  it("reports missing producer load_order", async () => {
+    await expectMissingProducer("compiled-producer-error-010", "load_order");
+  });
+
+  it("reports missing producer resolve_account", async () => {
+    await expectMissingProducer("compiled-producer-error-011", "resolve_account");
+  });
+
+  it("reports missing producer lookup_region", async () => {
+    await expectMissingProducer("compiled-producer-error-012", "lookup_region");
+  });
+
+  it("reports missing producer read_token", async () => {
+    await expectMissingProducer("compiled-producer-error-013", "read_token");
+  });
+
+  it("reports missing producer count_attempts", async () => {
+    await expectMissingProducer("compiled-producer-error-014", "count_attempts");
+  });
+
+  it("reports missing producer count_items", async () => {
+    await expectMissingProducer("compiled-producer-error-015", "count_items");
+  });
+
+  it("reports missing producer set_priority", async () => {
+    await expectMissingProducer("compiled-producer-error-016", "set_priority");
+  });
+
+  it("reports missing producer compute_total", async () => {
+    await expectMissingProducer("compiled-producer-error-017", "compute_total");
+  });
+
+  it("reports missing producer calculate_tax", async () => {
+    await expectMissingProducer("compiled-producer-error-018", "calculate_tax");
+  });
+
+  it("reports missing producer score_risk", async () => {
+    await expectMissingProducer("compiled-producer-error-019", "score_risk");
+  });
+
+  it("reports missing producer locate_device", async () => {
+    await expectMissingProducer("compiled-producer-error-020", "locate_device");
+  });
+
+  it("reports missing producer check_active", async () => {
+    await expectMissingProducer("compiled-producer-error-021", "check_active");
+  });
+
+  it("reports missing producer check_verified", async () => {
+    await expectMissingProducer("compiled-producer-error-022", "check_verified");
+  });
+
+  it("reports missing producer request_review", async () => {
+    await expectMissingProducer("compiled-producer-error-023", "request_review");
+  });
+
+  it("reports missing producer record_consent", async () => {
+    await expectMissingProducer("compiled-producer-error-024", "record_consent");
+  });
+
+  it("reports missing producer load_profile", async () => {
+    await expectMissingProducer("compiled-producer-error-025", "load_profile");
+  });
+
+  it("reports missing producer load_manifest", async () => {
+    await expectMissingProducer("compiled-producer-error-026", "load_manifest");
+  });
+
+  it("reports missing producer load_address", async () => {
+    await expectMissingProducer("compiled-producer-error-027", "load_address");
+  });
+
+  it("reports missing producer load_policy", async () => {
+    await expectMissingProducer("compiled-producer-error-028", "load_policy");
+  });
+
+  it("reports missing producer list_files", async () => {
+    await expectMissingProducer("compiled-producer-error-029", "list_files");
+  });
+
+  it("reports missing producer list_approvers", async () => {
+    await expectMissingProducer("compiled-producer-error-030", "list_approvers");
+  });
+});

--- a/tests/e2e/features/compiled_plan_unknown_roots.test.ts
+++ b/tests/e2e/features/compiled_plan_unknown_roots.test.ts
@@ -1,0 +1,137 @@
+import { after, before, describe, it } from "node:test";
+import { startServer, stopServer } from "../harness.ts";
+import type { ServerHandle } from "../harness.ts";
+import { expectUnknownRoot } from "../compiled_plan_cases.ts";
+
+describe("Compiled plan untyped roots", () => {
+  let server: ServerHandle | undefined;
+
+  before(async () => {
+    server = await startServer();
+  });
+
+  after(async () => {
+    await stopServer(server);
+  });
+
+  it("reports untyped state path phase", async () => {
+    await expectUnknownRoot("compiled-unknown-001", "state", "phase");
+  });
+
+  it("reports untyped state path attempt", async () => {
+    await expectUnknownRoot("compiled-unknown-002", "state", "attempt");
+  });
+
+  it("reports untyped state path status", async () => {
+    await expectUnknownRoot("compiled-unknown-003", "state", "status");
+  });
+
+  it("reports untyped state path cursor", async () => {
+    await expectUnknownRoot("compiled-unknown-004", "state", "cursor");
+  });
+
+  it("reports untyped state path checkpoint", async () => {
+    await expectUnknownRoot("compiled-unknown-005", "state", "checkpoint");
+  });
+
+  it("reports untyped state path iteration", async () => {
+    await expectUnknownRoot("compiled-unknown-006", "state", "iteration");
+  });
+
+  it("reports untyped state path branch", async () => {
+    await expectUnknownRoot("compiled-unknown-007", "state", "branch");
+  });
+
+  it("reports untyped state path started_at", async () => {
+    await expectUnknownRoot("compiled-unknown-008", "state", "started_at");
+  });
+
+  it("reports untyped state path deadline", async () => {
+    await expectUnknownRoot("compiled-unknown-009", "state", "deadline");
+  });
+
+  it("reports untyped state path owner", async () => {
+    await expectUnknownRoot("compiled-unknown-010", "state", "owner");
+  });
+
+  it("reports untyped state path lease", async () => {
+    await expectUnknownRoot("compiled-unknown-011", "state", "lease");
+  });
+
+  it("reports untyped state path revision", async () => {
+    await expectUnknownRoot("compiled-unknown-012", "state", "revision");
+  });
+
+  it("reports untyped state path mode", async () => {
+    await expectUnknownRoot("compiled-unknown-013", "state", "mode");
+  });
+
+  it("reports untyped state path progress", async () => {
+    await expectUnknownRoot("compiled-unknown-014", "state", "progress");
+  });
+
+  it("reports untyped state path result", async () => {
+    await expectUnknownRoot("compiled-unknown-015", "state", "result");
+  });
+
+  it("reports untyped config path region", async () => {
+    await expectUnknownRoot("compiled-unknown-016", "config", "region");
+  });
+
+  it("reports untyped config path environment", async () => {
+    await expectUnknownRoot("compiled-unknown-017", "config", "environment");
+  });
+
+  it("reports untyped config path endpoint", async () => {
+    await expectUnknownRoot("compiled-unknown-018", "config", "endpoint");
+  });
+
+  it("reports untyped config path timeout", async () => {
+    await expectUnknownRoot("compiled-unknown-019", "config", "timeout");
+  });
+
+  it("reports untyped config path retries", async () => {
+    await expectUnknownRoot("compiled-unknown-020", "config", "retries");
+  });
+
+  it("reports untyped config path feature", async () => {
+    await expectUnknownRoot("compiled-unknown-021", "config", "feature");
+  });
+
+  it("reports untyped config path policy", async () => {
+    await expectUnknownRoot("compiled-unknown-022", "config", "policy");
+  });
+
+  it("reports untyped config path namespace", async () => {
+    await expectUnknownRoot("compiled-unknown-023", "config", "namespace");
+  });
+
+  it("reports untyped config path queue", async () => {
+    await expectUnknownRoot("compiled-unknown-024", "config", "queue");
+  });
+
+  it("reports untyped config path pool", async () => {
+    await expectUnknownRoot("compiled-unknown-025", "config", "pool");
+  });
+
+  it("reports untyped config path runtime", async () => {
+    await expectUnknownRoot("compiled-unknown-026", "config", "runtime");
+  });
+
+  it("reports untyped config path version", async () => {
+    await expectUnknownRoot("compiled-unknown-027", "config", "version");
+  });
+
+  it("reports untyped config path locale", async () => {
+    await expectUnknownRoot("compiled-unknown-028", "config", "locale");
+  });
+
+  it("reports untyped config path currency", async () => {
+    await expectUnknownRoot("compiled-unknown-029", "config", "currency");
+  });
+
+  it("reports untyped config path timezone", async () => {
+    await expectUnknownRoot("compiled-unknown-030", "config", "timezone");
+  });
+});
+


### PR DESCRIPTION
Adds exactly 400 independently named Rust unit cases and 150 real-server Node.js end-to-end cases, plus a CI count gate. Validated with the targeted Rust and Node suites, strict Clippy, Rust formatting, TypeScript typecheck, exact-count validation, and diff/naming checks.