### PR TITLE
docs: align engine documentation with current features

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,35 +20,78 @@ Portable Continuity takes that further: a running execution can hand off between
 
 ## Features
 
-**Workflow Primitives** — Step, Parallel, Race, TryCatch, Loop, ForEach, Router, SubSequence, CancellationScope, AB Split, Saga (sequential steps with LIFO compensating rollback on failure)
+**Durable execution** — Snapshot-based crash recovery, retry with exponential
+backoff and conditional failure policies, idempotency keys, persistent circuit
+breakers, dead-letter fingerprinting, automatic incident reproduction, and
+checkpoint-based fork/resume. Side-effecting steps use a universal effect
+ledger so recovery can distinguish uncommitted, committed, unknown, and
+compensated effects.
 
-**Conditional Execution** — per-step `when` guards (skip a step based on context/prior outputs, no handler invocation), conditional retry policies (`retry_if` expression evaluated against the failure, `non_retryable_codes` denylist — both layer on top of `max_attempts`/backoff)
+**Workflow language** — Step, Parallel, Race, TryCatch, Loop, ForEach, Router,
+SubSequence, CancellationScope, AB Split, and Saga; per-step `when` guards;
+JSON Schema input/output contracts; dynamic block injection; and bounded
+concurrent execution of independent `Parallel` branches.
 
-**Scheduling** — Relative delays, business-days-only with holiday awareness, timezone-per-instance, jitter, send windows, cron triggers with configurable tick interval
+**Scheduling and dispatch** — Relative and cron schedules, business calendars,
+timezones, jitter, send windows, per-entity concurrency keys, weighted resource
+pools, sliding-window limits, daily caps, warmup ramps, four priority levels,
+and cooperative preemption at durable step boundaries.
 
-**Rate Limiting** — Per-resource sliding window with deferred scheduling (not rejection), resource pools with weighted rotation, daily caps, and warmup ramps
+**Workers and extensions** — Lease-based REST workers with resumable heartbeat
+checkpoints, queue/version/capability routing, a [negotiated bidirectional gRPC
+session](docs/GRPC_WORKER_STREAM.md), gRPC sidecars, WASM plugins, MCP client and
+server modes, Activepieces, signed webhooks, and deduplicated events. Worker,
+runtime, artifact-transfer, telemetry, and control sessions are bounded and
+resumable.
 
-**Reliability** — Crash recovery via state snapshots, configurable retry with exponential backoff, dead letter queue with root-cause fingerprinting and automatic incident reproduction, idempotency keys, circuit breakers with fallback handler routing and persistent state, block output schemas (JSON Schema-gated handler output)
+**Data, artifacts, and streams** — Durable local or S3-compatible encrypted
+artifacts, automatic externalization of oversized state, instance and
+tenant-namespaced semantic memory, a resumable tenant change feed, and bounded
+tumbling/sliding/session windows over durable continuity frames.
 
-**Concurrency** — Per-entity key control, priority queues (Low/Normal/High/Critical), bulk create/pause/resume/cancel, batch instance creation (up to 10k)
+**Multi-tenancy and governance** — Capability-scoped tenant principals,
+provider-neutral plan entitlements, tenant rate/concurrency limits,
+tenant-isolated breakers and memory, authoritative [tenant partition
+routing](docs/TENANT_PARTITION_ROUTING.md), and fail-closed residency,
+disclosure, delegation, and federation policy.
 
-**Multi-tenancy** — Tenant-scoped queries, per-tenant rate limits, per-tenant circuit breakers, tenant isolation middleware, per-tenant noisy-neighbor protection
+**Security** — Secure-by-default API-key and tenant enforcement, AES-256-GCM
+encryption for context, credentials, artifacts, worker checkpoints, and
+protected mobile fields; OAuth2 credential refresh; mTLS workload identity;
+HMAC-signed webhooks; signed packages/capsules/provenance; nonce and federation
+replay boundaries; CORS controls; and outbound URL/SSRF validation.
 
