### PR TITLE
fix(ci): allow cold fuzz smoke builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,9 @@ jobs:
   fuzz-smoke:
     name: Fuzz Smoke (${{ matrix.target }})
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # A cold cargo-fuzz compile can exceed 10 minutes before the bounded
+    # 60-second fuzz pass begins.
+    timeout-minutes: 20
     needs: [check]
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Provenance-enabled container indexes compose correctly**: release aggregation now uses Buildx imagetools, which accepts the OCI indexes emitted for provenance-enabled per-platform images, so the versioned multi-architecture image can be published after both platform smoke tests pass.
 
+- **Cold fuzz-smoke builds have sufficient CI headroom**: the fuzz matrix keeps its bounded 60-second execution window but allows enough job time for an uncached cargo-fuzz compile, avoiding infrastructure cancellations just before a release tag.
+
 - **Ubuntu 22.04 release builds support proto3 optional fields**: protobuf generation now passes the compatibility flag required by the runner's protoc 3.12 while remaining valid with newer compilers, so glibc-compatible GNU release artifacts can be built successfully.
 
 - **Release artifacts are installable and correctly licensed**: GNU binaries are built on Ubuntu 22.04 for compatibility with the Debian Bookworm release image, every distributed archive and container includes the BUSL-1.1 license, and the Android Maven metadata now declares the same license as the Rust workspace.

--- a/scripts/test-review-fix-guards.sh
+++ b/scripts/test-review-fix-guards.sh
@@ -62,6 +62,8 @@ bash -n "$repo_root/scripts/embed-aar-license.sh"
 
 workspace_version="$(awk -F'"' '/^\[workspace\.package\]/{f=1; next} /^\[/{f=0} f && /^version/{print $2; exit}' "$repo_root/Cargo.toml")"
 [[ -n "$workspace_version" ]] || fail "could not read the workspace version"
+fuzz_timeout="$(awk '/^  fuzz-smoke:/{f=1; next} f && /timeout-minutes:/{print $2; exit}' "$repo_root/.github/workflows/ci.yml")"
+[[ "$fuzz_timeout" == "20" ]] || fail "fuzz smoke timeout is $fuzz_timeout minutes, expected 20"
 for package in orch8-engine orch8-publisher orch8-storage orch8-types; do
     fuzz_version="$(lock_package_version "$repo_root/fuzz/Cargo.lock" "$package")"
     [[ "$fuzz_version" == "$workspace_version" ]] \


### PR DESCRIPTION
## Summary
- raise fuzz-smoke job timeout from 10 to 20 minutes
- keep each actual fuzz pass bounded to 60 seconds
- add a release guard for the timeout and document the hardening

## Evidence
Exact-main rc.5 CI job Fuzz Smoke (template) was canceled at 10m09s while the fuzz command was compiling/running. The sibling target and all completed gates passed.

## Validation
- bash scripts/test-review-fix-guards.sh
- bash -n scripts/test-review-fix-guards.sh
- actionlint
- cargo fmt --all -- --check
- git diff --check