### PR TITLE
chore: stage v0.7.0-rc.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,6 +266,15 @@ jobs:
           curl -fsS http://localhost:8080/health/live > /dev/null
           curl -fsS http://localhost:8080/metrics | head -20
 
+      - name: Verify Cloud management surface
+        run: |
+          curl -fsS "http://localhost:8080/sequences?limit=1&tenant_id=default" > /dev/null
+          curl -fsS "http://localhost:8080/events?limit=1&tenant_id=default" > /dev/null
+          curl -fsS -X POST http://localhost:8080/sequences/preflight \
+            -H 'content-type: application/json' \
+            --data '{"id":"00000000-0000-4000-8000-000000000001","tenant_id":"default","namespace":"default","name":"ci-smoke","version":1,"created_at":"2026-01-01T00:00:00Z","blocks":[]}' \
+            > /dev/null
+
       - name: Tear down
         if: always()
         run: docker rm -f orch8-ci || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,6 +255,15 @@ jobs:
           docker logs orch8-release-smoke
           exit 1
 
+      - name: Verify Cloud management surface
+        run: |
+          curl -fsS "http://localhost:8080/sequences?limit=1&tenant_id=default" > /dev/null
+          curl -fsS "http://localhost:8080/events?limit=1&tenant_id=default" > /dev/null
+          curl -fsS -X POST http://localhost:8080/sequences/preflight \
+            -H 'content-type: application/json' \
+            --data '{"id":"00000000-0000-4000-8000-000000000001","tenant_id":"default","namespace":"default","name":"release-smoke","version":1,"created_at":"2026-01-01T00:00:00Z","blocks":[]}' \
+            > /dev/null
+
       # The docker-manifest job (and its `latest` update) only runs once both
       # platform legs pass this smoke test.
       - name: Tear down smoke container

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -581,6 +581,8 @@ jobs:
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.3.2
         with:
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
           files: |
             artifacts/orch8-*.tar.gz
             artifacts/orch8-*.tar.gz.sha256
@@ -594,6 +596,7 @@ jobs:
   # -- install.sh smoke test -------------------------------------------------
   install-sh-smoke:
     name: install.sh Smoke Test (${{ matrix.os }})
+    if: ${{ !contains(github.ref_name, '-') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     needs: [release]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "orch8"
-version = "0.7.0"
+version = "0.7.0-rc.1"
 dependencies = [
  "axum",
  "chrono",
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-api"
-version = "0.7.0"
+version = "0.7.0-rc.1"
 dependencies = [
  "axum",
  "base64",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-cli"
-version = "0.7.0"
+version = "0.7.0-rc.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-engine"
-version = "0.7.0"
+version = "0.7.0-rc.1"
 dependencies = [
  "async-nats",
  "base64",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-grpc"
-version = "0.7.0"
+version = "0.7.0-rc.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3113,7 +3113,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-mobile"
-version = "0.7.0"
+version = "0.7.0-rc.1"
 dependencies = [
  "base64",
  "chrono",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-publisher"
-version = "0.7.0"
+version = "0.7.0-rc.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-push"
-version = "0.7.0"
+version = "0.7.0-rc.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-server"
-version = "0.7.0"
+version = "0.7.0-rc.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-storage"
-version = "0.7.0"
+version = "0.7.0-rc.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-types"
-version = "0.7.0"
+version = "0.7.0-rc.1"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "orch8"
-version = "0.7.0-dev"
+version = "0.7.0"
 dependencies = [
  "axum",
  "chrono",
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-api"
-version = "0.7.0-dev"
+version = "0.7.0"
 dependencies = [
  "axum",
  "base64",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-cli"
-version = "0.7.0-dev"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-engine"
-version = "0.7.0-dev"
+version = "0.7.0"
 dependencies = [
  "async-nats",
  "base64",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-grpc"
-version = "0.7.0-dev"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3113,7 +3113,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-mobile"
-version = "0.7.0-dev"
+version = "0.7.0"
 dependencies = [
  "base64",
  "chrono",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-publisher"
-version = "0.7.0-dev"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-push"
-version = "0.7.0-dev"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-server"
-version = "0.7.0-dev"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-storage"
-version = "0.7.0-dev"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-types"
-version = "0.7.0-dev"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.0-rc.1"
 edition = "2024"
 rust-version = "1.97"
 license = "BUSL-1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0-dev"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.97"
 license = "BUSL-1.1"

--- a/scripts/test-review-fix-guards.sh
+++ b/scripts/test-review-fix-guards.sh
@@ -86,6 +86,10 @@ assert_contains .github/workflows/release.yml 'needs: [verify]'
 assert_contains .github/workflows/release.yml 'provenance: true'
 assert_contains .github/workflows/release.yml 'Smoke test pushed image'
 assert_contains .github/workflows/release.yml "if [[ \"\$TAG\" == *-* ]]"
+assert_contains .github/workflows/release.yml "prerelease: \${{ contains(github.ref_name, '-') }}"
+assert_contains .github/workflows/release.yml "if: \${{ !contains(github.ref_name, '-') }}"
+assert_contains .github/workflows/release.yml 'Verify Cloud management surface'
+assert_contains .github/workflows/ci.yml 'Verify Cloud management surface'
 assert_contains .github/workflows/ci.yml 'sqlite-smoke:'
 assert_contains .github/workflows/ci.yml 'fuzz-smoke:'
 assert_contains .github/workflows/ci.yml 'mobile-sync-smoke:'


### PR DESCRIPTION
## Why\n\nCloud production depends on management routes added after v0.6.0, including GET /events and POST /sequences/preflight. Fresh managed instances are pinned to v0.6.0, so Cloud reports them as degraded.\n\n## Change\n\n- stage the already-green 0.7.0-dev workspace as 0.7.0-rc.1\n- smoke-test the exact Cloud management routes in CI and each pushed architecture image\n- ensure prerelease tags do not move GHCR latest or GitHub Releases latest\n- skip install.sh latest-release smoke for prereleases\n\n## Validation\n\n- cargo metadata --locked --no-deps --format-version 1\n- ./scripts/test-review-fix-guards.sh\n- actionlint .github/workflows/ci.yml .github/workflows/release.yml\n- cargo fmt --all -- --check\n- git diff --check\n\nAfter merge and green main CI, tag v0.7.0-rc.1, publish the image, canary it on one disposable Cloud instance, then promote only after the production lifecycle passes.