-**Extensibility** — External workers through REST polling or a [negotiated bidirectional gRPC session](docs/GRPC_WORKER_STREAM.md), gRPC sidecar plugins, WASM plugins, webhook events (HMAC-signed with replay protection), workflow interceptors, emit-event with deduplication, and tenant-scoped signed workflow/connector packages with verifiable publication history. See [Package Registry](docs/PACKAGE_REGISTRY.md).
+**AI and human workflows** — Multi-provider `llm_call` with structured-output
+repair, multimodal artifacts, cost/token telemetry, effect-safe provider
+failover, durable ReAct agents, governed shared knowledge, bounded cumulative
+budgets, evidence-scoped evaluation gates, and lease-safe human attention.
 
-**Observability** — Prometheus metrics, structured JSON logging, audit log, execution tree visualization, Grafana dashboard template, visual execution workbench (unified timeline, run comparison, fork preview), template debugger and resolution inspector, stuck-instance doctor with ranked diagnostics
+**Release and distribution safety** — Sequence preflight, typed-dataflow
+compilation, semantic diff, historical effect-free replay, guarded canaries,
+automatic rollback gates, workflow contracts, signed packages, append-only
+registry history, runtime-targeted channels, attestations, dependency locks,
+and verified delta fallback. See [Safe Releases](docs/RELEASES.md), [Package
+Registry](docs/PACKAGE_REGISTRY.md), and [Governed Distribution](docs/DISTRIBUTION_GOVERNANCE.md).
 
-**Release Safety** — semantic diff between sequence versions, historical validation against recorded runs, canary routing with automatic rollback gates, workflow contracts (declarative scenario tests with virtual time), sequence preflight readiness checks
+**Mobile, edge, and portable continuity** — Native iOS/Android execution via
+Rust + UniFFI, offline-first sync, protected device tools, durable APNs/FCM
+wake delivery, capability-aware placement, signed capsule handoff, ownership
+epochs, provenance, live migration/rollback, receipt-backed compensation,
+what-if simulation, sovereign-edge enforcement, and signed federation
+send/receive primitives. See [Mobile SDK](docs/MOBILE_SDK.md), [Continuity
+Operations](docs/CONTINUITY_OPERATIONS.md), and [Continuity Debugging](docs/CONTINUITY_DEBUGGING.md).
 
-**AI Agent Support** — Unified `llm_call` handler covering all major providers (OpenAI, Anthropic, Gemini + 7 more), dynamic step injection (self_modify), human-in-the-loop with timeout/escalation, SSE streaming, query-instance handler for cross-workflow coordination
+**Operations and observability** — Role-specific all-in-one/control/executor/
+gateway/edge nodes, secure verified bootstrap, aggregate startup preflight,
+auditable draining, outbound managed-control tunnels, redacted support bundles,
+Prometheus metrics, OTLP/JSON telemetry, audit and provenance logs, execution
+workbench, ranked diagnosis, previewable remediation, and the operator
+dashboard. See [Node Roles](docs/NODE_ROLES.md), [Secure Bootstrap](docs/SECURE_BOOTSTRAP.md),
+and [Support Bundle](docs/SUPPORT_BUNDLE.md).
 
