### PR TITLE
fix(mobile): repair installable Apple artifacts

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,8 @@
 [target.aarch64-apple-ios]
-rustflags = ["-C", "link-arg=-mios-version-min=15.0"]
+rustflags = ["-C", "link-arg=-mios-version-min=16.0"]
 
 [target.aarch64-apple-ios-sim]
-rustflags = ["-C", "link-arg=-mios-simulator-version-min=15.0"]
+rustflags = ["-C", "link-arg=-mios-simulator-version-min=16.0"]
 
 [target.x86_64-apple-ios]
-rustflags = ["-C", "link-arg=-mios-simulator-version-min=15.0"]
+rustflags = ["-C", "link-arg=-mios-simulator-version-min=16.0"]

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -188,17 +188,19 @@ jobs:
           cp artifacts/bindings/swift/Orch8MobileFFI.h build/headers/
           cp artifacts/bindings/swift/Orch8MobileFFI.modulemap build/headers/module.modulemap
 
+          mkdir -p build/ios-simulator
           lipo -create \
             build/ios-sim-arm64/liborch8_mobile.a \
             build/ios-sim-x64/liborch8_mobile.a \
-            -output build/liborch8_mobile-sim.a
+            -output build/ios-simulator/liborch8_mobile.a
 
           xcodebuild -create-xcframework \
             -library build/ios-device/liborch8_mobile.a -headers build/headers \
-            -library build/liborch8_mobile-sim.a -headers build/headers \
+            -library build/ios-simulator/liborch8_mobile.a -headers build/headers \
             -output build/Orch8Mobile.xcframework
 
           cp LICENSE build/Orch8Mobile.xcframework/LICENSE
+          ./scripts/check-xcframework.sh build/Orch8Mobile.xcframework
 
       - name: Upload XCFramework
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           fi
           echo "Tag ${TAG} matches workspace version ${CRATE_VERSION}."
 
-      - name: SDK versions match workspace version
+      - name: SDK versions are internally consistent
         run: ./scripts/check-sdk-versions.sh
 
       - name: CI is green on the tagged SHA
@@ -477,17 +477,19 @@ jobs:
           cp artifacts/bindings/swift/Orch8MobileFFI.h build/headers/
           cp artifacts/bindings/swift/Orch8MobileFFI.modulemap build/headers/module.modulemap
 
+          mkdir -p build/ios-simulator
           lipo -create \
             build/ios-sim-arm64/liborch8_mobile.a \
             build/ios-sim-x64/liborch8_mobile.a \
-            -output build/liborch8_mobile-sim.a
+            -output build/ios-simulator/liborch8_mobile.a
 
           xcodebuild -create-xcframework \
             -library build/ios-device/liborch8_mobile.a -headers build/headers \
-            -library build/liborch8_mobile-sim.a -headers build/headers \
+            -library build/ios-simulator/liborch8_mobile.a -headers build/headers \
             -output build/Orch8Mobile.xcframework
 
           cp LICENSE build/Orch8Mobile.xcframework/LICENSE
+          ./scripts/check-xcframework.sh build/Orch8Mobile.xcframework
 
       - name: Package XCFramework
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] — 2026-07-30
+
+### Fixed
+
+- **Installable Apple mobile artifacts**: XCFramework device and simulator
+  slices now share the `liborch8_mobile.a` basename required by CocoaPods.
+  Release and mobile CI validate slice names and Mach-O deployment metadata,
+  and all Apple packages consistently require iOS 16 rather than advertising
+  an unsupported iOS 15 target or unnecessarily restricting consumers to iOS
+  26.
+
 ## [0.7.0] — 2026-07-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "orch8"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "axum",
  "chrono",
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-api"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "axum",
  "base64",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-engine"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-nats",
  "base64",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-grpc"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3113,7 +3113,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-mobile"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64",
  "chrono",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-publisher"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-push"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-server"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-storage"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-types"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 rust-version = "1.97"
 license = "BUSL-1.1"

--- a/docs/MOBILE_SDK.md
+++ b/docs/MOBILE_SDK.md
@@ -3,7 +3,7 @@
 Server-configurable workflows running on-device. Update onboarding flows, promotions, and feature journeys without app store deployments.
 
 This document describes the bindings generated from the current workspace
-(`0.7.0`). Published Swift and Android artifacts may version independently.
+(`0.7.1`). Published Swift and Android artifacts may version independently.
 Replace `<published-version>` below with a version that exists in your package
 repository; do not assume it matches the Rust workspace version.
 
