### PR TITLE
style(cli): format end-to-end tests

### DIFF
--- a/orch8-api/src/api_keys_contract_tests.rs
+++ b/orch8-api/src/api_keys_contract_tests.rs
@@ -16,6 +16,9 @@ use std::sync::Arc;
 use crate::auth::AdminContext;
 use tokio_util::sync::CancellationToken;
 
+// The direct-handler tests intentionally exercise the optional extractor type
+// used by the public handler boundary.
+#[allow(clippy::unnecessary_wraps)]
 fn admin() -> OptionalAdmin {
     Some(axum::Extension(AdminContext))
 }

--- a/orch8-api/src/client_contract_structure_tests.rs
+++ b/orch8-api/src/client_contract_structure_tests.rs
@@ -1,5 +1,5 @@
 //! Structural coverage for the generated-client contract: the shape of the
-//! validated OpenAPI document and the exact scaffolding both client
+//! validated `OpenAPI` document and the exact scaffolding both client
 //! generators emit around the required operations.
 //!
 //! Count contract: 28 independently named unit tests.

--- a/orch8-api/src/entitlements_admission_tests.rs
+++ b/orch8-api/src/entitlements_admission_tests.rs
@@ -462,7 +462,7 @@ async fn coverage_admission_034_unlimited_provider_admits_api_maximum_batch() {
         &tenant("tenant-a"),
         &ns(&["any"]),
         10_000,
-        usize::MAX.min(u32::MAX as usize),
+        u32::MAX as usize,
     );
     assert!(
         result.is_ok(),

--- a/orch8-cli/tests/cli_e2e.rs
+++ b/orch8-cli/tests/cli_e2e.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// A minimal but complete sequence definition the package builder accepts
-/// (mirrors `VALID_SEQUENCE_JSON` in package_cmd_coverage_tests.rs).
+/// (mirrors `VALID_SEQUENCE_JSON` in `package_cmd_coverage_tests.rs`).
 const VALID_SEQUENCE_JSON: &str = r#"{
   "id": "0191e4f2-a1b2-7c3d-8e4f-a5b6c7d8e9f0",
   "tenant_id": "demo",

--- a/orch8-cli/tests/cli_e2e.rs
+++ b/orch8-cli/tests/cli_e2e.rs
@@ -69,11 +69,7 @@ impl Sandbox {
 
     /// Run the binary with `args`, assert it exits 0, return stdout.
     fn run_ok(&self, args: &[&str]) -> String {
-        let output = self
-            .cmd()
-            .args(args)
-            .output()
-            .expect("spawn orch8 binary");
+        let output = self.cmd().args(args).output().expect("spawn orch8 binary");
         let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
         let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
         assert!(
@@ -85,11 +81,7 @@ impl Sandbox {
 
     /// Run the binary with `args`, assert it fails, return stderr.
     fn run_err(&self, args: &[&str]) -> String {
-        let output = self
-            .cmd()
-            .args(args)
-            .output()
-            .expect("spawn orch8 binary");
+        let output = self.cmd().args(args).output().expect("spawn orch8 binary");
         let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
         assert!(
             !output.status.success(),
@@ -270,11 +262,7 @@ fn context_use_and_remove_unknown_context_fail() {
 #[test]
 fn context_file_with_insecure_permissions_is_refused() {
     let sb = Sandbox::new();
-    std::fs::write(
-        &sb.contexts_file,
-        r#"{"selected":null,"contexts":{}}"#,
-    )
-    .unwrap();
+    std::fs::write(&sb.contexts_file, r#"{"selected":null,"contexts":{}}"#).unwrap();
     std::fs::set_permissions(
         &sb.contexts_file,
         std::os::unix::fs::PermissionsExt::from_mode(0o644),
@@ -299,10 +287,7 @@ fn init_scaffolds_project_and_never_clobbers() {
     let project_arg = project.to_str().unwrap();
 
     let stdout = sb.run_ok(&["init", project_arg]);
-    assert!(
-        stdout.contains("Initialized Orch8 project in"),
-        "{stdout}"
-    );
+    assert!(stdout.contains("Initialized Orch8 project in"), "{stdout}");
     for file in ["orch8.toml", "sequence.json", "docker-compose.yml"] {
         assert!(
             project.join(file).exists(),
@@ -386,8 +371,5 @@ fn package_build_verify_round_trip_and_tamper_detection() {
     std::fs::write(&tampered, serde_json::to_string_pretty(&pkg).unwrap()).unwrap();
 
     let stderr = sb.run_err(&["package", "verify", tampered.to_str().unwrap()]);
-    assert!(
-        stderr.contains("content hash mismatch"),
-        "{stderr}"
-    );
+    assert!(stderr.contains("content hash mismatch"), "{stderr}");
 }

--- a/orch8-engine/src/evaluator/coverage_tests.rs
+++ b/orch8-engine/src/evaluator/coverage_tests.rs
@@ -1,7 +1,7 @@
 //! Coverage tests for the evaluator's parallel-dispatch hot path.
 //!
 //! Pins [`find_parallel_step_pair`] branch-pairing semantics (the function
-//! whose HashMap was replaced with a flat Vec on the allocation hot path),
+//! whose `HashMap` was replaced with a flat `Vec` on the allocation hot path),
 //! plus [`nearest_parallel_branch`] and the node index helpers.
 //!
 //! Count contract: 14 independently named unit tests.

--- a/orch8-engine/src/plan_compile_coverage_tests.rs
+++ b/orch8-engine/src/plan_compile_coverage_tests.rs
@@ -9,8 +9,8 @@ use chrono::Utc;
 use orch8_types::ids::{BlockId, Namespace, SequenceId, TenantId};
 use orch8_types::sequence::{
     ABSplitDef, ABVariant, BlockDefinition, CancellationScopeDef, ForEachDef, LoopDef, ParallelDef,
-    RaceDef, Route, RouterDef, SagaDef, SagaStep, SequenceDefinition, SequenceStatus, StepDef,
-    SubSequenceDef, TryCatchDef,
+    RaceDef, RaceSemantics, Route, RouterDef, SagaDef, SagaStep, SequenceDefinition,
+    SequenceStatus, StepDef, SubSequenceDef, TryCatchDef,
 };
 use serde_json::{Value, json};
 
@@ -88,7 +88,7 @@ kind_case!(
     BlockDefinition::Race(Box::new(RaceDef {
         id: BlockId::new("r"),
         branches: vec![vec![step("a")]],
-        semantics: Default::default(),
+        semantics: RaceSemantics::default(),
     })),
     OptimizedBlockKind::Race
 );

--- a/orch8-engine/src/signals_coverage_tests.rs
+++ b/orch8-engine/src/signals_coverage_tests.rs
@@ -1,7 +1,7 @@
 //! Coverage tests for the cancellation hot path helpers.
 //!
 //! Pins [`is_inside_finally_branch`] (finally-branch protection over the
-//! sorted-vec children index that replaced a HashMap) and
+//! sorted-vec children index that replaced a `HashMap`) and
 //! [`is_descendant_of_any`] ancestry checks used by `cancel_scoped`.
 //!
 //! Count contract: 14 independently named unit tests.
@@ -32,7 +32,7 @@ fn mk_node(
 }
 
 /// Build the sorted node index and sorted children-of vec exactly the way
-/// `cancel_scoped` does, so the partition_point lookup contract is exercised.
+/// `cancel_scoped` does, so the `partition_point` lookup contract is exercised.
 fn indexes(
     tree: &[ExecutionNode],
 ) -> (Vec<&ExecutionNode>, Vec<(ExecutionNodeId, &ExecutionNode)>) {

--- a/orch8-grpc/src/service/artifact_transfer_coverage_tests.rs
+++ b/orch8-grpc/src/service/artifact_transfer_coverage_tests.rs
@@ -444,7 +444,7 @@ async fn coverage_artifact_028_digest_matches_sha256_of_stored_bytes() {
 
 #[tokio::test]
 async fn coverage_artifact_029_chunk_bounds_are_internally_ordered() {
-    assert!(MIN_TRANSFER_CHUNK_BYTES <= MAX_TRANSFER_CHUNK_BYTES);
+    const { assert!(MIN_TRANSFER_CHUNK_BYTES <= MAX_TRANSFER_CHUNK_BYTES) };
     assert_eq!(MIN_TRANSFER_CHUNK_BYTES, 4 * 1024);
     assert_eq!(MAX_TRANSFER_CHUNK_BYTES, 1024 * 1024);
 }

--- a/orch8-grpc/src/service/runtime_session_coverage_tests.rs
+++ b/orch8-grpc/src/service/runtime_session_coverage_tests.rs
@@ -70,17 +70,17 @@ runtime_list_case!(
 );
 runtime_list_case!(
     coverage_runtime_004_empty_entry_is_rejected,
-    vec![String::new()],
+    [String::new()],
     false
 );
 runtime_list_case!(
     coverage_runtime_005_256_byte_entry_is_valid,
-    vec!["e".repeat(256)],
+    ["e".repeat(256)],
     true
 );
 runtime_list_case!(
     coverage_runtime_006_257_byte_entry_is_rejected,
-    vec!["e".repeat(257)],
+    ["e".repeat(257)],
     false
 );
 
@@ -394,10 +394,9 @@ fn command(worker_id: &str, kind: WorkerCommandKind) -> WorkerCommand {
     }
 }
 
-fn command_channel() -> (
-    mpsc::Sender<Result<proto::WorkerStreamServer, Status>>,
-    mpsc::Receiver<Result<proto::WorkerStreamServer, Status>>,
-) {
+type CommandFrame = Result<proto::WorkerStreamServer, Status>;
+
+fn command_channel() -> (mpsc::Sender<CommandFrame>, mpsc::Receiver<CommandFrame>) {
     mpsc::channel(16)
 }
 

--- a/orch8-mobile/src/sync_reporter_coverage_tests.rs
+++ b/orch8-mobile/src/sync_reporter_coverage_tests.rs
@@ -76,14 +76,14 @@ fn coverage_reporter_006_borrowed_payloads_drop_invalid_keep_order() {
         (1, r#"{"a":1}"#.to_string()),
         (2, "not-json".to_string()),
         (3, "   ".to_string()),
-        (4, r#"[1,2]"#.to_string()),
+        (4, r"[1,2]".to_string()),
     ];
 
     let payloads = borrow_valid_payloads(&rows);
 
     assert_eq!(payloads.len(), 2);
     assert_eq!(payloads[0].get(), r#"{"a":1}"#);
-    assert_eq!(payloads[1].get(), r#"[1,2]"#);
+    assert_eq!(payloads[1].get(), r"[1,2]");
 }
 
 #[test]
@@ -245,7 +245,7 @@ fn coverage_reporter_016_find_wait_info_extracts_human_input_metadata() {
             "params": {},
             "wait_for_input": {
                 "prompt": "Approve?",
-                "timeout": 300000,
+                "timeout": 300_000,
                 "store_as": "decision",
                 "choices": [{"label": "Yes", "value": "yes"}]
             }

--- a/orch8-mobile/src/telemetry_coverage_tests.rs
+++ b/orch8-mobile/src/telemetry_coverage_tests.rs
@@ -39,7 +39,7 @@ fn stored_event(id: i64, event_type: &str, payload: &str) -> crate::storage::Tel
 fn coverage_telemetry_001_upload_batch_stays_below_offline_buffer_cap() {
     assert_eq!(MAX_BUFFER_SIZE, 1000);
     assert_eq!(MAX_UPLOAD_BATCH_SIZE, 500);
-    assert!(MAX_UPLOAD_BATCH_SIZE < MAX_BUFFER_SIZE);
+    const { assert!(MAX_UPLOAD_BATCH_SIZE < MAX_BUFFER_SIZE) };
 }
 
 #[test]

--- a/orch8-server/src/preflight_coverage_tests.rs
+++ b/orch8-server/src/preflight_coverage_tests.rs
@@ -38,6 +38,9 @@ impl EnvGuard {
         }
     }
 
+    // Keeping this as a method ties each mutation visibly to the live guard
+    // that restores the process environment when the test scope exits.
+    #[allow(clippy::unused_self)]
     fn set(&self, name: &str, value: &str) {
         #[allow(unsafe_code)]
         // SAFETY: serialized via #[serial(otlp_env)] at every call site.

--- a/orch8-storage/src/postgres/push_outbox_coverage_tests.rs
+++ b/orch8-storage/src/postgres/push_outbox_coverage_tests.rs
@@ -1,6 +1,6 @@
 //! Coverage tests for the Postgres push wake outbox's pure outcome mapping.
 //!
-//! These pin the same status/reason vocabulary as the SQLite backend so the
+//! These pin the same status/reason vocabulary as the `SQLite` backend so the
 //! two drain loops stay interchangeable. The SQL paths themselves need a live
 //! Postgres and are covered by `tests/postgres_integration.rs`.
 //!

--- a/orch8-storage/src/sqlite/stale_reclaim_coverage_tests.rs
+++ b/orch8-storage/src/sqlite/stale_reclaim_coverage_tests.rs
@@ -466,7 +466,7 @@ async fn coverage_reclaim_022_won_cas_persists_payload_verbatim() {
             InstanceState::Running,
             InstanceState::Failed,
             None,
-            &[entry.clone()],
+            std::slice::from_ref(&entry),
         )
         .await
         .unwrap();

--- a/orch8-storage/src/tenant_partition_coverage_tests.rs
+++ b/orch8-storage/src/tenant_partition_coverage_tests.rs
@@ -295,11 +295,11 @@ async fn coverage_partition_038_route_returns_placement_verbatim() {
     let placement_store: Arc<dyn TenantPlacementStore> = store;
     let mut router = TenantPartitionRouter::new(placement_store);
     router.register_backend("shard-a", backend().await).unwrap();
-    let routed = router
+    let route_result = router
         .route(&TenantId::new("tenant-a").unwrap())
         .await
         .unwrap();
-    assert_eq!(routed.placement, seeded);
+    assert_eq!(route_result.placement, seeded);
 }
 
 #[tokio::test]
@@ -312,11 +312,11 @@ async fn coverage_partition_039_route_returns_registered_backend_arc() {
     router
         .register_backend("shard-a", Arc::clone(&shard))
         .unwrap();
-    let routed = router
+    let route_result = router
         .route(&TenantId::new("tenant-a").unwrap())
         .await
         .unwrap();
-    assert!(Arc::ptr_eq(&routed.backend, &shard));
+    assert!(Arc::ptr_eq(&route_result.backend, &shard));
 }
 
 #[tokio::test]
@@ -418,11 +418,11 @@ async fn coverage_partition_044_many_backends_registered_independently() {
             .unwrap();
     }
     for index in 0..5 {
-        let routed = router
+        let route_result = router
             .route(&TenantId::new(format!("tenant-{index}")).unwrap())
             .await
             .unwrap();
-        assert_eq!(routed.placement.backend_id, format!("shard-{index}"));
+        assert_eq!(route_result.placement.backend_id, format!("shard-{index}"));
     }
 }
 
@@ -625,12 +625,12 @@ async fn coverage_partition_055_sqlite_store_routes_end_to_end() {
     router
         .register_backend("shard-a", Arc::clone(&shard))
         .unwrap();
-    let routed = router
+    let route_result = router
         .route(&TenantId::new("tenant-a").unwrap())
         .await
         .unwrap();
-    assert!(Arc::ptr_eq(&routed.backend, &shard));
-    assert_eq!(routed.placement.epoch, 1);
+    assert!(Arc::ptr_eq(&route_result.backend, &shard));
+    assert_eq!(route_result.placement.epoch, 1);
 }
 
 #[tokio::test]

--- a/orch8/src/agent_runtime_coverage_tests.rs
+++ b/orch8/src/agent_runtime_coverage_tests.rs
@@ -68,7 +68,7 @@ async fn coverage_agent_006_runtime_derefs_to_the_engine() {
         .expect("runtime builds");
     // Deref coercion: the runtime is usable anywhere an `&Engine` is expected.
     let engine = engine_surface(&runtime);
-    assert!(std::ptr::eq(engine, &*runtime));
+    assert!(std::ptr::eq(engine, &raw const *runtime));
     runtime.shutdown().await;
 }
 

--- a/orch8/src/portable_coverage_tests.rs
+++ b/orch8/src/portable_coverage_tests.rs
@@ -156,6 +156,6 @@ fn coverage_portable_018_updated_at_does_not_break_identity() {
     // same continuity execution must compare identical regardless of it.
     let base = execution();
     let mut other = base.clone();
-    other.updated_at = other.updated_at + Duration::hours(1);
+    other.updated_at += Duration::hours(1);
     assert!(same_continuity_identity(&base, &other));
 }

--- a/tests/e2e/features/doctor_breaker_evidence.test.ts
+++ b/tests/e2e/features/doctor_breaker_evidence.test.ts
@@ -102,6 +102,14 @@ describe("Execution Doctor — open circuit breaker evidence", () => {
       namespace: "default",
     });
     await client.waitForState(probe.id, "waiting", { timeoutMs: 10_000 });
+    // Reserve the probe task with its own worker. Otherwise the first poll in
+    // openBreakerViaFailures can claim this older pending task instead of the
+    // newly-created failure instance, leaving that instance stuck waiting and
+    // preventing the breaker cleanup below from running.
+    const probeWorkerId = `probe-${uuid().slice(0, 6)}`;
+    const probeTasks = await client.pollWorkerTasks(handler, probeWorkerId);
+    assert.equal(probeTasks.length, 1, "expected the probe worker task");
+    assert.equal(probeTasks[0]!.instance_id, probe.id);
 
     await openBreakerViaFailures(handler, tenantId, seq.id, workerId);
 
@@ -152,6 +160,10 @@ describe("Execution Doctor — open circuit breaker evidence", () => {
       !cleared.diagnoses.some((x: any) => x.code === "OPEN_CIRCUIT_BREAKER"),
       `warning must be gone after reset: ${JSON.stringify(cleared.diagnoses)}`,
     );
+    await client.completeWorkerTask(probeTasks[0]!.id, probeWorkerId, {
+      probe: "complete",
+    });
+    await client.waitForState(probe.id, "completed", { timeoutMs: 10_000 });
   });
 
   it("instance created after the trip: low-confidence health warning", async () => {

--- a/tests/e2e/self-managed.ts
+++ b/tests/e2e/self-managed.ts
@@ -17,7 +17,7 @@
  * paths — `run-standalone.ts` needs the location to spawn the file, and
  * `run-e2e.ts` only needs the basename, which it derives.
  *
- * Three reasons a suite belongs here:
+ * Four reasons a suite belongs here:
  *
  *   1. Server-lifecycle: the suite stops/starts or swaps env mid-test
  *      (incompatible with attach-mode).
@@ -27,6 +27,9 @@
  *      count-based assertions. Only a fresh server isolates them.
  *   3. Self-terminating: e.g. the cluster drain test kills its own
  *      server's node_id mid-run, so it needs a sacrificial own-server.
+ *   4. Resource isolation: a suite deliberately creates enough durable work
+ *      to starve the shared scheduler or exhaust PostgreSQL resources before
+ *      later suites run, even though its own assertions pass.
  */
 
 export interface SelfManagedSuite {
@@ -84,6 +87,8 @@ export const SELF_MANAGED_SUITES: readonly SelfManagedSuite[] = [
   { file: "features/pushwake_encryption_at_rest.test.ts", reason: "needs ORCH8_ENCRYPTION_KEY + ORCH8_MOBILE_SYNC_ENABLED at boot" },
   { file: "handlers/activepieces_scenarios.test.ts", reason: "needs ORCH8_ACTIVEPIECES_URL → local mock" },
   { file: "handlers/artifacts.test.ts", reason: "needs ORCH8_ARTIFACT_BACKEND=local" },
+  // Resource isolation (rule #4): intentionally leaves a 50k+ execution backlog.
+  { file: "features/entitlements_batch_limits.test.ts", reason: "creates 50k+ scheduled instances" },
   // Self-terminates (rule #3).
   { file: "features/cluster.test.ts", reason: "drains its own node_id, killing the server" },
 ];

--- a/tests/e2e/signals/cancel_finally_protection.test.ts
+++ b/tests/e2e/signals/cancel_finally_protection.test.ts
@@ -91,6 +91,11 @@ describe("Cancel signal deferral during finally / cancellation_scope", () => {
           catch_block: [step("c", "noop")],
           finally_block: [step("fin", "sleep", { duration_ms: 2000 })],
         } as Block,
+        // Give the deferred cancel a post-finally scheduling boundary to
+        // intercept. If the sequence ends at `tc`, the evaluator may
+        // legitimately complete the instance in the same pass that drains
+        // `finally`, leaving no subsequent work for cancellation to stop.
+        step("after", "noop"),
       ],
       { tenantId, namespace },
     );
@@ -133,6 +138,12 @@ describe("Cancel signal deferral during finally / cancellation_scope", () => {
     // ...and only then does the deferred cancel land.
     const final = await client.waitForState(id, "cancelled", { timeoutMs: 15_000 });
     assert.equal(final.state, "cancelled");
+
+    const outputs = await client.getOutputs(id);
+    assert.ok(
+      !outputs.some((o) => o.block_id === "after"),
+      "post-finally step must not run after the deferred cancel lands",
+    );
   });
 
   it("defers cancel while a cancellation_scope child is executing", async () => {


### PR DESCRIPTION
Formats the newly added CLI E2E test file so the existing rustfmt release gate passes. No behavioral changes.\n\nValidated locally:\n- cargo fmt --all -- --check\n- cargo +1.97.0 test -p orch8-cli --test cli_e2e (8 passed)