-**Mobile** — Native iOS and Android SDK via Rust + UniFFI, offline-first execution, battery-aware sync intervals, server-side visibility into mobile workflows, human-in-the-loop approvals via a [durable APNs/FCM wake outbox](docs/PUSH_DELIVERY.md), single bidirectional sync endpoint
-
-**Portable Continuity** — cryptographically-signed capsule handoff lets a running execution move between server, device, and back mid-flight with exactly-once ownership transfer, tamper-evident provenance chains, effect-receipt tracking (at-most-once side effects across retries and handoffs), capability-aware placement routing, live migration between sequence versions with rollback, comparative what-if simulation from a checkpoint, and fail-closed residency/federation controls for regulated data. See [Continuity Operations](docs/CONTINUITY_OPERATIONS.md) and [Continuity Debugging](docs/CONTINUITY_DEBUGGING.md).
-
-**Typed Dataflow** — a bounded compiler analyzes `data.*`/`outputs.*`/`state.*`/`config.*` references across a sequence and generates matching, byte-stable TypeScript and Python bindings plus a canonical schema; missing producers and closed-schema violations fail preflight with the exact reference chain. See [Typed Dataflow](docs/TYPED_DATAFLOW.md).
-
-**Security** — AES-256-GCM encryption at rest for context and credentials, OAuth2 credential refresh, API key authentication, CORS configuration, HMAC-signed webhooks with nonce replay protection
+The [documentation index](docs/README.md) maps each capability to its guide.
+For the exact release-by-release inventory, including migrations and explicit
+non-guarantees, see the [changelog](CHANGELOG.md#unreleased).
 
 ## Install
 
@@ -301,8 +344,15 @@ engine/
 docker run -d \
   -p 8080:8080 \
   -e ORCH8_DATABASE_URL=postgres://user:pass@host:5432/orch8 \
+  -e ORCH8_API_KEY=replace-with-a-long-random-secret \
+  -e ORCH8_ENCRYPTION_KEY=replace-with-64-hex-characters \
+  -e ORCH8_REQUIRE_TENANT_HEADER=true \
   ghcr.io/orch8-io/engine:latest
 ```
+
+Mount configuration and secrets instead of putting them directly in shell
+history in production. See the [Docker deployment guide](docs/DEPLOYMENT.md#docker)
+and [secure bootstrap](docs/SECURE_BOOTSTRAP.md).
 
 ### Helm
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -27,7 +27,7 @@ version lifecycle contract.
 
 ## Authentication
 
-When `ORCH8_API_KEY` is set, every endpoint requires an `x-api-key` header — including `/metrics`, `/swagger-ui`, and `/api-docs/openapi.json`. When `ORCH8_REQUIRE_TENANT_HEADER` is set, requests must also carry an `x-tenant-id` header, and tenant-owned resources are scoped to that tenant.
+When `ORCH8_API_KEY` is set, every endpoint requires an `x-api-key` header — including `/metrics`, `/swagger-ui`, and `/api-docs/openapi.json`. `ORCH8_REQUIRE_TENANT_HEADER` defaults to `true`; authenticated requests must also carry an `x-tenant-id` header unless a capability-scoped tenant key supplies the authoritative tenant. Disabling tenant-header enforcement requires the explicit `ORCH8_ALLOW_NO_TENANT_ISOLATION=1` risk acknowledgement. Tenant-owned resources remain scoped to the authenticated tenant.
 
 Only the health probes (`/health/live`, `/health/ready`, `/info`) and inbound public webhooks (`POST /webhooks/{slug}`, which use their own per-trigger secrets) stay public, so load-balancer checks and third-party webhook callers keep working.
 
@@ -1534,12 +1534,16 @@ which are summarized rather than repeated field-by-field here:
 - **Plugins** — WASM and gRPC plugin registration
 - **Approvals** — Human-in-the-loop approval inbox
 - **Cluster** — Node listing, heartbeat, drain
+- **Diagnosis and remediation** — Ranked instance findings, state-bound previews, and audited apply
+- **Tenant change feed** — Cursor-resumable polling and bounded SSE over immutable audit changes
 - **Webhooks** — Webhook subscription management
 - **Telemetry** — Execution telemetry and rollback history
-- **API Keys** — Per-tenant API key create/list/revoke (`/api-keys`)
+- **API Keys and principals** — Per-tenant capability-scoped key create/list/revoke (`/api-keys`)
+- **Admission entitlements** — Namespace, context-size, batch-size, and active-instance limits on instance creation
 - **Sequence lifecycle** — List, delete, versions, promote/deprecate/unpublish, status, and `POST /sequences/migrate-instance`
-- **Execution introspection** — `GET /instances/{id}/tree` (execution tree), `/timeline`, `/audit`, `/artifacts`, and SSE streaming at `GET /instances/{id}/stream`
+- **Execution introspection** — `GET /instances/{id}/tree` (execution tree), `/timeline`, `/audit`, `/artifacts`, `/effects`, and SSE streaming at `GET /instances/{id}/stream`
 - **Checkpoints & recovery** — `GET|POST /instances/{id}/checkpoints`, `/checkpoints/latest`, `/checkpoints/prune`, `POST /instances/{id}/fork`, `POST /instances/{id}/resume-from/{block_id}`, `POST /instances/{id}/inject-blocks`
+- **Continuity control** — Ownership handoff, provenance, budgets, evidence gates, migrations, compensations, attention, residency, federation, fault lab, and stream windows
 - **Bulk reschedule** — `PATCH /instances/bulk/reschedule` (shift `next_fire_at` by `offset_secs`)
 - **Rollback policies** — `/rollback-policies` CRUD
 - **Usage & info** — `GET /usage`, `GET /info` (version + environment label)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,7 +20,11 @@ Sequence Definition          Task Instance
                               +-----------------------------+
 ```
 
-**Single binary** — API server, scheduler, cron loop, and worker reaper all run in one process. PostgreSQL is the only dependency.
+**One deployable binary, five roles** — `all_in_one` runs the API, scheduler,
+cron loop, worker reaper, and push outbox in one process. `control`, `executor`,
+`gateway`, and `edge` assemble narrower surfaces from the same binary. See
+[Node Roles](NODE_ROLES.md). PostgreSQL is the production dependency; SQLite
+supports development, embedding, and mobile runtimes.
 
 ---
 
@@ -31,7 +35,7 @@ orch8-server          Binary entry point, wires config/storage/api/engine
     |
 orch8-api             REST routes (axum), request/response types
     |
-orch8-grpc            gRPC service (tonic) for high-throughput clients
+orch8-grpc            gRPC workers, runtime control, artifact transfer, telemetry
     |
 orch8-engine          Scheduler tick loop, evaluator, handlers, signals, recovery
     |
@@ -41,11 +45,11 @@ orch8-types           Domain types, IDs, config, errors (shared by every crate)
     |
 orch8-mobile          UniFFI bindings for iOS/Android, offline-first engine
     |
-orch8-push            APNs/FCM push notification providers
+orch8-push            Durable, governed APNs/FCM wake delivery
     |
-orch8-publisher       Event publishing (webhooks, NATS)
+orch8-publisher       Signed package registry and governed distribution
     |
-orch8-cli             CLI tool (init, sequence, instance, signal, health)
+orch8-cli             Bootstrap, authoring, operations, debugging, releases
 ```
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,28 +24,41 @@ health probes and inbound webhook routes are intentionally public.
 - [Dashboard](DASHBOARD.md) — connect the operator console and use its current surfaces.
 - [Safe releases](RELEASES.md) — diff, validate, canary, evaluate, promote, and roll back.
 - [Deployment](DEPLOYMENT.md) — Docker, Kubernetes, cloud targets, and the production checklist.
+- [Secure production bootstrap](SECURE_BOOTSTRAP.md) — scaffold, validate, start, and readiness-check a secure node.
+- [Node roles](NODE_ROLES.md) — assemble all-in-one, control, executor, gateway, and edge processes; operate managed-control sessions and fleet draining.
+- [Operator support bundle](SUPPORT_BUNDLE.md) — collect bounded, redacted diagnostics atomically.
 - [External workers](WORKERS.md) — poll, heartbeat, complete, and fail work from any language.
+- [Negotiated gRPC worker stream](GRPC_WORKER_STREAM.md) — worker sessions, control, resumable artifacts, telemetry, and mTLS identity.
 - [Webhooks](WEBHOOKS.md) — delivery, signatures, replay protection, and receiver example.
+- [Durable push delivery](PUSH_DELIVERY.md) — APNs/FCM wake outbox lifecycle and recovery.
+- [Governed execution wakes](PUSH_GOVERNANCE.md) — tenant credential routing, signed wake metadata, collapse, and token quarantine.
 - [Continuity operations](CONTINUITY_OPERATIONS.md) — portable handoff, migration, effects, and provenance.
 - [Continuity debugging](CONTINUITY_DEBUGGING.md) — fault lab, DLQ reproduction, checkpoints, and fixture extraction.
 
 ## Reference
 
-- [Engine capability priorities](ENGINE_FEATURE_PRIORITIES.md) — engine-only roadmap, estimates, and proposals deliberately not pursued.
 - [REST API](API.md) — curated guide to the most-used routes and payloads.
 - [Live OpenAPI](http://localhost:8080/swagger-ui) — complete generated request/response reference for a running engine.
+- [API entitlements and generated-client gate](API_ENTITLEMENTS_AND_CLIENT_GATE.md) — plan admission limits and OpenAPI compatibility enforcement.
 - [Configuration](CONFIGURATION.md) — TOML and environment variables.
+- [CLI productization commands](CLI_PRODUCTIZATION.md) — contexts, deploy gates, and bounded debugging.
 - [Mobile SDK](MOBILE_SDK.md) — iOS/Android API and build reference.
+- [Mobile protected fields and device tools](MOBILE_PRIVACY_AND_TOOLS.md) — capability descriptors, opaque handles, redaction, and field-key rotation.
 - [Typed dataflow](TYPED_DATAFLOW.md) — static reference checking and generated bindings.
 - [Storage backend conformance](STORAGE_BACKEND_CONFORMANCE.md) — reusable minimum behavioral suite for third-party backends.
+- [Tenant partition routing](TENANT_PARTITION_ROUTING.md) — authoritative backend placement, fencing epochs, and tenant moves.
 - [Externalized state](EXTERNALIZATION.md) — payload offloading behavior and metrics.
 - [Governed durable memory](GOVERNED_MEMORY.md) — memory authorization, retention, residency labels, deletion, and provenance.
+- [Package registry](PACKAGE_REGISTRY.md) — signed object layout, publication, and consumer verification.
+- [Governed distribution](DISTRIBUTION_GOVERNANCE.md) — channels, deltas, private policy, attestations, and dependency locks.
+- [Workflow compiler optimization](WORKFLOW_OPTIMIZER.md) — immutable optimization sidecars and equivalence guarantees.
 - [Database migrations](../migrations/README.md) — immutability and checksum rules.
 
 ## Understand
 
 - [Architecture](ARCHITECTURE.md) — crates, execution model, storage, concurrency, and observability.
 - [Embedding applications](APPLICATIONS.md) — mobile, desktop, browser, edge, and game-engine use cases.
+- [Engine capability priorities](ENGINE_FEATURE_PRIORITIES.md) — implemented engine primitives, deliberate bounds, and rejected duplicate abstractions.
 
 ## Component and example documentation
 


### PR DESCRIPTION
## What changed

- expand the root feature overview to cover the implemented execution, worker, governance, AI, security, distribution, continuity, and operations capabilities
- make `docs/README.md` a complete index of the repository's feature guides
- align architecture documentation with node roles, gRPC sessions, governed push delivery, package distribution, and current CLI responsibilities
- update the curated API guide for secure tenant defaults, principals, entitlements, effects, change feeds, remediation, and continuity controls
- make the Docker example include the authentication and encryption configuration required by secure defaults

## Why

Recent engine features were documented in focused guides and the changelog, but the primary README, architecture overview, API summary, and documentation index did not consistently expose them. This made implemented capabilities difficult to discover and left one Docker example inconsistent with startup requirements.

## Impact

New users and operators can now discover the current feature set from the main entry points, while generated OpenAPI and the changelog remain the exhaustive sources of truth.

## Validation

- `git diff --check`
- verified every relative Markdown link in the changed files resolves locally
- verified every top-level `docs/*.md` guide is linked from `docs/README.md`
