### PR TITLE
Harden v0.7.0-rc.2 release artifacts

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -51,7 +51,7 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
       - name: Ensure cargo on PATH
-        run: echo "$(dirname "$(rustup which cargo)")" >> "$GITHUB_PATH"
+        run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
         with:
           key: ios-${{ matrix.target }}
@@ -88,7 +88,7 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
       - name: Ensure cargo on PATH
-        run: echo "$(dirname "$(rustup which cargo)")" >> "$GITHUB_PATH"
+        run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
         with:
           key: android-${{ matrix.target }}
@@ -103,15 +103,17 @@ jobs:
         run: |
           NDK_PATH="${{ steps.setup-ndk.outputs.ndk-path }}"
           TOOLCHAIN="${NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64"
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=${TOOLCHAIN}/bin/aarch64-linux-android24-clang" >> "$GITHUB_ENV"
-          echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=${TOOLCHAIN}/bin/armv7a-linux-androideabi24-clang" >> "$GITHUB_ENV"
-          echo "CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=${TOOLCHAIN}/bin/x86_64-linux-android24-clang" >> "$GITHUB_ENV"
-          echo "CC_aarch64_linux_android=${TOOLCHAIN}/bin/aarch64-linux-android24-clang" >> "$GITHUB_ENV"
-          echo "CC_armv7_linux_androideabi=${TOOLCHAIN}/bin/armv7a-linux-androideabi24-clang" >> "$GITHUB_ENV"
-          echo "CC_x86_64_linux_android=${TOOLCHAIN}/bin/x86_64-linux-android24-clang" >> "$GITHUB_ENV"
-          echo "AR_aarch64_linux_android=${TOOLCHAIN}/bin/llvm-ar" >> "$GITHUB_ENV"
-          echo "AR_armv7_linux_androideabi=${TOOLCHAIN}/bin/llvm-ar" >> "$GITHUB_ENV"
-          echo "AR_x86_64_linux_android=${TOOLCHAIN}/bin/llvm-ar" >> "$GITHUB_ENV"
+          {
+            echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=${TOOLCHAIN}/bin/aarch64-linux-android24-clang"
+            echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=${TOOLCHAIN}/bin/armv7a-linux-androideabi24-clang"
+            echo "CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=${TOOLCHAIN}/bin/x86_64-linux-android24-clang"
+            echo "CC_aarch64_linux_android=${TOOLCHAIN}/bin/aarch64-linux-android24-clang"
+            echo "CC_armv7_linux_androideabi=${TOOLCHAIN}/bin/armv7a-linux-androideabi24-clang"
+            echo "CC_x86_64_linux_android=${TOOLCHAIN}/bin/x86_64-linux-android24-clang"
+            echo "AR_aarch64_linux_android=${TOOLCHAIN}/bin/llvm-ar"
+            echo "AR_armv7_linux_androideabi=${TOOLCHAIN}/bin/llvm-ar"
+            echo "AR_x86_64_linux_android=${TOOLCHAIN}/bin/llvm-ar"
+          } >> "$GITHUB_ENV"
 
       - name: Build liborch8_mobile
         run: cargo build --profile mobile-release --target ${{ matrix.target }} -p orch8-mobile
@@ -133,7 +135,7 @@ jobs:
         with:
           toolchain: stable
       - name: Ensure cargo on PATH
-        run: echo "$(dirname "$(rustup which cargo)")" >> "$GITHUB_PATH"
+        run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
 
       - name: Build library for binding generation
@@ -192,6 +194,8 @@ jobs:
             -library build/liborch8_mobile-sim.a -headers build/headers \
             -output build/Orch8Mobile.xcframework
 
+          cp LICENSE build/Orch8Mobile.xcframework/LICENSE
+
       - name: Upload XCFramework
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -236,6 +240,9 @@ jobs:
           cp ../../artifacts/bindings/kotlin/io/orch8/mobile/orch8_mobile.kt orch8-mobile/src/main/java/io/orch8/mobile/
 
           gradle :orch8-mobile:assembleRelease
+          bash ../../scripts/embed-aar-license.sh \
+            orch8-mobile/build/outputs/aar/orch8-mobile-release.aar \
+            ../../LICENSE
 
       - name: Upload AAR
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -251,42 +258,7 @@ jobs:
           ORCH8_MOBILE_VERSION: ${{ github.ref_name }}
         run: gradle :orch8-mobile:publishReleasePublicationToGitHubPackagesRepository
 
