### PR TITLE
fix: enable Pages for contract publishing

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -37,6 +37,8 @@ jobs:
           cargo run --locked -p orch8-api --example export_openapi -- contracts/openapi.json
           node scripts/export-contracts.mjs contracts
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+        with:
+          enablement: true
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: contracts


### PR DESCRIPTION
## Summary
- allow the contract publishing workflow to initialize GitHub Pages when the site does not yet exist
- retain the pinned Pages actions and existing least-privilege workflow permissions

## Validation
- actionlint .github/workflows/contracts.yml
- git diff --check

Fixes the post-merge Publish API contracts failure after contract generation completed successfully.