### PR TITLE
fix: scope engine smoke requests to tenant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,10 +268,13 @@ jobs:
 
       - name: Verify Cloud management surface
         run: |
-          curl -fsS "http://localhost:8080/sequences?limit=1&tenant_id=default" > /dev/null
-          curl -fsS "http://localhost:8080/events?limit=1&tenant_id=default" > /dev/null
+          curl -fsS -H 'X-Tenant-Id: default' \
+            "http://localhost:8080/sequences?limit=1&tenant_id=default" > /dev/null
+          curl -fsS -H 'X-Tenant-Id: default' \
+            "http://localhost:8080/events?limit=1&tenant_id=default" > /dev/null
           curl -fsS -X POST http://localhost:8080/sequences/preflight \
             -H 'content-type: application/json' \
+            -H 'X-Tenant-Id: default' \
             --data '{"id":"00000000-0000-4000-8000-000000000001","tenant_id":"default","namespace":"default","name":"ci-smoke","version":1,"created_at":"2026-01-01T00:00:00Z","blocks":[]}' \
             > /dev/null
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,10 +257,13 @@ jobs:
 
       - name: Verify Cloud management surface
         run: |
-          curl -fsS "http://localhost:8080/sequences?limit=1&tenant_id=default" > /dev/null
-          curl -fsS "http://localhost:8080/events?limit=1&tenant_id=default" > /dev/null
+          curl -fsS -H 'X-Tenant-Id: default' \
+            "http://localhost:8080/sequences?limit=1&tenant_id=default" > /dev/null
+          curl -fsS -H 'X-Tenant-Id: default' \
+            "http://localhost:8080/events?limit=1&tenant_id=default" > /dev/null
           curl -fsS -X POST http://localhost:8080/sequences/preflight \
             -H 'content-type: application/json' \
+            -H 'X-Tenant-Id: default' \
             --data '{"id":"00000000-0000-4000-8000-000000000001","tenant_id":"default","namespace":"default","name":"release-smoke","version":1,"created_at":"2026-01-01T00:00:00Z","blocks":[]}' \
             > /dev/null
 


### PR DESCRIPTION
The new Cloud management-surface smoke correctly exposed that production-style engine routes are behind required tenant middleware. Add the required `X-Tenant-Id` header to sequence, event, and preflight probes in both CI and release workflows.\n\nValidated locally with release guard tests, actionlint, and diff checks. This remains a hard gate before tagging v0.7.0-rc.1.