-  # -- Publish tagged native artifacts ------------------------------------
-  release:
-    name: Publish native release assets
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: macos-latest
-    needs: [xcframework, aar]
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: Orch8Mobile.xcframework
-          path: release/Orch8Mobile.xcframework
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: orch8-mobile.aar
-          path: release/android
-      - name: Archive XCFramework
-        run: ditto -c -k --sequesterRsrc --keepParent release/Orch8Mobile.xcframework release/Orch8Mobile.xcframework.zip
-      - name: Normalize Android artifact name
-        run: cp release/android/orch8-mobile-release.aar release/orch8-mobile.aar
-      - name: Generate checksums
-        working-directory: release
-        run: shasum -a 256 Orch8Mobile.xcframework.zip orch8-mobile.aar > SHA256SUMS
-      - name: Create release when absent
-        id: release_check
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release view "${GITHUB_REF_NAME}"
-      - name: Create GitHub release
-        if: steps.release_check.outcome == 'failure'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release create "${GITHUB_REF_NAME}" --generate-notes --title "Orch8 ${GITHUB_REF_NAME}"
-      - name: Upload native packages
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${GITHUB_REF_NAME}" release/Orch8Mobile.xcframework.zip release/orch8-mobile.aar release/SHA256SUMS --clobber
+  # GitHub Release creation and native release assets are owned exclusively by
+  # release.yml. Keeping a second publisher here creates a race and can produce
+  # an incomplete or incorrectly classified prerelease. This workflow still
+  # publishes the versioned Android Maven package from the AAR job above.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,9 @@ jobs:
           mkdir "$DIR"
           cp "target/${TARGET}/release/orch8-server" "$DIR/"
           cp "target/${TARGET}/release/orch8" "$DIR/"
+          cp LICENSE "$DIR/"
           tar -czf "${DIR}.tar.gz" "$DIR"
+          tar -tzf "${DIR}.tar.gz" | grep -Fx "${DIR}/LICENSE"
           shasum -a 256 "${DIR}.tar.gz" > "${DIR}.tar.gz.sha256"
 
       - name: Upload artifacts
@@ -202,6 +204,7 @@ jobs:
           tar -xzf "artifacts/orch8-${TAG}-${{ matrix.target }}.tar.gz"
           cp "orch8-${TAG}-${{ matrix.target }}/orch8-server" docker-ctx/
           cp "orch8-${TAG}-${{ matrix.target }}/orch8" docker-ctx/
+          cp LICENSE docker-ctx/
           cp Dockerfile.release docker-ctx/Dockerfile
 
       - name: Log in to GHCR
