### PR TITLE
chore: align SDK releases with v0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
         run: ./scripts/check-destructive-migrations.sh
       - name: Review-fix guard regression tests
         run: ./scripts/test-review-fix-guards.sh
+      - name: SDK version alignment
+        run: ./scripts/check-sdk-versions.sh
       - name: Expanded test counts
         run: bash ./scripts/check-expanded-test-counts.sh
       - name: Check

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -9,6 +9,8 @@ on:
       - "orch8-engine/**"
       - "orch8-storage/**"
       - "orch8-types/**"
+      - "packages/**"
+      - "scripts/check-sdk-versions.sh"
       - ".github/workflows/mobile.yml"
   pull_request:
     branches: [main]
@@ -17,6 +19,8 @@ on:
       - "orch8-engine/**"
       - "orch8-storage/**"
       - "orch8-types/**"
+      - "packages/**"
+      - "scripts/check-sdk-versions.sh"
       - ".github/workflows/mobile.yml"
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ jobs:
           fi
           echo "Tag ${TAG} matches workspace version ${CRATE_VERSION}."
 
+      - name: SDK versions match workspace version
+        run: ./scripts/check-sdk-versions.sh
+
       - name: CI is green on the tagged SHA
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/android/gradle.properties
+++ b/packages/android/gradle.properties
@@ -1,0 +1,1 @@
+VERSION_NAME=0.7.0

--- a/packages/flutter/android/build.gradle.kts
+++ b/packages/flutter/android/build.gradle.kts
@@ -22,5 +22,5 @@ android {
 }
 
 dependencies {
-    implementation("io.orch8:orch8-mobile:0.1.0")
+    implementation("io.orch8:orch8-mobile:0.7.0")
 }

--- a/packages/flutter/android/src/main/kotlin/io/orch8/flutter/Orch8FlutterPlugin.kt
+++ b/packages/flutter/android/src/main/kotlin/io/orch8/flutter/Orch8FlutterPlugin.kt
@@ -67,7 +67,7 @@ class Orch8FlutterPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, Event
                 telemetryEnabled = args["telemetryEnabled"] as? Boolean ?: true,
                 environment = args["environment"] as? String ?: "production",
                 rootPublicKey = args["rootPublicKey"] as? String ?: "",
-                sdkVersion = args["sdkVersion"] as? String ?: "0.1.0",
+                sdkVersion = args["sdkVersion"] as? String ?: "0.7.0",
             )
 
             engine = MobileEngine(dbPath, cfg)

--- a/packages/flutter/ios/Classes/Orch8FlutterPlugin.swift
+++ b/packages/flutter/ios/Classes/Orch8FlutterPlugin.swift
@@ -59,7 +59,7 @@ public class Orch8FlutterPlugin: NSObject, FlutterPlugin {
             telemetryEnabled: args["telemetryEnabled"] as? Bool ?? true,
             environment: args["environment"] as? String ?? "production",
             rootPublicKey: args["rootPublicKey"] as? String ?? "",
-            sdkVersion: args["sdkVersion"] as? String ?? "0.1.0"
+            sdkVersion: args["sdkVersion"] as? String ?? "0.7.0"
         )
 
         do {

--- a/packages/flutter/ios/orch8_flutter.podspec
+++ b/packages/flutter/ios/orch8_flutter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'orch8_flutter'
-  s.version          = '0.1.0'
+  s.version          = '0.7.0'
   s.summary          = 'Flutter plugin for the Orch8 Mobile SDK'
   s.homepage         = 'https://github.com/orch8-io/orch8-flutter'
   s.license          = { :type => 'MIT' }

--- a/packages/flutter/lib/orch8_flutter.dart
+++ b/packages/flutter/lib/orch8_flutter.dart
@@ -36,7 +36,7 @@ class Orch8Config {
     this.telemetryEnabled = true,
     this.environment = 'production',
     this.rootPublicKey = '',
-    this.sdkVersion = '0.1.0',
+    this.sdkVersion = '0.7.0',
   });
 
   Map<String, dynamic> toMap() => {

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: orch8_flutter
 description: Flutter plugin for the Orch8 Mobile SDK — server-configurable on-device workflows.
-version: 0.1.0
+version: 0.7.0
 homepage: https://github.com/orch8-io/orch8-flutter
 
 environment:

--- a/packages/react-native/android/src/main/java/io/orch8/reactnative/Orch8Module.kt
+++ b/packages/react-native/android/src/main/java/io/orch8/reactnative/Orch8Module.kt
@@ -31,7 +31,7 @@ class Orch8Module(reactContext: ReactApplicationContext) :
                 telemetryEnabled = if (config.hasKey("telemetryEnabled")) config.getBoolean("telemetryEnabled") else true,
                 environment = config.getString("environment") ?: "production",
                 rootPublicKey = config.getString("rootPublicKey") ?: "",
-                sdkVersion = config.getString("sdkVersion") ?: "0.1.0",
+                sdkVersion = config.getString("sdkVersion") ?: "0.7.0",
             )
 
             engine = MobileEngine(dbPath, cfg)

