### PR TITLE
Fix React Native npm organization scope

### DIFF
--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -1,9 +1,9 @@
-# react-native-orch8
+# @orch8.io/react-native-orch8
 
 React Native bridge for the Orch8 `0.7.1` embedded durable workflow engine.
 
 ```bash
-npm install react-native-orch8@0.7.1
+npm install @orch8.io/react-native-orch8@0.7.1
 ```
 
 On iOS, run `pod install` after installing the package. On Android, the
@@ -11,7 +11,7 @@ package resolves the native AAR from Orch8's public, read-only Maven
 repository.
 
 ```ts
-import { orch8 } from "react-native-orch8";
+import { orch8 } from "@orch8.io/react-native-orch8";
 
 await orch8.initialize();
 ```

--- a/packages/react-native/package-lock.json
+++ b/packages/react-native/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "react-native-orch8",
+  "name": "@orch8.io/react-native-orch8",
   "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "react-native-orch8",
+      "name": "@orch8.io/react-native-orch8",
       "version": "0.7.1",
       "license": "BUSL-1.1",
       "devDependencies": {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-orch8",
+  "name": "@orch8.io/react-native-orch8",
   "version": "0.7.1",
   "description": "React Native bridge for the Orch8 Mobile SDK",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary
- publish the React Native SDK as `@orch8.io/react-native-orch8`
- update lockfile identity and installation/import documentation

## Validation
- standalone package TypeScript check passes
- `npm pack --dry-run` resolves `@orch8.io/react-native-orch8@0.7.1` with expected native artifacts