@@ -238,6 +241,7 @@ jobs:
           IMAGE: ghcr.io/orch8-io/engine:${{ steps.version.outputs.tag }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
         run: |
           docker pull "$IMAGE"
+          docker run --rm --entrypoint test "$IMAGE" -f /usr/share/licenses/orch8/LICENSE
           # Mirrors the ci.yml docker-smoke job: default SQLite backend and
           # --insecure, since the smoke container has no API/encryption keys.
           docker run -d --name orch8-release-smoke \
@@ -478,11 +482,15 @@ jobs:
             -library build/liborch8_mobile-sim.a -headers build/headers \
             -output build/Orch8Mobile.xcframework
 
+          cp LICENSE build/Orch8Mobile.xcframework/LICENSE
+
       - name: Package XCFramework
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           cd build && zip -r "../Orch8Mobile-${TAG}.xcframework.zip" Orch8Mobile.xcframework
-          cd .. && shasum -a 256 "Orch8Mobile-${TAG}.xcframework.zip" > "Orch8Mobile-${TAG}.xcframework.zip.sha256"
+          cd ..
+          unzip -l "Orch8Mobile-${TAG}.xcframework.zip" | grep -F 'Orch8Mobile.xcframework/LICENSE'
+          shasum -a 256 "Orch8Mobile-${TAG}.xcframework.zip" > "Orch8Mobile-${TAG}.xcframework.zip.sha256"
 
       - name: Upload XCFramework archive
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -527,6 +535,9 @@ jobs:
           cp ../../artifacts/bindings/kotlin/io/orch8/mobile/orch8_mobile.kt orch8-mobile/src/main/java/io/orch8/mobile/
 
           gradle :orch8-mobile:assembleRelease
+          bash ../../scripts/embed-aar-license.sh \
+            orch8-mobile/build/outputs/aar/orch8-mobile-release.aar \
+            ../../LICENSE
 
       - name: Package AAR
         run: |
@@ -549,6 +560,8 @@ jobs:
     timeout-minutes: 10
     needs: [bindings]
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Download bindings
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -558,7 +571,9 @@ jobs:
       - name: Package
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
+          cp LICENSE bindings/LICENSE
           zip -r "orch8-bindings-${TAG}.zip" bindings/
+          unzip -l "orch8-bindings-${TAG}.zip" | grep -F 'bindings/LICENSE'
           shasum -a 256 "orch8-bindings-${TAG}.zip" > "orch8-bindings-${TAG}.zip.sha256"
 
       - name: Upload
@@ -616,20 +631,25 @@ jobs:
         env:
           INSTALL_DIR: ${{ runner.temp }}/orch8-bin
         run: |
+          installed=false
           mkdir -p "$INSTALL_DIR"
           for i in $(seq 1 12); do
-            if curl -sSL https://api.github.com/repos/orch8-io/engine/releases/latest 2>/dev/null \
-              | grep -q '"tag_name"'; then
+            if sh ./install.sh --dir "$INSTALL_DIR" --version "$GITHUB_REF_NAME"; then
+              installed=true
               break
             fi
-            echo "Waiting for release to propagate... (attempt $i/12)"
+            echo "Waiting for ${GITHUB_REF_NAME} assets to propagate... (attempt $i/12)"
             sleep 10
           done
-          sh ./install.sh --dir "$INSTALL_DIR"
+          if [[ "$installed" != "true" ]]; then
+            echo "::error::install.sh could not install ${GITHUB_REF_NAME} after 12 attempts."
+            exit 1
+          fi
 
       - name: Verify installed binaries
         env:
           INSTALL_DIR: ${{ runner.temp }}/orch8-bin
         run: |
-          "$INSTALL_DIR/orch8" --version
+          VERSION="${GITHUB_REF_NAME#v}"
+          "$INSTALL_DIR/orch8" --version | grep -F "$VERSION"
           "$INSTALL_DIR/orch8-server" --help | head -5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Release artifacts are installable and correctly licensed**: GNU binaries are built on Ubuntu 22.04 for compatibility with the Debian Bookworm release image, every distributed archive and container includes the BUSL-1.1 license, and the Android Maven metadata now declares the same license as the Rust workspace.
+
+- **Single-owner release publishing and exact-version smoke tests**: `release.yml` is the only workflow that creates GitHub Releases and uploads native assets, eliminating the competing mobile publisher. Final-release installer smoke tests now request the tag being released and verify the installed CLI reports that exact version instead of accidentally installing the previous latest release.
+
 - **Nondeterministic `{{ outputs.* }}` resolution for same-millisecond outputs**: `get_all_outputs` ordered by `created_at` only, so when two attempts of a block shared a timestamp (same-ms retry batches) the last-wins pick in `build_outputs_shape` was planner-dependent and could flip between runs. Both backends now tiebreak by `id` (UUIDv7 — time-ordered), matching the existing `get_outputs_page` convention, so the latest save deterministically wins.
 
 - **Crash-safe capsule redelivery**: capsule import now claims its `(tenant, capsule, destination runtime)` identity, creates the paused destination instance, and persists its checkpoint in one database transaction. Re-saving the same immutable manifest is idempotent while a capsule ID bound to different bytes fails closed; redelivery returns the original imported instance instead of creating duplicates, while encrypted-storage decorators preserve field encryption across the atomic path. PostgreSQL migration `060_capsule_import_idempotency.sql` and SQLite schema v26 add the durable import ledger; the encrypted capsule integration test now covers idempotent redelivery.

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,5 +1,7 @@
 FROM debian:bookworm-slim
 
+LABEL org.opencontainers.image.licenses="BUSL-1.1"
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/*
@@ -8,6 +10,7 @@ RUN groupadd --system orch8 && useradd --system --gid orch8 orch8
 
 COPY orch8-server /usr/local/bin/orch8-server
 COPY orch8 /usr/local/bin/orch8
+COPY LICENSE /usr/share/licenses/orch8/LICENSE
 
 ENV ORCH8_STORAGE_BACKEND=sqlite \
     ORCH8_DATABASE_URL=sqlite:///data/orch8.db \

--- a/docs/MOBILE_SDK.md
+++ b/docs/MOBILE_SDK.md
@@ -3,7 +3,7 @@
 Server-configurable workflows running on-device. Update onboarding flows, promotions, and feature journeys without app store deployments.
 
 This document describes the bindings generated from the current workspace
-(`0.7.0-dev`). Published Swift and Android artifacts may version independently.
+(`0.7.0-rc.2`). Published Swift and Android artifacts may version independently.
 Replace `<published-version>` below with a version that exists in your package
 repository; do not assume it matches the Rust workspace version.
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1787,7 +1787,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "orch8-engine"
-version = "0.7.0-dev"
+version = "0.7.0-rc.2"
 dependencies = [
  "base64",
  "bytes",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-publisher"
-version = "0.7.0-dev"
+version = "0.7.0-rc.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-storage"
-version = "0.7.0-dev"
+version = "0.7.0-rc.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-types"
-version = "0.7.0-dev"
+version = "0.7.0-rc.2"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/packages/android/orch8-mobile/build.gradle.kts
+++ b/packages/android/orch8-mobile/build.gradle.kts
@@ -64,8 +64,8 @@ afterEvaluate {
                     url.set("https://github.com/orch8-io/engine")
                     licenses {
                         license {
-                            name.set("Apache License 2.0")
-                            url.set("https://www.apache.org/licenses/LICENSE-2.0")
+                            name.set("Business Source License 1.1")
+                            url.set("https://github.com/orch8-io/engine/blob/main/LICENSE")
                         }
                     }
                 }

--- a/scripts/embed-aar-license.sh
+++ b/scripts/embed-aar-license.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Embed the repository license at the conventional AAR metadata path.
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 <aar-path> <license-path>" >&2
+    exit 2
+fi
+
+aar_path="$1"
+license_path="$2"
+
+[[ -f "$aar_path" ]] || { echo "AAR not found: $aar_path" >&2; exit 1; }
+[[ -f "$license_path" ]] || { echo "license not found: $license_path" >&2; exit 1; }
+
+license_dir="$(mktemp -d "${TMPDIR:-/tmp}/orch8-aar-license.XXXXXX")"
+trap 'rm -rf -- "$license_dir"' EXIT
+mkdir -p "$license_dir/META-INF"
+cp "$license_path" "$license_dir/META-INF/LICENSE"
+
+aar_dir="$(cd "$(dirname "$aar_path")" && pwd)"
+aar_path="${aar_dir}/$(basename "$aar_path")"
+(
+    cd "$license_dir"
+    zip -q "$aar_path" META-INF/LICENSE
+)
+unzip -Z1 "$aar_path" | grep -Fx 'META-INF/LICENSE'

--- a/scripts/test-review-fix-guards.sh
+++ b/scripts/test-review-fix-guards.sh
@@ -16,6 +16,14 @@ assert_contains() {
         || fail "$file is missing required guard: $pattern"
 }
 
+assert_not_contains() {
+    local file="$1"
+    local pattern="$2"
+    if grep -qF -- "$pattern" "$repo_root/$file"; then
+        fail "$file contains forbidden release behavior: $pattern"
+    fi
+}
+
 expect_failure() {
     local label="$1"
     shift
@@ -24,8 +32,32 @@ expect_failure() {
     fi
 }
 
+lock_package_version() {
+    local lockfile="$1"
+    local package="$2"
+    awk -v package="$package" '
+        /^\[\[package\]\]$/ { in_package = 0 }
+        $0 == "name = \"" package "\"" { in_package = 1; next }
+        in_package && /^version = "/ {
+            gsub(/^version = "|"$/, "")
+            print
+            exit
+        }
+    ' "$lockfile"
+}
+
 bash -n "$repo_root/scripts/check-migration-immutability.sh"
 bash -n "$repo_root/scripts/check-destructive-migrations.sh"
+bash -n "$repo_root/scripts/embed-aar-license.sh"
+
+workspace_version="$(awk -F'"' '/^\[workspace\.package\]/{f=1; next} /^\[/{f=0} f && /^version/{print $2; exit}' "$repo_root/Cargo.toml")"
+[[ -n "$workspace_version" ]] || fail "could not read the workspace version"
+for package in orch8-engine orch8-publisher orch8-storage orch8-types; do
+    fuzz_version="$(lock_package_version "$repo_root/fuzz/Cargo.lock" "$package")"
+    [[ "$fuzz_version" == "$workspace_version" ]] \
+        || fail "fuzz/Cargo.lock has ${package} ${fuzz_version}, expected ${workspace_version}"
+done
+assert_contains docs/MOBILE_SDK.md "(\`${workspace_version}\`)"
 
 # Exercise migration guards in an isolated tagged repository.
 fixture="$(mktemp -d "${TMPDIR:-/tmp}/orch8-migration-guards.XXXXXX")"
@@ -33,6 +65,17 @@ trap 'rm -rf -- "$fixture"' EXIT
 mkdir -p "$fixture/migrations" "$fixture/scripts"
 cp "$repo_root/scripts/check-migration-immutability.sh" "$fixture/scripts/"
 cp "$repo_root/scripts/check-destructive-migrations.sh" "$fixture/scripts/"
+
+# Prove the shipped AAR helper embeds the exact repository license bytes.
+cp "$repo_root/LICENSE" "$fixture/aar-payload"
+(
+    cd "$fixture"
+    zip -q sample.aar aar-payload
+)
+"$repo_root/scripts/embed-aar-license.sh" "$fixture/sample.aar" "$repo_root/LICENSE" > /dev/null
+unzip -p "$fixture/sample.aar" META-INF/LICENSE | cmp -s - "$repo_root/LICENSE" \
+    || fail "AAR license contents do not match LICENSE"
+
 (
     cd "$fixture"
     git init -q
@@ -90,10 +133,26 @@ assert_contains .github/workflows/release.yml "prerelease: \${{ contains(github.
 assert_contains .github/workflows/release.yml "if: \${{ !contains(github.ref_name, '-') }}"
 assert_contains .github/workflows/release.yml 'Verify Cloud management surface'
 assert_contains .github/workflows/release.yml 'os: ubuntu-22.04'
+assert_contains .github/workflows/release.yml 'sh ./install.sh --dir "$INSTALL_DIR" --version "$GITHUB_REF_NAME"'
+assert_contains .github/workflows/release.yml 'cp LICENSE "$DIR/"'
+assert_contains .github/workflows/release.yml 'cp LICENSE docker-ctx/'
+assert_contains .github/workflows/release.yml 'test "$IMAGE" -f /usr/share/licenses/orch8/LICENSE'
+assert_contains .github/workflows/release.yml 'cp LICENSE build/Orch8Mobile.xcframework/LICENSE'
+assert_contains .github/workflows/release.yml 'bash ../../scripts/embed-aar-license.sh'
+assert_contains .github/workflows/release.yml 'cp LICENSE bindings/LICENSE'
+assert_contains .github/workflows/mobile.yml 'cp LICENSE build/Orch8Mobile.xcframework/LICENSE'
+assert_contains .github/workflows/mobile.yml 'bash ../../scripts/embed-aar-license.sh'
+assert_not_contains .github/workflows/mobile.yml 'gh release create'
+assert_not_contains .github/workflows/mobile.yml 'gh release upload'
+assert_contains packages/android/orch8-mobile/build.gradle.kts 'name.set("Business Source License 1.1")'
+assert_not_contains packages/android/orch8-mobile/build.gradle.kts 'Apache License 2.0'
 assert_contains .github/workflows/ci.yml 'Verify Cloud management surface'
 assert_contains .github/workflows/ci.yml 'sqlite-smoke:'
 assert_contains .github/workflows/ci.yml 'fuzz-smoke:'
 assert_contains .github/workflows/ci.yml 'mobile-sync-smoke:'
 assert_contains Dockerfile.release "addr=\\\"\${ORCH8_HTTP_ADDR:-127.0.0.1:8080}\\\""
+assert_contains Dockerfile.release 'COPY LICENSE /usr/share/licenses/orch8/LICENSE'
+assert_contains Dockerfile.release 'LABEL org.opencontainers.image.licenses="BUSL-1.1"'
+assert_contains scripts/embed-aar-license.sh "unzip -Z1 \"\$aar_path\" | grep -Fx 'META-INF/LICENSE'"
 
 echo "OK: release and migration review-fix guards passed."


### PR DESCRIPTION
## What changed

- make `release.yml` the single owner of GitHub Release creation and native asset uploads
- install and verify the exact tagged version in final-release smoke tests
- embed the BUSL-1.1 license in binary archives, Docker images, XCFrameworks, AARs, and generated bindings archives
- correct Android Maven license metadata
- synchronize mobile/fuzz release metadata and add regression guards

## Why

The `v0.7.0-rc.1` release failed because GNU binaries required a newer glibc than the Bookworm release image and the mobile workflow raced the primary release publisher without a repository checkout. Release artifacts also did not consistently carry the repository license.

## Validation

- `actionlint` on CI, mobile, and release workflows
- ShellCheck at warning severity
- `cargo fmt --check`
- locked workspace and fuzz metadata
- `cargo check --locked --workspace`
- migration immutability and destructive-DDL guards
- release regression guard suite
- byte-for-byte AAR license test
- simulated binary tar, XCFramework, and bindings packaging
