### PR TITLE
fix(release): build GNU artifacts against Bookworm-compatible glibc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,10 +103,12 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            # Bookworm ships glibc 2.36. Build GNU artifacts on glibc 2.35 so
+            # both the standalone archive and Dockerfile.release remain compatible.
+            os: ubuntu-22.04
             archive: tar.gz
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             archive: tar.gz
           - target: x86_64-apple-darwin
             os: macos-latest
@@ -126,7 +128,7 @@ jobs:
 
       - name: Install protoc
         run: |
-          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+          if [[ "${{ matrix.os }}" == "ubuntu-22.04" ]]; then
             sudo apt-get update && sudo apt-get install -y protobuf-compiler
           else
             brew install protobuf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "orch8"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 dependencies = [
  "axum",
  "chrono",
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-api"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 dependencies = [
  "axum",
  "base64",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-cli"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-engine"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 dependencies = [
  "async-nats",
  "base64",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-grpc"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3113,7 +3113,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-mobile"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 dependencies = [
  "base64",
  "chrono",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-publisher"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-push"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-server"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-storage"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-types"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 edition = "2024"
 rust-version = "1.97"
 license = "BUSL-1.1"

--- a/scripts/test-review-fix-guards.sh
+++ b/scripts/test-review-fix-guards.sh
@@ -89,6 +89,7 @@ assert_contains .github/workflows/release.yml "if [[ \"\$TAG\" == *-* ]]"
 assert_contains .github/workflows/release.yml "prerelease: \${{ contains(github.ref_name, '-') }}"
 assert_contains .github/workflows/release.yml "if: \${{ !contains(github.ref_name, '-') }}"
 assert_contains .github/workflows/release.yml 'Verify Cloud management surface'
+assert_contains .github/workflows/release.yml 'os: ubuntu-22.04'
 assert_contains .github/workflows/ci.yml 'Verify Cloud management surface'
 assert_contains .github/workflows/ci.yml 'sqlite-smoke:'
 assert_contains .github/workflows/ci.yml 'fuzz-smoke:'


### PR DESCRIPTION
## What changed

- build both Linux GNU release artifacts on Ubuntu 22.04 instead of `ubuntu-latest`
- stage the engine workspace consistently as `0.7.0-rc.2`
- add a release-workflow guard for the pinned compatible runner

## Why

The `v0.7.0-rc.1` release built its GNU binary on Ubuntu 24.04, which linked against GLIBC 2.38+, then copied that binary into the Debian Bookworm runtime image, which provides glibc 2.36. The pushed amd64 image therefore failed its smoke test before the server could start.

Building on Ubuntu 22.04 (glibc 2.35) keeps the standalone GNU archives and Debian Bookworm images backward-compatible without changing the production runtime base.

## Impact

This unblocks publication of a Cloud-compatible engine release candidate. No engine runtime behavior changes in this PR.

## Validation

- `actionlint .github/workflows/release.yml`
- `bash scripts/test-review-fix-guards.sh`
- `cargo metadata --locked --no-deps --format-version 1`
- workspace/lockfile version-count assertions
- `git diff --check`

The authoritative runtime validation remains the release workflow's amd64 and arm64 image smoke tests after merge and tagging.