@@ -49,7 +49,7 @@ Or use the local path during development:
 .package(path: "../packages/swift")
 ```
 
-**Requirements:** iOS 15+, Xcode 15+.
+**Requirements:** iOS 16+, Xcode 16+.
 
 ### Android (Gradle)
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1816,7 +1816,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "orch8-engine"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64",
  "bytes",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-publisher"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -1883,7 +1883,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-push"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -1905,7 +1905,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-storage"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "orch8-types"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 PROFILE="debug"
 CARGO_FLAGS=""
+export IPHONEOS_DEPLOYMENT_TARGET="16.0"
 if [[ "${1:-}" == "--release" ]]; then
     PROFILE="mobile-release"
     CARGO_FLAGS="--profile mobile-release"
@@ -17,7 +18,7 @@ fi
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BUILD="${ROOT}/target/xcframework-build"
 rm -rf "${BUILD}"
-mkdir -p "${BUILD}/headers"
+mkdir -p "${BUILD}/headers" "${BUILD}/simulator"
 
 echo "==> Building iOS targets (${PROFILE})…"
 for TARGET in aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios; do
@@ -41,7 +42,7 @@ echo "==> Creating fat simulator library…"
 lipo -create \
     "target/aarch64-apple-ios-sim/${PROFILE}/liborch8_mobile.a" \
     "target/x86_64-apple-ios/${PROFILE}/liborch8_mobile.a" \
-    -output "${BUILD}/liborch8_mobile-sim.a"
+    -output "${BUILD}/simulator/liborch8_mobile.a"
 
 # Rename modulemap for Xcode compatibility.
 cp "${BUILD}/headers/Orch8MobileFFI.modulemap" "${BUILD}/headers/module.modulemap"
@@ -51,9 +52,11 @@ rm -rf "${ROOT}/packages/swift/Orch8Mobile.xcframework"
 xcodebuild -create-xcframework \
     -library "target/aarch64-apple-ios/${PROFILE}/liborch8_mobile.a" \
     -headers "${BUILD}/headers" \
-    -library "${BUILD}/liborch8_mobile-sim.a" \
+    -library "${BUILD}/simulator/liborch8_mobile.a" \
     -headers "${BUILD}/headers" \
     -output "${ROOT}/packages/swift/Orch8Mobile.xcframework"
+
+"${ROOT}/scripts/check-xcframework.sh" "${ROOT}/packages/swift/Orch8Mobile.xcframework"
 
 # Copy generated Swift source alongside the package.
 cp "${BUILD}/headers/Orch8Mobile.swift" \

--- a/scripts/check-sdk-versions.sh
+++ b/scripts/check-sdk-versions.sh
@@ -4,24 +4,28 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-workspace_version="$(awk -F'"' '/^\[workspace\.package\]/{found=1; next} /^\[/{found=0} found && /^version = /{print $2; exit}' Cargo.toml)"
-if [[ -z "$workspace_version" ]]; then
-  echo "Could not read [workspace.package] version from Cargo.toml." >&2
+sdk_version="$(awk -F= '/^VERSION_NAME=/{print $2; exit}' packages/android/gradle.properties)"
+if [[ -z "$sdk_version" ]]; then
+  echo "Could not read VERSION_NAME from packages/android/gradle.properties." >&2
   exit 1
 fi
 
+flutter_swift_path="packages/flutter/ios/orch8_flutter/Sources/orch8_flutter/Orch8FlutterPlugin.swift"
+if [[ ! -f "$flutter_swift_path" ]]; then
+  flutter_swift_path="packages/flutter/ios/Classes/Orch8FlutterPlugin.swift"
+fi
+
 version_checks=(
-  "packages/android/gradle.properties|VERSION_NAME=$workspace_version"
-  "packages/flutter/android/build.gradle.kts|implementation(\"io.orch8:orch8-mobile:$workspace_version\")"
-  "packages/flutter/android/src/main/kotlin/io/orch8/flutter/Orch8FlutterPlugin.kt|?: \"$workspace_version\""
-  "packages/flutter/ios/Classes/Orch8FlutterPlugin.swift|?? \"$workspace_version\""
-  "packages/flutter/ios/orch8_flutter.podspec|s.version          = '$workspace_version'"
-  "packages/flutter/lib/orch8_flutter.dart|this.sdkVersion = '$workspace_version'"
-  "packages/flutter/pubspec.yaml|version: $workspace_version"
-  "packages/react-native/android/src/main/java/io/orch8/reactnative/Orch8Module.kt|?: \"$workspace_version\""
-  "packages/react-native/ios/Orch8Module.swift|?? \"$workspace_version\""
-  "packages/react-native/package.json|\"version\": \"$workspace_version\""
-  "packages/swift/Sources/Orch8Mobile/Orch8Mobile.swift|orch8MobileVersion = \"$workspace_version\""
+  "packages/android/gradle.properties|VERSION_NAME=$sdk_version"
+  "packages/flutter/android/src/main/kotlin/io/orch8/flutter/Orch8FlutterPlugin.kt|?: \"$sdk_version\""
+  "$flutter_swift_path|?? \"$sdk_version\""
+  "packages/flutter/ios/orch8_flutter.podspec|s.version          = '$sdk_version'"
+  "packages/flutter/lib/orch8_flutter.dart|this.sdkVersion = '$sdk_version'"
+  "packages/flutter/pubspec.yaml|version: $sdk_version"
+  "packages/react-native/android/src/main/java/io/orch8/reactnative/Orch8Module.kt|?: \"$sdk_version\""
+  "packages/react-native/ios/Orch8Module.swift|?? \"$sdk_version\""
+  "packages/react-native/package.json|\"version\": \"$sdk_version\""
+  "packages/swift/Sources/Orch8Mobile/Orch8Mobile.swift|orch8MobileVersion = \"$sdk_version\""
 )
 
 failed=0
@@ -29,7 +33,7 @@ for check in "${version_checks[@]}"; do
   file="${check%%|*}"
   expected="${check#*|}"
   if ! grep -Fq "$expected" "$file"; then
-    echo "SDK version drift: $file does not declare workspace version $workspace_version." >&2
+    echo "SDK version drift: $file does not declare SDK version $sdk_version." >&2
     failed=1
   fi
 done
@@ -38,4 +42,4 @@ if (( failed != 0 )); then
   exit 1
 fi
 
-echo "All SDKs match workspace version $workspace_version."
+echo "All mobile SDK packages consistently declare version $sdk_version."

--- a/scripts/check-xcframework.sh
+++ b/scripts/check-xcframework.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+xcframework="${1:?usage: check-xcframework.sh <path-to-xcframework>}"
+
+if [[ ! -d "$xcframework" || ! -f "$xcframework/Info.plist" ]]; then
+  echo "Invalid XCFramework: $xcframework" >&2
+  exit 1
+fi
+
+# CocoaPods requires all static-library slices in an XCFramework to have the
+# same basename. A device liborch8_mobile.a paired with a simulator
+# liborch8_mobile-sim.a is rejected even though SwiftPM can resolve it.
+libraries=()
+while IFS= read -r library; do
+  libraries+=("$library")
+done < <(find "$xcframework" -type f -name '*.a' -print | sort)
+
+if [[ "${#libraries[@]}" -ne 2 ]]; then
+  echo "Expected two static-library slices, found ${#libraries[@]}." >&2
+  exit 1
+fi
+
+for library in "${libraries[@]}"; do
+  if [[ "$(basename "$library")" != "liborch8_mobile.a" ]]; then
+    echo "XCFramework slice has an incompatible basename: $library" >&2
+    exit 1
+  fi
+
+  highest_min_version="$(otool -l "$library" | awk '
+    $1 == "minos" {
+      split($2, parts, ".")
+      numeric = parts[1] * 1000 + parts[2]
+      if (numeric > highest) {
+        highest = numeric
+        version = $2
+      }
+    }
+    END { print version }
+  ')"
+  if [[ "$highest_min_version" != "16.0" ]]; then
+    echo "Unexpected highest deployment target in $library: $highest_min_version" >&2
+    exit 1
+  fi
+done
+
+echo "XCFramework slices use liborch8_mobile.a and target iOS 16.0."


### PR DESCRIPTION
## Summary
- package device and simulator static libraries with the same XCFramework basename required by CocoaPods
- align Rust and package deployment targets with the artifact actual iOS 16 minimum
- add artifact-level validation for slice names and Mach-O deployment metadata
- cut engine patch version 0.7.1 without coupling wrapper release timing to the engine checksum

## Verification
- cargo test -p orch8-mobile --all-features (420 passed)
- local release XCFramework build
- check-xcframework regression rejects v0.7.0 artifact and accepts repaired artifact
- shell syntax and diff checks

## Release risk
2/12 (low): medium-sized CI/packaging diff; no dependencies, database, auth, or external-integration changes.