### PR TITLE
fix(release): support Ubuntu 22.04 protoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Ubuntu 22.04 release builds support proto3 optional fields**: protobuf generation now passes the compatibility flag required by the runner's protoc 3.12 while remaining valid with newer compilers, so glibc-compatible GNU release artifacts can be built successfully.
+
 - **Release artifacts are installable and correctly licensed**: GNU binaries are built on Ubuntu 22.04 for compatibility with the Debian Bookworm release image, every distributed archive and container includes the BUSL-1.1 license, and the Android Maven metadata now declares the same license as the Rust workspace.
 
 - **Single-owner release publishing and exact-version smoke tests**: `release.yml` is the only workflow that creates GitHub Releases and uploads native assets, eliminating the competing mobile publisher. Final-release installer smoke tests now request the tag being released and verify the installed CLI reports that exact version instead of accidentally installing the previous latest release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "orch8"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 dependencies = [
  "axum",
  "chrono",
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-api"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 dependencies = [
  "axum",
  "base64",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-cli"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-engine"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 dependencies = [
  "async-nats",
  "base64",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-grpc"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3113,7 +3113,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-mobile"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 dependencies = [
  "base64",
  "chrono",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-publisher"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-push"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-server"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-storage"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-types"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 edition = "2024"
 rust-version = "1.97"
 license = "BUSL-1.1"

--- a/docs/MOBILE_SDK.md
+++ b/docs/MOBILE_SDK.md
@@ -3,7 +3,7 @@
 Server-configurable workflows running on-device. Update onboarding flows, promotions, and feature journeys without app store deployments.
 
 This document describes the bindings generated from the current workspace
-(`0.7.0-rc.2`). Published Swift and Android artifacts may version independently.
+(`0.7.0-rc.3`). Published Swift and Android artifacts may version independently.
 Replace `<published-version>` below with a version that exists in your package
 repository; do not assume it matches the Rust workspace version.
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -548,6 +548,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,6 +1438,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "base64",
+ "getrandom 0.2.17",
+ "js-sys",
+ "pem",
+ "serde",
+ "serde_json",
+ "signature",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,6 +1710,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,7 +1816,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "orch8-engine"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 dependencies = [
  "base64",
  "bytes",
@@ -1832,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-publisher"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -1853,8 +1882,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "orch8-push"
+version = "0.7.0-rc.3"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "ed25519-dalek",
+ "hex",
+ "jsonwebtoken",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "urlencoding",
+ "uuid",
+ "zeroize",
+]
+
+[[package]]
 name = "orch8-storage"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1862,11 +1913,13 @@ dependencies = [
  "futures",
  "moka",
  "object_store",
+ "orch8-push",
  "orch8-types",
  "rand 0.9.5",
  "serde",
  "serde_json",
  "sqlx",
+ "thiserror",
  "tokio",
  "tracing",
  "uuid",
@@ -1874,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-types"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -1925,6 +1978,16 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -2067,6 +2130,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2725,6 +2794,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3074,6 +3155,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3359,6 +3470,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -3908,6 +4025,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/orch8-grpc/build.rs
+++ b/orch8-grpc/build.rs
@@ -2,6 +2,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_prost_build::configure()
         .build_server(true)
         .build_client(true)
+        // Ubuntu 22.04 ships protoc 3.12, where proto3 optional fields still
+        // require the compatibility flag. Newer protoc versions accept it too.
+        .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(&["../proto/orch8.proto"], &["../proto"])?;
     Ok(())
 }

--- a/scripts/test-review-fix-guards.sh
+++ b/scripts/test-review-fix-guards.sh
@@ -133,6 +133,7 @@ assert_contains .github/workflows/release.yml "prerelease: \${{ contains(github.
 assert_contains .github/workflows/release.yml "if: \${{ !contains(github.ref_name, '-') }}"
 assert_contains .github/workflows/release.yml 'Verify Cloud management surface'
 assert_contains .github/workflows/release.yml 'os: ubuntu-22.04'
+assert_contains orch8-grpc/build.rs '.protoc_arg("--experimental_allow_proto3_optional")'
 assert_contains .github/workflows/release.yml 'sh ./install.sh --dir "$INSTALL_DIR" --version "$GITHUB_REF_NAME"'
 assert_contains .github/workflows/release.yml 'cp LICENSE "$DIR/"'
 assert_contains .github/workflows/release.yml 'cp LICENSE docker-ctx/'


### PR DESCRIPTION
## Summary
- pass the proto3 optional compatibility flag required by Ubuntu 22.04's protoc 3.12
- bump the replacement release candidate to v0.7.0-rc.3 and refresh lockfiles/docs
- guard the required protobuf option in release regression tests

## Root cause
v0.7.0-rc.2 fixed GNU glibc compatibility by building on Ubuntu 22.04, but that runner's protoc rejected proto3 optional fields without the compatibility flag. The failed candidate produced no GitHub Release or container manifest, and its mobile publication run was cancelled.

## Validation
- cargo fmt --all -- --check
- cargo metadata --locked --format-version 1
- cargo metadata --locked --offline --manifest-path fuzz/Cargo.toml --format-version 1
- bash scripts/test-review-fix-guards.sh
- cargo test -p orch8-grpc (254 passed)