### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API

### DIFF
--- a/orch8-api/src/workers.rs
+++ b/orch8-api/src/workers.rs
@@ -62,9 +62,11 @@ pub(crate) struct ListPinsQuery {
 )]
 pub(crate) async fn set_version_pin(
     State(state): State<AppState>,
+    admin: OptionalAdmin,
     tenant_ctx: crate::auth::OptionalTenant,
     Json(req): Json<SetVersionPinRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
+    crate::api_keys::require_admin(&admin)?;
     let tenant_id = crate::auth::enforce_tenant_create(
         &tenant_ctx,
         &orch8_types::ids::TenantId::unchecked(req.tenant_id),
@@ -97,9 +99,11 @@ pub(crate) async fn set_version_pin(
 )]
 pub(crate) async fn list_version_pins(
     State(state): State<AppState>,
+    admin: OptionalAdmin,
     tenant_ctx: crate::auth::OptionalTenant,
     Query(q): Query<ListPinsQuery>,
 ) -> Result<impl IntoResponse, ApiError> {
+    crate::api_keys::require_admin(&admin)?;
     let scoped = crate::auth::scoped_tenant_id(&tenant_ctx, q.tenant_id.as_deref());
     let pins = state
         .storage
@@ -119,9 +123,11 @@ pub(crate) async fn list_version_pins(
 )]
 pub(crate) async fn delete_version_pin(
     State(state): State<AppState>,
+    admin: OptionalAdmin,
     tenant_ctx: crate::auth::OptionalTenant,
     Path((tenant_id, handler_name)): Path<(String, String)>,
 ) -> Result<impl IntoResponse, ApiError> {
+    crate::api_keys::require_admin(&admin)?;
     crate::auth::enforce_tenant_access(
         &tenant_ctx,
         &orch8_types::ids::TenantId::unchecked(&tenant_id),


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Authorization bypass. The `set_version_pin`, `list_version_pins`, and `delete_version_pin` endpoints in `orch8-api/src/workers.rs` were missing the `admin: OptionalAdmin` parameter and the `crate::api_keys::require_admin(&admin)?;` check, allowing any authenticated user to manage worker version pins instead of restricting it to admin users as intended.
🎯 Impact: An attacker could bypass authorization and manage worker version pins, potentially leading to denial of service or execution of outdated worker code by pinning to older versions.
🔧 Fix: Added `admin: OptionalAdmin` to the function signatures and `crate::api_keys::require_admin(&admin)?;` to the function bodies of `set_version_pin`, `list_version_pins`, and `delete_version_pin`.
✅ Verification: Ran `cargo +nightly test -p orch8-api` and `cargo +nightly test --test workers` to ensure the API still functions as expected.

---
*PR created automatically by Jules for task [13401782701069735663](https://jules.google.com/task/13401782701069735663) started by @ovasylenko*