### PR TITLE
Fix API contract Pages deployment action pin

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -41,4 +41,4 @@ jobs:
         with:
           path: contracts
       - id: deploy
-        uses: actions/deploy-pages@4c30dbf64e4e7116c4a7cf4e05bf8f600d139a7 # v4.0.5
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
Pins actions/deploy-pages v4 to the valid official commit. The previous SHA did not exist, so the post-merge contract publication workflow failed before checkout.