### PR TITLE
fix(release): compose provenance image indexes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,6 +293,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
       - name: Extract version
         id: version
         run: echo "tag=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
@@ -300,20 +303,18 @@ jobs:
       - name: Create and push multi-arch manifest
         run: |
           TAG="${{ steps.version.outputs.tag }}"
-          docker manifest create "ghcr.io/orch8-io/engine:${TAG}" \
+          docker buildx imagetools create --tag "ghcr.io/orch8-io/engine:${TAG}" \
             "ghcr.io/orch8-io/engine:${TAG}-amd64" \
             "ghcr.io/orch8-io/engine:${TAG}-arm64"
-          docker manifest push "ghcr.io/orch8-io/engine:${TAG}"
 
           # Prerelease tags (anything with a '-', e.g. 0.7.0-rc.1) publish
           # their own manifest but must not move `latest`.
           if [[ "$TAG" == *-* ]]; then
             echo "Prerelease tag ${TAG} — skipping the latest manifest."
           else
-            docker manifest create "ghcr.io/orch8-io/engine:latest" \
+            docker buildx imagetools create --tag "ghcr.io/orch8-io/engine:latest" \
               "ghcr.io/orch8-io/engine:${TAG}-amd64" \
               "ghcr.io/orch8-io/engine:${TAG}-arm64"
-            docker manifest push "ghcr.io/orch8-io/engine:latest"
           fi
 
   # -- iOS builds (3 targets) -----------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Cross-architecture container smoke tests run the image they built**: release validation now passes the matrix platform explicitly when pulling and running per-architecture images, allowing ARM64 images to execute through QEMU on AMD64 GitHub runners before the multi-architecture manifest is published.
 
+- **Provenance-enabled container indexes compose correctly**: release aggregation now uses Buildx imagetools, which accepts the OCI indexes emitted for provenance-enabled per-platform images, so the versioned multi-architecture image can be published after both platform smoke tests pass.
+
 - **Ubuntu 22.04 release builds support proto3 optional fields**: protobuf generation now passes the compatibility flag required by the runner's protoc 3.12 while remaining valid with newer compilers, so glibc-compatible GNU release artifacts can be built successfully.
 
 - **Release artifacts are installable and correctly licensed**: GNU binaries are built on Ubuntu 22.04 for compatibility with the Debian Bookworm release image, every distributed archive and container includes the BUSL-1.1 license, and the Android Maven metadata now declares the same license as the Rust workspace.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "orch8"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "axum",
  "chrono",
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-api"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "axum",
  "base64",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-cli"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-engine"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "async-nats",
  "base64",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-grpc"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3113,7 +3113,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-mobile"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "base64",
  "chrono",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-publisher"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-push"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-server"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-storage"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-types"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 edition = "2024"
 rust-version = "1.97"
 license = "BUSL-1.1"

--- a/docs/MOBILE_SDK.md
+++ b/docs/MOBILE_SDK.md
@@ -3,7 +3,7 @@
 Server-configurable workflows running on-device. Update onboarding flows, promotions, and feature journeys without app store deployments.
 
 This document describes the bindings generated from the current workspace
-(`0.7.0-rc.4`). Published Swift and Android artifacts may version independently.
+(`0.7.0-rc.5`). Published Swift and Android artifacts may version independently.
 Replace `<published-version>` below with a version that exists in your package
 repository; do not assume it matches the Rust workspace version.
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1816,7 +1816,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "orch8-engine"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "base64",
  "bytes",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-publisher"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -1883,7 +1883,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-push"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -1905,7 +1905,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-storage"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-types"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/scripts/test-review-fix-guards.sh
+++ b/scripts/test-review-fix-guards.sh
@@ -24,6 +24,16 @@ assert_not_contains() {
     fi
 }
 
+assert_count() {
+    local file="$1"
+    local pattern="$2"
+    local expected="$3"
+    local actual
+    actual="$(awk -v pattern="$pattern" 'index($0, pattern) { count++ } END { print count + 0 }' "$repo_root/$file")"
+    [[ "$actual" == "$expected" ]] \
+        || fail "$file contains $actual occurrences of $pattern, expected $expected"
+}
+
 expect_failure() {
     local label="$1"
     shift
@@ -141,6 +151,9 @@ assert_contains .github/workflows/release.yml 'test "$IMAGE" -f /usr/share/licen
 assert_contains .github/workflows/release.yml 'docker pull --platform "$PLATFORM" "$IMAGE"'
 assert_contains .github/workflows/release.yml 'docker run --platform "$PLATFORM" --rm --entrypoint test'
 assert_contains .github/workflows/release.yml 'docker run --platform "$PLATFORM" -d --name orch8-release-smoke'
+assert_contains .github/workflows/release.yml 'docker buildx imagetools create --tag "ghcr.io/orch8-io/engine:${TAG}"'
+assert_not_contains .github/workflows/release.yml 'docker manifest create'
+assert_count .github/workflows/release.yml 'docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2' 2
 assert_contains .github/workflows/release.yml 'cp LICENSE build/Orch8Mobile.xcframework/LICENSE'
 assert_contains .github/workflows/release.yml 'bash ../../scripts/embed-aar-license.sh'
 assert_contains .github/workflows/release.yml 'cp LICENSE bindings/LICENSE'


### PR DESCRIPTION
## Summary
- compose provenance-enabled per-platform OCI indexes with Buildx imagetools
- explicitly set up pinned Buildx in the manifest job
- add regression guards and advance the immutable candidate to 0.7.0-rc.5

## Root cause
The rc.4 arm64 and amd64 image builds and smoke tests passed, but legacy docker manifest create rejected each provenance-enabled source tag because it is itself an OCI manifest list.

## Validation
- cargo check -p orch8-grpc
- cargo fmt --all -- --check
- cargo metadata --locked (workspace and fuzz)
- bash scripts/test-review-fix-guards.sh
- actionlint
- git diff --check