--- a/packages/react-native/ios/Orch8Module.swift
+++ b/packages/react-native/ios/Orch8Module.swift
@@ -42,7 +42,7 @@ class Orch8Module: RCTEventEmitter {
             telemetryEnabled: config["telemetryEnabled"] as? Bool ?? true,
             environment: config["environment"] as? String ?? "production",
             rootPublicKey: config["rootPublicKey"] as? String ?? "",
-            sdkVersion: config["sdkVersion"] as? String ?? "0.1.0"
+            sdkVersion: config["sdkVersion"] as? String ?? "0.7.0"
         )
 
         do {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-orch8",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "description": "React Native bridge for the Orch8 Mobile SDK",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/swift/Sources/Orch8Mobile/Orch8Mobile.swift
+++ b/packages/swift/Sources/Orch8Mobile/Orch8Mobile.swift
@@ -4,3 +4,6 @@
 // provides a namespace for any convenience extensions.
 
 @_exported import Orch8MobileFFI
+
+/// Version of the Orch8 engine embedded in this SDK release.
+public let orch8MobileVersion = "0.7.0"

--- a/scripts/check-sdk-versions.sh
+++ b/scripts/check-sdk-versions.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+workspace_version="$(awk -F'"' '/^\[workspace\.package\]/{found=1; next} /^\[/{found=0} found && /^version = /{print $2; exit}' Cargo.toml)"
+if [[ -z "$workspace_version" ]]; then
+  echo "Could not read [workspace.package] version from Cargo.toml." >&2
+  exit 1
+fi
+
+version_checks=(
+  "packages/android/gradle.properties|VERSION_NAME=$workspace_version"
+  "packages/flutter/android/build.gradle.kts|implementation(\"io.orch8:orch8-mobile:$workspace_version\")"
+  "packages/flutter/android/src/main/kotlin/io/orch8/flutter/Orch8FlutterPlugin.kt|?: \"$workspace_version\""
+  "packages/flutter/ios/Classes/Orch8FlutterPlugin.swift|?? \"$workspace_version\""
+  "packages/flutter/ios/orch8_flutter.podspec|s.version          = '$workspace_version'"
+  "packages/flutter/lib/orch8_flutter.dart|this.sdkVersion = '$workspace_version'"
+  "packages/flutter/pubspec.yaml|version: $workspace_version"
+  "packages/react-native/android/src/main/java/io/orch8/reactnative/Orch8Module.kt|?: \"$workspace_version\""
+  "packages/react-native/ios/Orch8Module.swift|?? \"$workspace_version\""
+  "packages/react-native/package.json|\"version\": \"$workspace_version\""
+  "packages/swift/Sources/Orch8Mobile/Orch8Mobile.swift|orch8MobileVersion = \"$workspace_version\""
+)
+
+failed=0
+for check in "${version_checks[@]}"; do
+  file="${check%%|*}"
+  expected="${check#*|}"
+  if ! grep -Fq "$expected" "$file"; then
+    echo "SDK version drift: $file does not declare workspace version $workspace_version." >&2
+    failed=1
+  fi
+done
+
+if (( failed != 0 )); then
+  exit 1
+fi
+
+echo "All SDKs match workspace version $workspace_version."


### PR DESCRIPTION
## What changed

- align Android, Swift, Flutter, and React Native SDK-reported versions with engine `0.7.0`
- point the Flutter Android bridge at `io.orch8:orch8-mobile:0.7.0`
- add a CI/release guard that rejects SDK/workspace version drift
- make mobile CI react to package and version-check changes

## Why

The engine and native mobile artifacts were released as `v0.7.0`, while Flutter and React Native metadata and runtime telemetry defaults still reported `0.1.0`.

## Impact

SDK metadata and telemetry now consistently identify `0.7.0`. Future engine tags cannot publish when the SDK declarations are out of sync.

## Validation

- `./scripts/check-sdk-versions.sh`
- `bash -n scripts/check-sdk-versions.sh`
- `git diff --check`
- `npm pack --dry-run --json ./packages/react-native`
- Ruby syntax checks for both podspecs
- Swift parse check for the Swift wrapper

## Release note

The existing `v0.7.0` Android AAR, XCFramework, and generated bindings are already live. Flutter/npm/pub.dev publication remains intentionally blocked until the standalone native package repositories/dependencies exist; publishing the current wrappers to those registries would produce packages whose native dependencies cannot be resolved.
